### PR TITLE
Remove duplicate merge-header logic.

### DIFF
--- a/gcp_variant_transforms/libs/vcf_header_parser.py
+++ b/gcp_variant_transforms/libs/vcf_header_parser.py
@@ -32,68 +32,27 @@ __all__ = ['HeaderFields', 'get_merged_vcf_headers']
 HeaderFields = namedtuple('HeaderFields', ['infos', 'formats'])
 
 
-def get_merged_vcf_headers(input_pattern):
-  """Returns merged VCF headers (FORMAT and INFO) from ``input_pattern``.
-
-  If multiple files are specified by ``input_pattern`` then header fields will
-  be merged by key and only one will be chosen as representative (in no
-  particular order). If the same key is used in multiple files, then all types
-  and numbers must be the same.
+def get_vcf_headers(input_file):
+  """Returns VCF headers (FORMAT and INFO) from ``input_file``.
 
   Args:
-    input_pattern (str): A string specifying the path to VCF input file(s). They
-      can be local or remote (e.g. on GCS).
+    input_file (str): A string specifying the path to the representative VCF
+    file, i.e., the VCF file that contains a header representative of all VCF
+    files matching the input_pattern of the job. It can be local or remote (e.g.
+    on GCS).
   Returns:
-    `HeaderFields`` specifying merged header info from all files in
-    ``input_pattern``.
+    ``HeaderFields`` specifying header info.
   Raises:
-    ValueError: If the VCF headers are invalid or incompatible (e.g. the same
-      key if defined with different types in multiple files).
+    ValueError: If ``input_file`` is not a valid VCF file (e.g. bad format,
+    empty, non-existent).
   """
-  merged_info_fields = {}
-  merged_format_fields = {}
-  # The match implementation supports one pattern, but the API technically
-  # supports multiple patterns, hence the need for a list (in both request
-  # and response).
-  match_results = FileSystems.match([input_pattern])
-  if not match_results:
-    return HeaderFields(merged_info_fields, merged_format_fields)
-  for file_metadata in match_results[0].metadata_list:
-    file_name = file_metadata.path
-    if not file_metadata.size_in_bytes:
-      continue  # Ignore empty files.
-    try:
-      vcf_reader = vcf.Reader(fsock=_line_generator(file_name))
-    except SyntaxError as e:
-      raise ValueError('Invalid VCF header: %s' % str(e))
-    _merge_header_fields(merged_info_fields, vcf_reader.infos)
-    _merge_header_fields(merged_format_fields, vcf_reader.formats)
-  return HeaderFields(merged_info_fields, merged_format_fields)
-
-
-def _merge_header_fields(source, to_merge):
-  """Modifies ``source`` to add any keys from ``to_merge`` not in ``source``.
-
-  Args:
-    source (dict): Source header fields.
-    to_merge (dict): Header fields to merge with ``source``.
-  Raises:
-    ValueError: If the header fields are incompatible (e.g. same key with
-      different types or numbers).
-  """
-  if not to_merge:
-    return source
-  for key, to_merge_value in to_merge.iteritems():
-    if key not in source:
-      source[key] = to_merge_value
-    else:
-      source_value = source[key]
-      if (source_value.num != to_merge_value.num or
-          source_value.type != to_merge_value.type):
-        raise ValueError(
-            'Incompatible number of types in header fields: %s, %s' % (
-                source_value, to_merge_value))
-
+  if not FileSystems.exists(input_file):
+    raise ValueError('VCF header does not exist')
+  try:
+    vcf_reader = vcf.Reader(fsock=_line_generator(input_file))
+  except (SyntaxError, StopIteration) as e:
+    raise ValueError('Invalid VCF header: %s' % str(e))
+  return HeaderFields(vcf_reader.infos, vcf_reader.formats)
 
 def _line_generator(file_name):
   """Generator to return lines delimited by newline chars from ``file_name``."""

--- a/gcp_variant_transforms/libs/vcf_header_parser_test.py
+++ b/gcp_variant_transforms/libs/vcf_header_parser_test.py
@@ -25,7 +25,7 @@ from gcp_variant_transforms.testing import testdata_util
 
 
 class GetMergedVcfHeadersTest(unittest.TestCase):
-  """Test cases for the ``get_merged_vcf_headers`` function."""
+  """Test cases for the ``get_vcf_headers`` function."""
 
   def _create_temp_vcf_file(self, lines, tempdir):
     return tempdir.create_temp_file(suffix='.vcf', lines=lines)
@@ -40,33 +40,9 @@ class GetMergedVcfHeadersTest(unittest.TestCase):
         '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample1	Sample2\n']
     with temp_dir.TempDir() as tempdir:
       file_path = self._create_temp_vcf_file(lines, tempdir)
-      header_fields = vcf_header_parser.get_merged_vcf_headers(file_path)
+      header_fields = vcf_header_parser.get_vcf_headers(file_path)
       self.assertItemsEqual(['NS', 'AF'], header_fields.infos.keys())
       self.assertItemsEqual(['GT', 'GQ'], header_fields.formats.keys())
-
-  def test_multiple_files(self):
-    file_1_lines = [
-        '##fileformat=VCFv4.2\n',
-        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
-        '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
-        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
-        '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="GQ">\n',
-        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample1	Sample2\n']
-    file_2_lines = [
-        '##fileformat=VCFv4.2\n',
-        '##INFO=<ID=NS2,Number=1,Type=Integer,Description="Number samples">\n',
-        '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
-        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
-        '##FORMAT=<ID=GQ2,Number=1,Type=Integer,Description="GQ">\n',
-        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample3\n']
-
-    with temp_dir.TempDir() as tempdir:
-      self._create_temp_vcf_file(file_1_lines, tempdir)
-      self._create_temp_vcf_file(file_2_lines, tempdir)
-      header_fields = vcf_header_parser.get_merged_vcf_headers(
-          os.path.join(tempdir.get_path(), '*.vcf'))
-      self.assertItemsEqual(['NS', 'AF', 'NS2'], header_fields.infos.keys())
-      self.assertItemsEqual(['GT', 'GQ', 'GQ2'], header_fields.formats.keys())
 
   def test_invalid_file(self):
     lines = [
@@ -78,42 +54,31 @@ class GetMergedVcfHeadersTest(unittest.TestCase):
     with temp_dir.TempDir() as tempdir:
       file_path = self._create_temp_vcf_file(lines, tempdir)
       try:
-        vcf_header_parser.get_merged_vcf_headers(file_path)
+        vcf_header_parser.get_vcf_headers(file_path)
         self.fail('Invalid VCF file must throw an exception.')
       except ValueError:
         pass
 
-  def test_incompatible_files(self):
-    # NS has Number=1 in file1, but Number=2 in file2.
-    file_1_lines = [
-        '##fileformat=VCFv4.2\n',
-        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
-        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample1	Sample2\n']
-    file_2_lines = [
-        '##fileformat=VCFv4.2\n',
-        '##INFO=<ID=NS,Number=2,Type=Integer,Description="Number samples">\n',
-        '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
-        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample3\n']
-
+  def test_empty_file(self):
+    lines = []
     with temp_dir.TempDir() as tempdir:
-      self._create_temp_vcf_file(file_1_lines, tempdir)
-      self._create_temp_vcf_file(file_2_lines, tempdir)
+      file_path = self._create_temp_vcf_file(lines, tempdir)
       try:
-        vcf_header_parser.get_merged_vcf_headers(
-            os.path.join(tempdir.get_path(), '*.vcf'))
-        self.fail('Incompatible VCF files must throw an exception.')
+        vcf_header_parser.get_vcf_headers(file_path)
+        self.fail('Empty VCF file must throw an exception.')
       except ValueError:
         pass
 
   def test_gz(self):
     """Tests successfully parsing gz files."""
     file_path = testdata_util.get_full_file_path('valid-4.0.vcf.gz')
-    header_fields = vcf_header_parser.get_merged_vcf_headers(file_path)
+    header_fields = vcf_header_parser.get_vcf_headers(file_path)
     self.assertGreater(len(header_fields.infos), 1)
     self.assertGreater(len(header_fields.formats), 1)
 
   def test_non_existent_input_pattern(self):
-    expected_header_fields = vcf_header_parser.HeaderFields({}, {})
-    self.assertEqual(expected_header_fields,
-                     vcf_header_parser.get_merged_vcf_headers('randompath/*'))
-
+    try:
+      vcf_header_parser.get_vcf_headers('randompath/non-existent-file.vcf')
+      self.fail('Non existent VCF file must throw an exception.')
+    except ValueError:
+      pass


### PR DESCRIPTION
Remove duplicate merge-header logic. This is achieved by using the merge_headers pipeline with DirectRunner for small inputs. This allows us to modify this logic easier (DRY).

In the next cl, we will modify the merge logic to accept
compatible type conflicts (i.e., int vs double).