### PR TITLE
fixed bug in merge_with_non_variants_strategy that duplicated data

### DIFF
--- a/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
@@ -238,3 +238,69 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
     self.assertEqual(next(keys), '2:6')
     self.assertEqual(next(keys), '2:8')
     self.assertEqual(next(keys), '2:10')
+
+  def test_merge_many_different_alternates(self):
+    strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
+        None, None, None, 2)
+
+    variant_1 = vcfio.Variant(reference_name='1',
+                              start=1,
+                              end=2,
+                              reference_bases='A',
+                              alternate_bases=['C'])
+    variant_2 = vcfio.Variant(reference_name='1',
+                              start=1,
+                              end=2,
+                              reference_bases='A',
+                              alternate_bases=['G'])
+    variant_3 = vcfio.Variant(reference_name='1',
+                              start=1,
+                              end=2,
+                              reference_bases='A',
+                              alternate_bases=['T'])
+    variant_1.calls.append(vcfio.VariantCall(name='Sample1', genotype=[1, 0]))
+    variant_2.calls.append(vcfio.VariantCall(name='Sample2', genotype=[1, 0]))
+    variant_3.calls.append(vcfio.VariantCall(name='Sample3', genotype=[1, 0]))
+    variants = [variant_1, variant_2, variant_3]
+    merged_variants = strategy.get_merged_variants(variants)
+    self.assertEqual(sorted(merged_variants), sorted(variants))
+
+  def test_merge_one_overlap(self):
+    strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
+        None, None, None, 2)
+
+    variant_1 = vcfio.Variant(reference_name='1',
+                              start=1,
+                              end=2,
+                              reference_bases='A',
+                              alternate_bases=['C'])
+    variant_2 = vcfio.Variant(reference_name='1',
+                              start=1,
+                              end=2,
+                              reference_bases='A',
+                              alternate_bases=['G'])
+    variant_3 = vcfio.Variant(reference_name='1',
+                              start=1,
+                              end=2,
+                              reference_bases='A',
+                              alternate_bases=['T'])
+    variant_4 = vcfio.Variant(reference_name='1',
+                              start=1,
+                              end=2,
+                              reference_bases='A',
+                              alternate_bases=['C'])
+    variant_1.calls.append(vcfio.VariantCall(name='Sample1', genotype=[1, 0]))
+    variant_2.calls.append(vcfio.VariantCall(name='Sample2', genotype=[1, 0]))
+    variant_3.calls.append(vcfio.VariantCall(name='Sample3', genotype=[1, 0]))
+    variant_4.calls.append(vcfio.VariantCall(name='Sample4', genotype=[1, 0]))
+    variants = [variant_1, variant_2, variant_3, variant_4]
+    merged = vcfio.Variant(reference_name='1',
+                           start=1,
+                           end=2,
+                           reference_bases='A',
+                           alternate_bases=['C'])
+    merged.calls.append(vcfio.VariantCall(name='Sample1', genotype=[1, 0]))
+    merged.calls.append(vcfio.VariantCall(name='Sample4', genotype=[1, 0]))
+    merged_variants = strategy.get_merged_variants(variants)
+    self.assertEqual(
+        sorted(merged_variants), sorted([merged, variant_2, variant_3]))

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -59,13 +59,9 @@ _MERGE_WITH_NON_VARIANTS_STRING = 'MERGE_WITH_NON_VARIANTS'
 # - NONE: Variants will not be merged across files.
 # - MOVE_TO_CALLS: uses libs.variant_merge.move_to_calls_strategy
 #   for merging. Please see the documentation in that file for details.
-# - MERGE_WITH_NON_VARIANTS: uses
-#   libs.variant_merge.merge_with_non_variants_strategy for merging. Please see
-#   documentation in that file for details.
 _VARIANT_MERGE_STRATEGIES = [
     _NONE_STRING,
     _MOVE_TO_CALLS_STRING,
-    _MERGE_WITH_NON_VARIANTS_STRING,
 ]
 
 


### PR DESCRIPTION
Previously merge_with_non_varaints_strategy would duplicate samples if a record merged with one overlapping record and did not merge with another. This change fixes the bug.