### PR TITLE
Fixed remaining issues of the integration test and added some minimal verification

### DIFF
--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0.json
@@ -2,5 +2,16 @@
   "test_name": "valid-4-0",
   "table_name": "valid_4_0",
   "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf",
-  "runner": "DataflowRunner"
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(0) AS num_rows, ",
+    "  SUM(start_position) AS sum_start, ",
+    "  SUM(end_position) AS sum_end ",
+    "FROM {TABLE_NAME}"
+  ],
+  "expected_query_result": {
+    "num_rows": 5,
+    "sum_start": 3607195,
+    "sum_end": 3607203
+  }
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_bz2.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_bz2.json
@@ -2,5 +2,16 @@
   "test_name": "valid-4-0-bz2",
   "table_name": "valid_4_0_bz2",
   "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.bz2",
-  "runner": "DataflowRunner"
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(0) AS num_rows, ",
+    "  SUM(start_position) AS sum_start, ",
+    "  SUM(end_position) AS sum_end ",
+    "FROM {TABLE_NAME}"
+  ],
+  "expected_query_result": {
+    "num_rows": 5,
+    "sum_start": 3607195,
+    "sum_end": 3607203
+  }
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_gz.json
@@ -2,5 +2,16 @@
   "test_name": "valid-4-0-gz",
   "table_name": "valid_4_0_gz",
   "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.gz",
-  "runner": "DataflowRunner"
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(0) AS num_rows, ",
+    "  SUM(start_position) AS sum_start, ",
+    "  SUM(end_position) AS sum_end ",
+    "FROM {TABLE_NAME}"
+  ],
+  "expected_query_result": {
+    "num_rows": 5,
+    "sum_start": 3607195,
+    "sum_end": 3607203
+  }
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_1.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_1.json
@@ -2,5 +2,16 @@
   "test_name": "valid-4-1",
   "table_name": "valid_4_1",
   "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.1-large.vcf",
-  "runner": "DataflowRunner"
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(0) AS num_rows, ",
+    "  SUM(start_position) AS sum_start, ",
+    "  SUM(end_position) AS sum_end ",
+    "FROM {TABLE_NAME}"
+  ],
+  "expected_query_result": {
+    "num_rows": 9882,
+    "sum_start": 5434957328,
+    "sum_end": 5435327553
+  }
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_1_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_1_gz.json
@@ -2,5 +2,16 @@
   "test_name": "valid-4-1-gz",
   "table_name": "valid_4_1_gz",
   "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.1-large.vcf.gz",
-  "runner": "DataflowRunner"
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(0) AS num_rows, ",
+    "  SUM(start_position) AS sum_start, ",
+    "  SUM(end_position) AS sum_end ",
+    "FROM {TABLE_NAME}"
+  ],
+  "expected_query_result": {
+    "num_rows": 9882,
+    "sum_start": 5434957328,
+    "sum_end": 5435327553
+  }
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2.json
@@ -2,5 +2,16 @@
   "test_name": "valid-4-2",
   "table_name": "valid_4_2",
   "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf",
-  "runner": "DataflowRunner"
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(0) AS num_rows, ",
+    "  SUM(start_position) AS sum_start, ",
+    "  SUM(end_position) AS sum_end ",
+    "FROM {TABLE_NAME}"
+  ],
+  "expected_query_result": {
+    "num_rows": 13,
+    "sum_start": 23031929,
+    "sum_end": 23033052
+  }
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_gz.json
@@ -2,5 +2,16 @@
   "test_name": "valid-4-2-gz",
   "table_name": "valid_4_2_gz",
   "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf.gz",
-  "runner": "DataflowRunner"
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(0) AS num_rows, ",
+    "  SUM(start_position) AS sum_start, ",
+    "  SUM(end_position) AS sum_end ",
+    "FROM {TABLE_NAME}"
+  ],
+  "expected_query_result": {
+    "num_rows": 13,
+    "sum_start": 23031929,
+    "sum_end": 23033052
+  }
 }

--- a/setup.py
+++ b/setup.py
@@ -27,11 +27,16 @@ REQUIRED_PACKAGES = [
     'google-api-python-client>=1.6',
     'intervaltree>=2.1.0,<2.2.0',
     'pyvcf<0.7.0',
-    ]
+]
+
+INTEGRATION_TEST_REQUIREMENTS = [
+    # Need to explicitly install v>0.25 as the BigQuery python API has changed.
+    'google-cloud-bigquery>0.25',
+]
 
 REQUIRED_SETUP_PACKAGES = [
     'nose>=1.0',
-    ]
+]
 
 setuptools.setup(
     name='gcp_variant_transforms',
@@ -56,6 +61,9 @@ setuptools.setup(
 
     setup_requires=REQUIRED_SETUP_PACKAGES,
     install_requires=REQUIRED_PACKAGES,
+    extras_require={
+        'int_test': INTEGRATION_TEST_REQUIREMENTS,
+    },
     test_suite='nose.collector',
     packages=setuptools.find_packages(),
     package_data={


### PR DESCRIPTION
Two related notable changes:
* Two new test flags are added which are useful when debugging failing tests.
* Because of the bigquery version conflict, I have used the [extras] option in setup.py. For normal tests the usual install works. For integration test, this install should be done first:
`pip install --upgrade .[int_test]`
I will update the documents once this test is added as part of the presubmit process.

Tested:
Ran the test with various flag settings.

Issue: #62