### PR TITLE
Adds an option to split annotation fields.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -78,8 +78,10 @@ def _get_sample_variant_1():
       reference_name='20', start=1233, end=1234, reference_bases='C',
       alternate_bases=['A', 'T'], names=['rs123', 'rs2'], quality=50,
       filters=['PASS'],
-      info={'AF': vcfio.VariantInfo(data=[0.5, 0.1], field_count='A'),
-            'NS': vcfio.VariantInfo(data=1, field_count='1')})
+      info={'AF': vcfio.VariantInfo(data=[0.5, 0.1], field_count='A',
+                                    annotation_names=None),
+            'NS': vcfio.VariantInfo(data=1, field_count='1',
+                                    annotation_names=None)})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[0, 0], info={'GQ': 48}))
   variant.calls.append(
@@ -103,7 +105,8 @@ def _get_sample_variant_2():
       reference_name='19', start=122, end=125, reference_bases='GTC',
       alternate_bases=[], names=['rs1234'], quality=40,
       filters=['q10', 's50'],
-      info={'NS': vcfio.VariantInfo(data=2, field_count='1')})
+      info={'NS': vcfio.VariantInfo(data=2, field_count='1',
+                                    annotation_names=None)})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[1, 0],
                         phaseset=vcfio.DEFAULT_PHASESET_VALUE,
@@ -127,7 +130,8 @@ def _get_sample_variant_3():
   variant = vcfio.Variant(
       reference_name='19', start=11, end=12, reference_bases='C',
       alternate_bases=['<SYMBOLIC>'], quality=49, filters=['q10'],
-      info={'AF': vcfio.VariantInfo(data=[0.5], field_count='A')})
+      info={'AF': vcfio.VariantInfo(data=[0.5], field_count='A',
+                                    annotation_names=None)})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                         phaseset='1',
@@ -392,7 +396,8 @@ class VcfSourceTest(unittest.TestCase):
     expected_variant = Variant(
         reference_name='19', start=122, end=123, reference_bases='G',
         alternate_bases=['A'], filters=['PASS'],
-        info={'AF': VariantInfo(data=[0.2], field_count='A')})
+        info={'AF': VariantInfo(data=[0.2], field_count='A',
+                                annotation_names=None)})
     read_data = self._create_temp_file_and_read_records(
         _SAMPLE_HEADER_LINES[:-1] + [header_line, record_line])
     self.assertEqual(1, len(read_data))
@@ -423,19 +428,27 @@ class VcfSourceTest(unittest.TestCase):
     variant_1 = Variant(
         reference_name='19', start=1, end=2, reference_bases='A',
         alternate_bases=['T', 'C'],
-        info={'HA': VariantInfo(data=['a1', 'a2'], field_count='A'),
-              'HG': VariantInfo(data=[1, 2, 3], field_count='G'),
-              'HR': VariantInfo(data=['a', 'b', 'c'], field_count='R'),
-              'HF': VariantInfo(data=True, field_count='0'),
-              'HU': VariantInfo(data=[0.1], field_count=None)})
+        info={'HA': VariantInfo(data=['a1', 'a2'], field_count='A',
+                                annotation_names=None),
+              'HG': VariantInfo(data=[1, 2, 3], field_count='G',
+                                annotation_names=None),
+              'HR': VariantInfo(data=['a', 'b', 'c'], field_count='R',
+                                annotation_names=None),
+              'HF': VariantInfo(data=True, field_count='0',
+                                annotation_names=None),
+              'HU': VariantInfo(data=[0.1], field_count=None,
+                                annotation_names=None)})
     variant_1.calls.append(VariantCall(name='Sample1', genotype=[1, 0]))
     variant_1.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
     variant_2 = Variant(
         reference_name='19', start=123, end=124, reference_bases='A',
         alternate_bases=['T'],
-        info={'HG': VariantInfo(data=[3, 4, 5], field_count='G'),
-              'HR': VariantInfo(data=['d', 'e'], field_count='R'),
-              'HU': VariantInfo(data=[1.1, 1.2], field_count=None)})
+        info={'HG': VariantInfo(data=[3, 4, 5], field_count='G',
+                                annotation_names=None),
+              'HR': VariantInfo(data=['d', 'e'], field_count='R',
+                                annotation_names=None),
+              'HU': VariantInfo(data=[1.1, 1.2], field_count=None,
+                                annotation_names=None)})
     variant_2.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
     variant_2.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
     read_data = self._create_temp_file_and_read_records(
@@ -755,9 +768,12 @@ class VcfSinkTest(unittest.TestCase):
   def test_info_field_count(self):
     coder = self._get_coder()
     variant = Variant()
-    variant.info['NS'] = VariantInfo(data=3, field_count='1')
-    variant.info['AF'] = VariantInfo(data=[0.333, 0.667], field_count='A')
-    variant.info['DB'] = VariantInfo(data=True, field_count='0')
+    variant.info['NS'] = VariantInfo(data=3, field_count='1',
+                                     annotation_names=None)
+    variant.info['AF'] = VariantInfo(data=[0.333, 0.667], field_count='A',
+                                     annotation_names=None)
+    variant.info['DB'] = VariantInfo(data=True, field_count='0',
+                                     annotation_names=None)
     expected = '.	.	.	.	.	.	.	NS=3;AF=0.333,0.667;DB	.\n'
 
     self._assert_variant_lines_equal(coder.encode(variant), expected)

--- a/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
@@ -32,8 +32,8 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'A1': vcfio.VariantInfo('some data', '1', None),
+              'A2': vcfio.VariantInfo(['data1', 'data2'], '2', None)},
         calls=[
             vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                               info={'GQ': 20, 'HQ': [10, 20]}),
@@ -43,8 +43,8 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs3'], quality=20,
         filters=['q10'],
-        info={'A1': vcfio.VariantInfo('some data2', '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A1': vcfio.VariantInfo('some data2', '2', None),
+              'A3': vcfio.VariantInfo(['data3', 'data4'], '2', None)},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(name='Sample4', genotype=[1, 0],
@@ -87,9 +87,9 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
     self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
     self.assertTrue(
         merged_variant.info['A1'].data in ('some data', 'some data2'))
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2', None),
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2', None),
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_quality_and_filter_to_calls(self):
@@ -135,9 +135,9 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
     self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
     self.assertTrue(
         merged_variant.info['A1'].data in ('some data', 'some data2'))
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2', None),
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2', None),
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_info_to_calls(self):
@@ -170,9 +170,9 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
                            info={'GQ': 20, 'A1': 'some data2'})],
         merged_variant.calls)
     self.assertItemsEqual(['A2', 'A3'], merged_variant.info.keys())
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2', None),
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2', None),
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_everything_to_calls(self):

--- a/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy_test.py
@@ -33,8 +33,8 @@ class MoveToCallsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'A1': vcfio.VariantInfo('some data', '1', None),
+              'A2': vcfio.VariantInfo(['data1', 'data2'], '2', None)},
         calls=[
             vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                               info={'GQ': 20, 'HQ': [10, 20]}),
@@ -44,8 +44,8 @@ class MoveToCallsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs3'], quality=20,
         filters=['q10'],
-        info={'A1': vcfio.VariantInfo('some data2', '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A1': vcfio.VariantInfo('some data2', '2', None),
+              'A3': vcfio.VariantInfo(['data3', 'data4'], '2', None)},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(name='Sample4', genotype=[1, 0],
@@ -87,9 +87,9 @@ class MoveToCallsStrategyTest(unittest.TestCase):
     self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
     self.assertTrue(
         merged_variant.info['A1'].data in ('some data', 'some data2'))
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2', None),
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2', None),
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_quality_and_filter_to_calls(self):
@@ -135,9 +135,9 @@ class MoveToCallsStrategyTest(unittest.TestCase):
     self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
     self.assertTrue(
         merged_variant.info['A1'].data in ('some data', 'some data2'))
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2', None),
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2', None),
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_info_to_calls(self):
@@ -170,9 +170,9 @@ class MoveToCallsStrategyTest(unittest.TestCase):
                            info={'GQ': 20, 'A1': 'some data2'})],
         merged_variant.calls)
     self.assertItemsEqual(['A2', 'A3'], merged_variant.info.keys())
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2', None),
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2', None),
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_everything_to_calls(self):

--- a/gcp_variant_transforms/libs/vcf_header_parser.py
+++ b/gcp_variant_transforms/libs/vcf_header_parser.py
@@ -32,6 +32,42 @@ __all__ = ['HeaderFields', 'get_vcf_headers']
 HeaderFields = namedtuple('HeaderFields', ['infos', 'formats'])
 
 
+def extract_annotation_list_with_alt(annotation_str):
+  """Extracts annotations from an annotation INFO field.
+
+  This works by dividing the ``annotation_str`` on '|'. The first element is
+  the alternate allele and the rest are the annotations.
+
+  Args:
+    annotation_str (``str``): The content of annotation field for one alt.
+
+  Returns:
+    The list of annotations with the first element being the alternate.
+  """
+  return annotation_str.split('|')
+
+
+def extract_annotation_names(description):
+  """Extracts annotation list from the description of an annotation INFO field.
+
+  This is similar to extract_extract_annotation_list_with_alt with the
+  difference that it ignores everything before the first '|'.
+
+  Args:
+    description (``str``): The "Description" part of the annotation INFO field
+      in the header of VCF.
+
+  Returns:
+    The list of annotation names.
+  """
+  annotation_names = extract_annotation_list_with_alt(description)
+  if len(annotation_names) < 2:
+    raise ValueError(
+        'Expected at least one | in annotation description {}'.format(
+            description))
+  return annotation_names[1:]
+
+
 def get_vcf_headers(input_file):
   """Returns VCF headers (FORMAT and INFO) from ``input_file``.
 

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -59,6 +59,13 @@ class VcfReadOptions(VariantTransformsOptions):
               'Failed reads will be logged as warnings and returned as '
               'MalformedVcfRecord objects.'))
     parser.add_argument(
+        '--annotation_field',
+        default=None,
+        help=('If set, it is the name of the annotation field. The content '
+              'of this INFO field will be broken into multiple columns in the '
+              'output BigQuery table and stored as repeated fields with '
+              'corresponding alternate alleles. [EXPERIMENTAL]'))
+    parser.add_argument(
         '--optimize_for_large_inputs',
         type='bool', default=False, nargs='?', const=True,
         help=('If true, the pipeline runs in optimized way for handling large '

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_VEP.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_VEP.json
@@ -1,0 +1,15 @@
+{
+  "test_name": "valid-4-2-vep",
+  "table_name": "valid_4_2_VEP",
+  "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2_VEP.vcf",
+  "annotation_field": "CSQ",
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(DISTINCT CSQ.Feature) AS num_features ",
+    "FROM {TABLE_NAME} AS t, t.alternate_bases as alts, alts.CSQ as CSQ ",
+    "WHERE start_position = 1110695 AND alts.alt = 'G'"
+  ],
+  "expected_query_result": {
+    "num_features": 3
+  }
+}

--- a/gcp_variant_transforms/transforms/filter_variants_test.py
+++ b/gcp_variant_transforms/transforms/filter_variants_test.py
@@ -43,8 +43,8 @@ class FilterVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'A1': vcfio.VariantInfo('some data', '1', None),
+              'A2': vcfio.VariantInfo(['data1', 'data2'], '2', None)},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -58,8 +58,8 @@ class FilterVariantsTest(unittest.TestCase):
         reference_name='20', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=20,
         filters=['q10'],
-        info={'A1': vcfio.VariantInfo('some data2', '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A1': vcfio.VariantInfo('some data2', '2', None),
+              'A3': vcfio.VariantInfo(['data3', 'data4'], '2', None)},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(

--- a/gcp_variant_transforms/transforms/merge_variants_test.py
+++ b/gcp_variant_transforms/transforms/merge_variants_test.py
@@ -36,8 +36,8 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'A1': vcfio.VariantInfo('some data', '1', None),
+              'A2': vcfio.VariantInfo(['data1', 'data2'], '2', None)},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -51,8 +51,8 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=20,
         filters=['q10'],
-        info={'A1': vcfio.VariantInfo('some data2', '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A1': vcfio.VariantInfo('some data2', '2', None),
+              'A3': vcfio.VariantInfo(['data3', 'data4'], '2', None)},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(
@@ -64,8 +64,8 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'],
         filters=['PASS', 'q10'], quality=20,
-        info={'A2': vcfio.VariantInfo(['data1', 'data2'], '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A2': vcfio.VariantInfo(['data1', 'data2'], '2', None),
+              'A3': vcfio.VariantInfo(['data3', 'data4'], '2', None)},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -37,10 +37,10 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'AF': vcfio.VariantInfo([0.1, 0.2], 'A'),
-              'AF2': vcfio.VariantInfo([0.2, 0.3], 'A'),
-              'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'AF': vcfio.VariantInfo([0.1, 0.2], 'A', None),
+              'AF2': vcfio.VariantInfo([0.2, 0.3], 'A', None),
+              'A1': vcfio.VariantInfo('some data', '1', None),
+              'A2': vcfio.VariantInfo(['data1', 'data2'], '2', None)},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -84,7 +84,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='20', start=123, end=125, reference_bases='CT',
         alternate_bases=[], filters=['q10', 's10'],
-        info={'INTINFO': vcfio.VariantInfo(1234, '1')})
+        info={'INTINFO': vcfio.VariantInfo(1234, '1', None)})
     row = {ColumnKeyConstants.REFERENCE_NAME: '20',
            ColumnKeyConstants.START_POSITION: 123,
            ColumnKeyConstants.END_POSITION: 125,

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -106,11 +106,13 @@ def _read_variants(pipeline, known_args):
                     [known_args.input_pattern])
                 | 'ReadAllFromVcf' >> vcfio.ReadAllFromVcf(
                     allow_malformed_records=(
-                        known_args.allow_malformed_records)))
+                        known_args.allow_malformed_records),
+                    annotation_field=known_args.annotation_field))
   else:
     variants = pipeline | 'ReadFromVcf' >> vcfio.ReadFromVcf(
         known_args.input_pattern,
-        allow_malformed_records=known_args.allow_malformed_records)
+        allow_malformed_records=known_args.allow_malformed_records,
+        annotation_field=known_args.annotation_field)
   return variants
 
 
@@ -224,7 +226,8 @@ def run(argv=None):
              variant_merger,
              known_args.split_alternate_allele_info_fields,
              append=known_args.append,
-             omit_empty_sample_calls=known_args.omit_empty_sample_calls))
+             omit_empty_sample_calls=known_args.omit_empty_sample_calls,
+             annotation_field=known_args.annotation_field))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Please note that some more unit-tests need to be added and there are a few TODOs (some for follow-up PRs), but this is in a reasonable shape for the first pass review.

Tested:
Added some unit-tests and one integration test (valid_4_2_VEP.json).
More interesting query: https://bigquery.cloud.google.com/results/gcp-variant-transforms-test:bquijob_7d798216_1616efded18

Issue #81 