### PR TITLE
added merge strategy that can handle non variants

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -210,6 +210,28 @@ class VariantCall(object):
     return ((self.name, self.genotype, self.phaseset, self.info) ==
             (other.name, other.genotype, other.phaseset, other.info))
 
+  def __lt__(self, other):
+    if self.name != other.name:
+      return self.name < other.name
+    elif self.genotype != other.genotype:
+      return self.genotype < other.genotype
+    elif self.phaseset != other.phaseset:
+      return self.phaset < other.phaseset
+    else:
+      return self.info < other.info
+
+  def __le__(self, other):
+    return self < other or self == other
+
+  def __gt__(self, other):
+    return other < self
+
+  def __ge__(self, other):
+    return other <= self
+
+  def __ne__(self, other):
+    return not self == other
+
   def __repr__(self):
     return ', '.join(
         [str(s) for s in [self.name, self.genotype, self.phaseset, self.info]])

--- a/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy.py
+++ b/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy.py
@@ -1,0 +1,116 @@
+# Copyright 2017 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Variant merge stategy that can handle both Variants and Non-variants."""
+
+from __future__ import absolute_import
+
+from intervaltree import IntervalTree
+
+from gcp_variant_transforms.beam_io.vcfio import Variant
+from gcp_variant_transforms.libs.variant_merge import move_to_calls_strategy
+from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy
+
+__all__ = ['MergeWithNonVariantsStrategy']
+
+# Default size of windows that variants will be grouped in based on the start
+# position of the variant.
+DEFAULT_WINDOW_SIZE = 2500
+
+
+class MergeWithNonVariantsStrategy(variant_merge_strategy.VariantMergeStrategy):
+  """A merging strategy that can handle non-variant records.
+
+  Variants will be merged across files by using reference_name and start
+  position as key. INFO fields should be moved to class if they match
+  `info_keys_to_move_to_calls_regex`. Otherwise, one will be chosen as
+  representatve (in no particular order) among the merged variants.
+  Filters will be merged across all variants matching the key and the
+  highest quality score will be chosen as representative for the merged
+  variants. The filters and quality fields can be optionally copied to
+  their associated calls using `copy_quality_to_calls` and
+  `copy_filter_to_calls` options.
+  Note: if a field is set to be moved from INFO to calls, then it must
+  not already exist in calls (i.e. specified by FORMAT in the VCF
+  header).
+  """
+
+  def __init__(self, info_keys_to_move_to_calls_regex, copy_quality_to_calls,
+               copy_filter_to_calls, window_size=DEFAULT_WINDOW_SIZE):
+    """Initializes the strategy.
+
+    Args:
+      info_keys_to_move_to_calls_regex (str): A regular expression
+        specifying info fields that should be moved to calls.
+      copy_quality_to_calls (bool): Whether to copy the quality field to
+        the associated calls in each record.
+      copy_filter_to_calls (bool): Whether to copy filter field to the
+        associated calls in each record.
+      window_size (int): Size of windows that variants will be grouped
+        in based on the start position of the variant.
+    """
+    self._move_to_calls_strategy = move_to_calls_strategy.MoveToCallsStrategy(
+        info_keys_to_move_to_calls_regex=info_keys_to_move_to_calls_regex,
+        copy_quality_to_calls=copy_filter_to_calls,
+        copy_filter_to_calls=copy_filter_to_calls)
+    self._window_size = window_size
+
+  def _merge_lists(self, list1, list2):
+    return sorted(set(list1 + list2))
+
+  def _merge(self, v1, v2):
+    if (v1.start == v2.start
+        and v1.end == v2.end
+        and v1.alternate_bases == v2.alternate_bases):
+      merged_variant = Variant(reference_name=v1.reference_name,
+                               start=v1.start,
+                               end=v1.end,
+                               reference_bases=v1.reference_bases,
+                               alternate_bases=v1.alternate_bases,
+                               names=self._merge_lists(v1.names, v2.names),
+                               filters=self._merge_lists(v1.filters, v2.filters),
+                               quality=max(v1.quality, v2.quality),
+                               calls=sorted(v1.calls + v2.calls))
+      self._move_to_calls_strategy.move_data_to_merged(v1, merged_variant)
+      self._move_to_calls_strategy.move_data_to_merged(v2, merged_variant)
+      yield merged_variant
+    else:
+      # TODO(msaul): Add logic for handling non-variant regions
+      yield v1
+      yield v2
+
+  def get_merged_variants(self, variants):
+    tree = IntervalTree()
+    for v in variants:
+      self._move_to_calls_strategy.move_data_to_calls(v)
+      overlapping_variants = [ov.data for ov in tree[v.start:v.end]]
+      if overlapping_variants:
+        for ov in overlapping_variants:
+          tree.removei(ov.start, ov.end, ov)
+          new_variants = self._merge(ov, v)
+          for nv in new_variants:
+            tree[nv.start:nv.end] = nv
+      else:
+        tree[v.start:v.end] = v
+    return [v.data for v in sorted(tree)]
+
+  def get_merge_keys(self, variant):
+    start = variant.start - (variant.start % self._window_size)
+    for i in range(start, variant.end, self._window_size):
+      yield ':'.join([str(x) for x in [variant.reference_name, i]])
+
+  def modify_bigquery_schema(self, schema, info_keys):
+    # Find the calls record so that it's easier to reference it below.
+    self._move_to_calls_strategy.modify_bigquery_schema(schema, info_keys)
+

--- a/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
@@ -1,0 +1,240 @@
+# Copyright 2017 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for merge_with_nonvariants_strategy."""
+
+from __future__ import absolute_import
+
+import unittest
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.libs.bigquery_vcf_schema import ColumnKeyConstants
+from gcp_variant_transforms.libs.variant_merge import merge_with_non_variants_strategy
+
+
+class MergeWithNonVariantsStrategyTest(unittest.TestCase):
+  """Tests for MergeWithNonVariantsStrategy."""
+
+  def _get_sample_variants(self):
+    variant_1 = vcfio.Variant(
+        reference_name='19', start=11, end=12, reference_bases='C',
+        alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
+        filters=['PASS'],
+        info={'A1': vcfio.VariantInfo('some data', '1'),
+              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        calls=[
+            vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                              info={'GQ': 20, 'HQ': [10, 20]}),
+            vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                              info={'GQ': 10, 'FLAG1': True})])
+    variant_2 = vcfio.Variant(
+        reference_name='19', start=11, end=12, reference_bases='C',
+        alternate_bases=['A', 'TT'], names=['rs1', 'rs3'], quality=20,
+        filters=['q10'],
+        info={'A1': vcfio.VariantInfo('some data2', '2'),
+              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        calls=[
+            vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
+            vcfio.VariantCall(name='Sample4', genotype=[1, 0],
+                              info={'GQ': 20})])
+    return [variant_1, variant_2]
+
+  def _assert_common_expected_merged_fields(self, merged_variant):
+    """Asserts expected common fields in the merged variant."""
+    self.assertEqual('19', merged_variant.reference_name)
+    self.assertEqual(11, merged_variant.start)
+    self.assertEqual(12, merged_variant.end)
+    self.assertEqual('C', merged_variant.reference_bases)
+    self.assertEqual(['A', 'TT'], merged_variant.alternate_bases)
+    self.assertEqual(['rs1', 'rs2', 'rs3'], merged_variant.names)
+    self.assertEqual(20, merged_variant.quality)
+    self.assertEqual(['PASS', 'q10'], merged_variant.filters)
+
+  def test_get_merged_variants_no_custom_options(self):
+    strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
+        info_keys_to_move_to_calls_regex=None,
+        copy_quality_to_calls=False,
+        copy_filter_to_calls=False)
+    variants = self._get_sample_variants()
+
+    # Test single variant merge.
+    self.assertEqual([variants[0]], strategy.get_merged_variants([variants[0]]))
+
+    # Test multiple variant merge.
+    merged_variant = strategy.get_merged_variants(variants)[0]
+    self._assert_common_expected_merged_fields(merged_variant)
+    self.assertEqual(
+        [vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                           info={'GQ': 20, 'HQ': [10, 20]}),
+         vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                           info={'GQ': 10, 'FLAG1': True}),
+         vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
+         vcfio.VariantCall(name='Sample4', genotype=[1, 0], info={'GQ': 20})],
+        merged_variant.calls)
+    self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
+    self.assertTrue(
+        merged_variant.info['A1'].data in ('some data', 'some data2'))
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+                     merged_variant.info['A2'])
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+                     merged_variant.info['A3'])
+
+  def test_get_merged_variants_move_quality_and_filter_to_calls(self):
+    strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
+        info_keys_to_move_to_calls_regex='',
+        copy_quality_to_calls=True,
+        copy_filter_to_calls=True)
+    variants = self._get_sample_variants()
+
+    # Test single variant merge.
+    single_merged_variant = strategy.get_merged_variants([variants[0]])[0]
+    self.assertEqual(
+        [vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                           info={'GQ': 20, 'HQ': [10, 20],
+                                 ColumnKeyConstants.QUALITY: 2,
+                                 ColumnKeyConstants.FILTER: ['PASS']}),
+         vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                           info={'GQ': 10, 'FLAG1': True,
+                                 ColumnKeyConstants.QUALITY: 2,
+                                 ColumnKeyConstants.FILTER: ['PASS']})],
+        single_merged_variant.calls)
+
+    # Test multiple variant merge.
+    merged_variant = strategy.get_merged_variants(variants)[0]
+    self._assert_common_expected_merged_fields(merged_variant)
+    self.assertEqual(
+        [vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                           info={'GQ': 20, 'HQ': [10, 20],
+                                 ColumnKeyConstants.QUALITY: 2,
+                                 ColumnKeyConstants.FILTER: ['PASS']}),
+         vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                           info={'GQ': 10, 'FLAG1': True,
+                                 ColumnKeyConstants.QUALITY: 2,
+                                 ColumnKeyConstants.FILTER: ['PASS']}),
+         vcfio.VariantCall(name='Sample3', genotype=[1, 1],
+                           info={ColumnKeyConstants.QUALITY: 20,
+                                 ColumnKeyConstants.FILTER: ['q10']}),
+         vcfio.VariantCall(name='Sample4', genotype=[1, 0],
+                           info={'GQ': 20,
+                                 ColumnKeyConstants.QUALITY: 20,
+                                 ColumnKeyConstants.FILTER: ['q10']})],
+        merged_variant.calls)
+    self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
+    self.assertTrue(
+        merged_variant.info['A1'].data in ('some data', 'some data2'))
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+                     merged_variant.info['A2'])
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+                     merged_variant.info['A3'])
+
+  def test_get_merged_variants_move_info_to_calls(self):
+    strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
+        info_keys_to_move_to_calls_regex='^A1$',
+        copy_quality_to_calls=False,
+        copy_filter_to_calls=False)
+    variants = self._get_sample_variants()
+
+    # Test single variant merge.
+    single_merged_variant = strategy.get_merged_variants([variants[0]])[0]
+    self.assertEqual(
+        [vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                           info={'GQ': 20, 'HQ': [10, 20], 'A1': 'some data'}),
+         vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                           info={'GQ': 10, 'FLAG1': True, 'A1': 'some data'})],
+        single_merged_variant.calls)
+
+    # Test multiple variant merge.
+    merged_variant = strategy.get_merged_variants(variants)[0]
+    self._assert_common_expected_merged_fields(merged_variant)
+    self.assertEqual(
+        [vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                           info={'GQ': 20, 'HQ': [10, 20], 'A1': 'some data'}),
+         vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                           info={'GQ': 10, 'FLAG1': True, 'A1': 'some data'}),
+         vcfio.VariantCall(name='Sample3', genotype=[1, 1],
+                           info={'A1': 'some data2'}),
+         vcfio.VariantCall(name='Sample4', genotype=[1, 0],
+                           info={'GQ': 20, 'A1': 'some data2'})],
+        merged_variant.calls)
+    self.assertItemsEqual(['A2', 'A3'], merged_variant.info.keys())
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+                     merged_variant.info['A2'])
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+                     merged_variant.info['A3'])
+
+  def test_get_merged_variants_move_everything_to_calls(self):
+    strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
+        info_keys_to_move_to_calls_regex='.*',
+        copy_quality_to_calls=True,
+        copy_filter_to_calls=True)
+    variants = self._get_sample_variants()
+
+    # Test single variant merge.
+    single_merged_variant = strategy.get_merged_variants([variants[0]])[0]
+    self.assertEqual(
+        [vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                           info={'GQ': 20, 'HQ': [10, 20],
+                                 'A1': 'some data', 'A2': ['data1', 'data2'],
+                                 ColumnKeyConstants.QUALITY: 2,
+                                 ColumnKeyConstants.FILTER: ['PASS']}),
+         vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                           info={'GQ': 10, 'FLAG1': True,
+                                 'A1': 'some data', 'A2': ['data1', 'data2'],
+                                 ColumnKeyConstants.QUALITY: 2,
+                                 ColumnKeyConstants.FILTER: ['PASS']})],
+        single_merged_variant.calls)
+
+    merged_variant = strategy.get_merged_variants(variants)[0]
+    self._assert_common_expected_merged_fields(merged_variant)
+    self.assertEqual(
+        [vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                           info={'GQ': 20, 'HQ': [10, 20],
+                                 'A1': 'some data', 'A2': ['data1', 'data2'],
+                                 ColumnKeyConstants.QUALITY: 2,
+                                 ColumnKeyConstants.FILTER: ['PASS']}),
+         vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                           info={'GQ': 10, 'FLAG1': True,
+                                 'A1': 'some data', 'A2': ['data1', 'data2'],
+                                 ColumnKeyConstants.QUALITY: 2,
+                                 ColumnKeyConstants.FILTER: ['PASS']}),
+         vcfio.VariantCall(name='Sample3', genotype=[1, 1],
+                           info={'A1': 'some data2', 'A3': ['data3', 'data4'],
+                                 ColumnKeyConstants.QUALITY: 20,
+                                 ColumnKeyConstants.FILTER: ['q10']}),
+         vcfio.VariantCall(name='Sample4', genotype=[1, 0],
+                           info={'GQ': 20,
+                                 'A1': 'some data2', 'A3': ['data3', 'data4'],
+                                 ColumnKeyConstants.QUALITY: 20,
+                                 ColumnKeyConstants.FILTER: ['q10']})],
+        merged_variant.calls)
+    self.assertEqual([], merged_variant.info.keys())
+
+  def test_get_snp_merge_keys(self):
+    strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
+        None, None, None, 2)
+
+    variant_1 = vcfio.Variant(reference_name='1', start=3, end=4)
+    variant_2 = vcfio.Variant(reference_name='2', start=4, end=5)
+
+    self.assertEqual(next(strategy.get_merge_keys(variant_1)), '1:2')
+    self.assertEqual(next(strategy.get_merge_keys(variant_2)), '2:4')
+
+  def test_get_non_variant_merge_keys(self):
+    strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
+        None, None, None, 2)
+    variant = vcfio.Variant(reference_name='2', start=6, end=12)
+    keys = strategy.get_merge_keys(variant)
+    self.assertEqual(next(keys), '2:6')
+    self.assertEqual(next(keys), '2:8')
+    self.assertEqual(next(keys), '2:10')

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ import setuptools
 
 REQUIRED_PACKAGES = [
     'apache-beam[gcp]>=2.0',
+    'intervaltree>=2.1.0,<2.2.0',
     'pyvcf<0.7.0',
     ]
 


### PR DESCRIPTION
Created MergeWithNonVariantsStrategy that can handle merging intervals. Current implementation only supports the same behavior as MoveToCallsStrategy, but functionality will later be extended to add merging logic for non variants.