### PR TITLE
Adds a cloudbuild_CI.yaml for Build Triggers with related fixes to test scripts.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,6 +24,5 @@ steps:
       - '--tag=gcr.io/$PROJECT_ID/gcp-variant-transforms:${_CUSTOM_TAG_NAME}'
       - '--file=docker/Dockerfile'
       - '.'
-    dir: '.'
 images:
   - 'gcr.io/$PROJECT_ID/gcp-variant-transforms:${_CUSTOM_TAG_NAME}'

--- a/cloudbuild_CI.yaml
+++ b/cloudbuild_CI.yaml
@@ -1,0 +1,50 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is meant to be used by the Build Triggers set in Container Builder Builds
+# of a cloud project. This is what it does:
+# * Builds an image using the last GitHub commit hash as the tag.
+# * Pushes that image to Container Registry.
+# * Runs the integration test from that very image.
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '--tag=gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
+      - '--file=docker/Dockerfile'
+      - '.'
+  # We have to push now since we are using this image in the next step.
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
+  # Run the test script from the image we just built and pushed.
+  - name: 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
+    args:
+      - 'bash'
+      - './deploy_and_run_tests.sh'
+      - '--keep_image'
+      - '--skip_build'
+      - '--project ${PROJECT_ID}'
+      - '--image_tag ${COMMIT_SHA}'
+      - '--run_unit_tests'
+      # By default the script uses a GS bucket of gcp-variant-transforms-test
+      # project. For other projects we should either use the following option
+      # or change the script to create a temporary bucket on the fly.
+      #
+      # - '--gs_dir bashir-variant_integration_test_runs'
+images:
+  - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
+timeout: 20m

--- a/gcp_variant_transforms/testing/integration/run_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_tests.py
@@ -36,6 +36,7 @@ import argparse
 import json
 import multiprocessing
 import os
+import sys
 import time
 
 from datetime import datetime
@@ -297,6 +298,10 @@ def _print_errors(results):
       errors.append((test.get_name(), _get_traceback(str(e))))
   for test_name, error in errors:
     print _get_failure_message(test_name, error)
+  if errors:
+    return 1
+  else:
+    return 0
 
 
 def _get_traceback(message):
@@ -331,8 +336,9 @@ def main():
     pool.close()
     pool.join()
 
-  _print_errors(results)
+  return _print_errors(results)
 
 
 if __name__ == '__main__':
-  main()
+  ret_code = main()
+  sys.exit(ret_code)


### PR DESCRIPTION
Please note that by default the container builder service account (by whom the cloudbuild steps will be run) only has Cloud Container Builder access. Of course that is not enough to run the integration tests. I tried to enable the accesses one by one (e.g., BigQuery, Genomics, GCP, etc.) but then decided it is easier to give this service account "Editor" access (like some other service accounts). That fixed all remaining permission issues.

Tested:
Created a Build Trigger in my project monitoring my forked git repo (using the new cloudbuild_CI.yaml) and tested both success and failure scenarios.

Issue: #62