### PR TITLE
Adds annotation field support and some related refactoring.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -38,6 +38,10 @@ __all__ = ['ReadFromVcf', 'ReadAllFromVcf', 'Variant', 'VariantCall',
            'VariantInfo', 'MalformedVcfRecord']
 
 
+# TODO(bashir2): We should remove VariantInfo and instead use the raw 'data'
+# only; field_count does not need to be carried with the variant and should
+# be extracted from the header data wherever needed.
+#
 # Stores data about variant INFO fields. The type of 'data' is specified in the
 # VCF headers. 'field_count' is a string that specifies the number of fields
 # that the data type contains. Its value can either be a number representing a

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema.py
@@ -21,11 +21,13 @@ import json
 import math
 import re
 import sys
+from typing import Dict, Any  #pylint: disable=unused-import
 
 import vcf
 
 from apache_beam.io.gcp.internal.clients import bigquery
 from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.libs import processed_variant
 
 
 __all__ = ['generate_schema_from_header_fields', 'get_rows_from_variant',
@@ -83,7 +85,8 @@ _JSON_CONCATENATION_OVERHEAD_BYTES = 5
 
 
 def generate_schema_from_header_fields(header_fields, variant_merger=None,
-                                       split_alternate_allele_info_fields=True):
+                                       split_alternate_allele_info_fields=True,
+                                       annotation_fields=None):
   """Returns a ``TableSchema`` for the BigQuery table storing variants.
 
   Args:
@@ -97,6 +100,8 @@ def generate_schema_from_header_fields(header_fields, variant_merger=None,
       `Number=A` (i.e. one value for each alternate allele) will be stored under
       the `alternate_bases` record. If false, they will be stored with the rest
       of the INFO fields.
+    annotation_fields (List[str]): If provided, it is the list of annotation
+      INFO fields.
   """
   schema = bigquery.TableSchema()
   schema.fields.append(bigquery.TableFieldSchema(
@@ -141,6 +146,27 @@ def generate_schema_from_header_fields(header_fields, variant_merger=None,
             type=_get_bigquery_type_from_vcf_type(field.type),
             mode=_TableFieldConstants.MODE_NULLABLE,
             description=_get_bigquery_sanitized_field(field.desc)))
+
+  for annot_field in annotation_fields or []:
+    if not annot_field in header_fields.infos:
+      raise ValueError('Annotation field {} not found'.format(annot_field))
+    annotation_names = processed_variant.extract_annotation_names(
+        header_fields.infos[annot_field].desc)
+    annotation_record = bigquery.TableFieldSchema(
+        name=_get_bigquery_sanitized_field(annot_field),
+        type=_TableFieldConstants.TYPE_RECORD,
+        mode=_TableFieldConstants.MODE_REPEATED,
+        description='List of {} annotations for this alternate.'.format(
+            annot_field))
+    for annotation_name in annotation_names:
+      annotation_record.fields.append(bigquery.TableFieldSchema(
+          name=_get_bigquery_sanitized_field(annotation_name),
+          type=_TableFieldConstants.TYPE_STRING,
+          mode=_TableFieldConstants.MODE_NULLABLE,
+          # TODO(bashir2): Add descriptions of well known annotations, e.g.,
+          # from VEP.
+          description=''))
+    alternate_bases_record.fields.append(annotation_record)
   schema.fields.append(alternate_bases_record)
 
   schema.fields.append(bigquery.TableFieldSchema(
@@ -198,11 +224,13 @@ def generate_schema_from_header_fields(header_fields, variant_merger=None,
 
   # Add info fields.
   info_keys = set()
+  annotation_fields_set = set(annotation_fields or [])
   for key, field in header_fields.infos.iteritems():
     # END info is already included by modifying the end_position.
     if (key == vcfio.END_INFO_KEY or
         (split_alternate_allele_info_fields and
-         field.num == vcf.parser.field_counts[_FIELD_COUNT_ALTERNATE_ALLELE])):
+         field.num == vcf.parser.field_counts[_FIELD_COUNT_ALTERNATE_ALLELE]) or
+        key in annotation_fields_set):
       continue
     schema.fields.append(bigquery.TableFieldSchema(
         name=_get_bigquery_sanitized_field_name(key),
@@ -216,8 +244,8 @@ def generate_schema_from_header_fields(header_fields, variant_merger=None,
 
 
 # TODO: refactor this to use a class instead.
-def get_rows_from_variant(variant, split_alternate_allele_info_fields=True,
-                          omit_empty_sample_calls=False):
+def get_rows_from_variant(variant, omit_empty_sample_calls=False):
+  # type: (processed_variant.ProcessedVariant, bool) -> Dict
   """Yields BigQuery rows according to the schema from the given variant.
 
   There is a 10MB limit for each BigQuery row, which can be exceeded by having
@@ -225,11 +253,7 @@ def get_rows_from_variant(variant, split_alternate_allele_info_fields=True,
   it exceeds 10MB.
 
   Args:
-    variant (``Variant``): Variant to process.
-    split_alternate_allele_info_fields (bool): If true, all INFO fields with
-      `Number=A` (i.e. one value for each alternate allele) will be stored under
-      the `alternate_bases` record. If false, they will be stored with the rest
-      of the INFO fields.
+    variant (``ProcessedVariant``): Variant to convert to a row.
     omit_empty_sample_calls (bool): If true, samples that don't have a given
       call will be omitted.
   Yields:
@@ -240,8 +264,7 @@ def get_rows_from_variant(variant, split_alternate_allele_info_fields=True,
   """
   # TODO: Add error checking here for cases where the schema defined
   # by the headers does not match actual records.
-  base_row = _get_base_row_from_variant(
-      variant, split_alternate_allele_info_fields)
+  base_row = _get_base_row_from_variant(variant)
   base_row_size_in_bytes = _get_json_object_size(base_row)
   row_size_in_bytes = base_row_size_in_bytes
   row = copy.deepcopy(base_row)  # Keep base_row intact.
@@ -287,16 +310,18 @@ def _get_call_record(call):
   return call_record, is_empty
 
 
-def _get_base_row_from_variant(variant, split_alternate_allele_info_fields):
+def _get_base_row_from_variant(variant):
+  # type: (processed_variant.ProcessedVariant) -> Dict[str, Any]
   """A helper method for ``get_rows_from_variant`` to get row without calls."""
   row = {
       ColumnKeyConstants.REFERENCE_NAME: variant.reference_name,
       ColumnKeyConstants.START_POSITION: variant.start,
       ColumnKeyConstants.END_POSITION: variant.end,
       ColumnKeyConstants.REFERENCE_BASES: variant.reference_bases
-  }
+  }  # type: Dict[str, Any]
   if variant.names:
-    row[ColumnKeyConstants.NAMES] = _get_bigquery_sanitized_field(variant.names)
+    row[ColumnKeyConstants.NAMES] = _get_bigquery_sanitized_field(
+        variant.names)
   if variant.quality is not None:
     row[ColumnKeyConstants.QUALITY] = variant.quality
   if variant.filters:
@@ -304,25 +329,17 @@ def _get_base_row_from_variant(variant, split_alternate_allele_info_fields):
         variant.filters)
   # Add alternate bases.
   row[ColumnKeyConstants.ALTERNATE_BASES] = []
-  for alt_index, alt in enumerate(variant.alternate_bases):
-    alt_record = {ColumnKeyConstants.ALTERNATE_BASES_ALT: alt}
-    if split_alternate_allele_info_fields:
-      for info_key, info in variant.info.iteritems():
-        if info.field_count == _FIELD_COUNT_ALTERNATE_ALLELE:
-          if alt_index >= len(info.data):
-            raise ValueError(
-                'Invalid number of "A" fields for key %s in variant %s ' % (
-                    info_key, variant))
-          alt_record[_get_bigquery_sanitized_field_name(info_key)] = (
-              _get_bigquery_sanitized_field(info.data[alt_index]))
+  for alt in variant.alternate_data_list:
+    alt_record = {ColumnKeyConstants.ALTERNATE_BASES_ALT:
+                  alt.alternate_bases}
+    for key, data in alt.info.iteritems():
+      alt_record[_get_bigquery_sanitized_field_name(key)] = data
     row[ColumnKeyConstants.ALTERNATE_BASES].append(alt_record)
   # Add info.
-  for key, info in variant.info.iteritems():
-    if (info.data is not None and
-        (not split_alternate_allele_info_fields or
-         info.field_count != _FIELD_COUNT_ALTERNATE_ALLELE)):
+  for key, data in variant.non_alt_info.iteritems():
+    if data is not None:
       row[_get_bigquery_sanitized_field_name(key)] = (
-          _get_bigquery_sanitized_field(info.data))
+          _get_bigquery_sanitized_field(data))
   # Set calls to empty for now (will be filled later).
   row[ColumnKeyConstants.CALLS] = []
   return row

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_test.py
@@ -29,6 +29,7 @@ from apache_beam.io.gcp.internal.clients import bigquery
 
 from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import bigquery_vcf_schema
+from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_header_parser
 from gcp_variant_transforms.libs.bigquery_vcf_schema import _TableFieldConstants as TableFieldConstants
 from gcp_variant_transforms.libs.bigquery_vcf_schema import ColumnKeyConstants
@@ -201,7 +202,14 @@ class GetRowsFromVariantTest(unittest.TestCase):
   """Test cases for the ``get_rows_from_variant`` library function."""
 
   def _get_row_list_from_variant(self, variant, **kwargs):
-    return list(bigquery_vcf_schema.get_rows_from_variant(variant, **kwargs))
+    # TODO(bashir2): To make this more of a "unit" test, we should create
+    # ProcessedVariant instances directly (instead of Variant) and avoid calling
+    # create_processed_variant here. Then we should also add cases that
+    # have annotation fields.
+    header_fields = vcf_header_parser.HeaderFields({}, {})
+    proc_var = processed_variant.ProcessedVariantFactory(
+        header_fields).create_processed_variant(variant)
+    return list(bigquery_vcf_schema.get_rows_from_variant(proc_var, **kwargs))
 
   def test_all_fields(self):
     variant = vcfio.Variant(
@@ -249,17 +257,6 @@ class GetRowsFromVariantTest(unittest.TestCase):
         'I1': 'some data',
         'I2': ['data1', 'data2']}
     self.assertEqual([expected_row], self._get_row_list_from_variant(variant))
-
-    # Test with split_alternate_allele_info_fields=False.
-    expected_row[ColumnKeyConstants.ALTERNATE_BASES] = [
-        {ColumnKeyConstants.ALTERNATE_BASES_ALT: 'A'},
-        {ColumnKeyConstants.ALTERNATE_BASES_ALT: 'TT'}]
-    expected_row['AF'] = [0.1, 0.2]
-    expected_row['AF2'] = [0.2, 0.3]
-    self.assertEqual(
-        [expected_row],
-        self._get_row_list_from_variant(
-            variant, split_alternate_allele_info_fields=False))
 
   def test_no_alternate_bases(self):
     variant = vcfio.Variant(

--- a/gcp_variant_transforms/libs/processed_variant.py
+++ b/gcp_variant_transforms/libs/processed_variant.py
@@ -1,0 +1,307 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Processes raw variant information using header information.
+
+Note that for creating instances of the data objects in this module, there is a
+factory function create_processed_variant. Other than that function, these
+objects should be used as non-mutable in other scopes, hence all mutating
+functions are "private".
+"""
+
+from __future__ import absolute_import
+
+import logging
+from collections import defaultdict
+from typing import Dict, List, Any  #pylint: disable=unused-import
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.libs import vcf_header_parser  #pylint: disable=unused-import
+
+
+_FIELD_COUNT_ALTERNATE_ALLELE = 'A'
+
+
+class ProcessedVariant(object):
+  """A wrapper around the ``Variant`` class with extra functionality.
+
+  Given header file information, this can parse INFO fields that need to be
+  split and attached to alternates. This is not inherited from
+  :class:``vcfio.Variant`` as an encapsulation layer and to prefer composition.
+  """
+
+  def __init__(self, variant):
+    # type: (vcfio.Variant) -> None
+    if not isinstance(variant, vcfio.Variant):
+      raise ValueError('Expected an instance of vcfio.Variant.')
+    self._variant = variant
+    self._non_alt_info = {}  # type: Dict[str, Any]
+    self._alternate_datas = []  # type: List[AlternateBaseData]
+    for a in variant.alternate_bases:
+      self._alternate_datas.append(AlternateBaseData(a))
+
+  def __repr__(self):
+    return ', '.join(
+        [str(s) for s in [
+            self._variant,
+            self._non_alt_info,
+            self._alternate_datas]])
+
+  def __eq__(self, other):
+    return (isinstance(other, ProcessedVariant) and
+            vars(self) == vars(other))
+
+  @property
+  def reference_name(self):
+    # type: () -> str
+    return self._variant.reference_name
+
+  @property
+  def start(self):
+    # type: () -> int
+    return self._variant.start
+
+  @property
+  def end(self):
+    # type: () -> int
+    return self._variant.end
+
+  @property
+  def reference_bases(self):
+    # type: () -> str
+    return self._variant.reference_bases
+
+  @property
+  def names(self):
+    # type: () -> List[str]
+    return self._variant.names
+
+  @property
+  def quality(self):
+    # type: () -> float
+    return self._variant.quality
+
+  @property
+  def filters(self):
+    # type: () -> List[str]
+    return self._variant.filters
+
+  @property
+  def calls(self):
+    # type: () -> List[vcfio.VariantCall]
+    return self._variant.calls
+
+  @property
+  def non_alt_info(self):
+    # type: () -> Dict[str, Any]
+    """Returns the INFO fields that are not alternate base specific.
+
+    The type of the values in the map is specified in the VCF header. The values
+    are copied from the `vcfio.VariantIfno.data` fields of the input variants.
+    """
+    return self._non_alt_info
+
+  @property
+  def alternate_data_list(self):
+    # type: () -> List[AlternateBaseData]
+    return self._alternate_datas
+
+
+class AlternateBaseData(object):
+  """This is to keep all information for a single alternate-bases."""
+
+  def __init__(self, alt_bases):
+    # type: (str) -> None
+    """
+    Args:
+      alt_bases(str): The alternate bases string for this instance.
+    """
+    self._alt_bases = alt_bases
+    # Note that `_info` also holds the split annotation fields. For those
+    # fields, the value in the `_info` dict has a list of dicts itself.
+    self._info = {}  # type: Dict[str, Any]
+
+  def __repr__(self):
+    return ', '.join([str(self._alt_bases), str(self._info)])
+
+  def __eq__(self, other):
+    return (isinstance(other, AlternateBaseData) and
+            vars(self) == vars(other))
+
+  @property
+  def alternate_bases(self):
+    # type: () -> str
+    return self._alt_bases
+
+  @property
+  def info(self):
+    # type: () -> Dict[str, Any]
+    return self._info
+
+
+class ProcessedVariantFactory(object):
+  """Factory class for creating `ProcessedVaraint` instances.
+
+  This is the only right way for creating ProcessedVariants in production code.
+  It uses the header information to process INFO fields and split them between
+  alternates if needed. In the process, it does some header sanity checking too.
+  """
+  def __init__(
+      self,
+      header_fields,
+      split_alternate_allele_info_fields=True,
+      annotation_fields=None):
+    # type: (vcf_header_parser.HeaderFields, bool, List[str]) -> None
+    """Sets the internal state of the factory class.
+
+    Args:
+      header_fields (:class:`vcf_header_parser.HeaderFields`): Header
+        information used for parsing and splitting INFO fields of thei variant.
+      split_alternate_allele_info_fields (bool): If True, splits fields with
+        field_count='A' (i.e., one value for each alternate) among alternates.
+      annotation_fields (List[str]): If provided, this is the list of
+        INFO field names that store variant annotations. The format of how
+        annotations are stored and their names are extracted from header_fields.
+    """
+    self._header_fields = header_fields
+    self._split_alternate_allele_info_fields = (
+        split_alternate_allele_info_fields)
+    self._annotation_field_set = set(annotation_fields or [])
+
+  def create_processed_variant(self, variant):
+    # type: (vcfio.Variant) -> ProcessedVariant
+    """The main factory method for creating ProcessedVariants.
+
+    Args:
+      variant (:class:`vcfio.Variant`): The raw variant information.
+    """
+    proc_var = ProcessedVariant(variant)
+    for key, variant_info in variant.info.iteritems():
+      # TODO(bashir2): field_count should be removed from VariantInfo and
+      # instead looked up from header_fields.
+      if (self._split_alternate_allele_info_fields and
+          variant_info.field_count == _FIELD_COUNT_ALTERNATE_ALLELE):
+        self._add_per_alt_info(proc_var, key, variant_info.data)
+      elif key in self._annotation_field_set:
+        self._add_annotation(proc_var, key, variant_info.data)
+      else:
+        proc_var._non_alt_info[key] = variant_info.data
+    return proc_var
+
+  def _add_per_alt_info(self, proc_var, field_name, variant_info_data):
+    # type: (ProcessedVariant, str, vcfio.VariantInfo) -> None
+    if len(variant_info_data) != len(proc_var._alternate_datas):
+      raise ValueError(
+          'Per alternate INFO field {} does not have same cardinality as '
+          ' number of alternates: {} vs {}'.format(
+              field_name, len(variant_info_data),
+              len(proc_var._alternate_datas)))
+    for alt_index, info in enumerate(variant_info_data):
+      proc_var._alternate_datas[alt_index]._info[field_name] = info
+
+  def _add_annotation(self, proc_var, field_name, data):
+    # type: (ProcessedVariant, str, List[str]) -> None
+    """Adds an annotation INFO field based on the format in the header.
+
+    Args:
+      proc_var (ProcessedVariant): The object to which the annotations are being
+        added.
+      field_name (str): The name of the annotation field.
+      data(List[str]): The data part of the field separated on comma.
+    """
+    if field_name not in self._header_fields.infos:
+      raise ValueError('{} INFO not found in the header, variant: {}'.format(
+          field_name, proc_var))
+    header_desc = self._header_fields.infos[field_name].desc
+    annotation_names = extract_annotation_names(header_desc)
+    alt_annotation_map = self._convert_annotation_strs_to_alt_map(
+        annotation_names, data)
+    for alt_bases, annotations_list in alt_annotation_map.iteritems():
+      # This assumes that number of alternate bases and annotation segments
+      # are not too big. If this assumption is not true, we should replace the
+      # following loop with a hash table search and avoid the quadratic time.
+      for alt in proc_var._alternate_datas:
+        if alt.alternate_bases == alt_bases:
+          alt._info[field_name] = annotations_list
+          break
+      # TODO(bashir2): Currently we only check exact matches of alternate bases
+      # which is not enough. We should implement the whole standard for finding
+      # alternate bases for an annotation list.
+      else:
+        logging.warning('Could not find matching alternate bases for %s in '
+                        'annotation filed %s', alt_bases, field_name)
+
+  def _convert_annotation_strs_to_alt_map(self, annotation_names, field_data):
+    # type: (List[str], List[str]) -> Dict[str, List[Dict[str, str]]]
+    alt_annotation_map = defaultdict(list)
+    for annotation_str in field_data:
+      annotations = _extract_annotation_list_with_alt(annotation_str)
+      alt_annotation_map[annotations[0]].append(
+          self._create_annotation_map(annotations, annotation_names))
+    return alt_annotation_map
+
+  def _create_annotation_map(self, annotations, annotation_names):
+    # type: (List[str], List[str]) -> Dict[str, str]
+    if len(annotation_names) != len(annotations) - 1:
+      raise ValueError('Expected {} annotations, got {}'.format(
+          len(annotation_names), len(annotations) - 1))
+    annotation_dict = {}
+    for index, name in enumerate(annotation_names):
+      annotation_dict[name] = annotations[index + 1]
+    return annotation_dict
+
+
+def _extract_annotation_list_with_alt(annotation_str):
+  # type: (str) -> List[str]
+  """Extracts annotations from an annotation INFO field.
+
+  This works by dividing the `annotation_str` on '|'. The first element is
+  the alternate allele and the rest are the annotations. For example, for
+  'G|upstream_gene_variant|MODIFIER|PSMF1' as `annotation_str`, it returns
+  ['G', 'upstream_gene_variant', 'MODIFIER', 'PSMF1'].
+
+  Args:
+    annotation_str: The content of annotation field for one alt.
+
+  Returns:
+    The list of annotations with the first element being the alternate.
+  """
+  return annotation_str.split('|')
+
+
+# TODO(bashir2): Once the refactoring of bigquery_vcf_schema is complete, these
+# functions should not be used outside this module (mark them as 'private').
+
+def extract_annotation_names(description):
+  # type: (str) -> List[str]
+  """Extracts annotation list from the description of an annotation INFO field.
+
+  This is similar to extract_extract_annotation_list_with_alt with the
+  difference that it ignores everything before the first '|'. For example, for
+  'some desc ... Format: Allele|Consequence|IMPACT|SYMBOL|Gene', it returns
+  ['Consequence', 'IMPACT', 'SYMBOL', 'Gene']
+
+  Args:
+    description: The "Description" part of the annotation INFO field
+      in the header of VCF.
+
+  Returns:
+    The list of annotation names.
+  """
+  annotation_names = _extract_annotation_list_with_alt(description)
+  if len(annotation_names) < 2:
+    raise ValueError(
+        'Expected at least one | in annotation description {}'.format(
+            description))
+  return annotation_names[1:]

--- a/gcp_variant_transforms/libs/processed_variant_test.py
+++ b/gcp_variant_transforms/libs/processed_variant_test.py
@@ -1,0 +1,106 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import unittest
+
+from vcf import parser
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.libs import processed_variant
+from gcp_variant_transforms.libs import vcf_header_parser
+
+class ProcessedVariantFactoryTest(unittest.TestCase):
+
+  def _get_sample_variant(self):
+    return vcfio.Variant(
+        reference_name='19', start=11, end=12, reference_bases='C',
+        alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
+        filters=['PASS'],
+        info={'A1': vcfio.VariantInfo('some data', '1'),
+              'A2': vcfio.VariantInfo(['data1', 'data2'], 'A')},
+        calls=[
+            vcfio.VariantCall(name='Sample1', genotype=[0, 1],
+                              info={'GQ': 20, 'HQ': [10, 20]}),
+            vcfio.VariantCall(name='Sample2', genotype=[1, 0],
+                              info={'GQ': 10, 'FLAG1': True})])
+
+  def test_create_processed_variant_no_change(self):
+    variant = self._get_sample_variant()
+    header_fields = vcf_header_parser.HeaderFields({}, {})
+    factory = processed_variant.ProcessedVariantFactory(
+        header_fields,
+        split_alternate_allele_info_fields=False)
+    proc_var = factory.create_processed_variant(variant)
+    # In this mode, the only difference between the original `variant` and
+    # `proc_var` should be that INFO fields are copied to `_non_alt_info` map
+    # and `_alternate_datas` are filled with alternate bases information only.
+    proc_var_synthetic = processed_variant.ProcessedVariant(variant)
+    proc_var_synthetic._non_alt_info = {'A1': 'some data',
+                                        'A2': ['data1', 'data2']}
+    proc_var_synthetic._alternate_datas = [
+        processed_variant.AlternateBaseData(a) for a in ['A', 'TT']]
+    self.assertEqual([proc_var_synthetic], [proc_var])
+
+  def test_create_processed_variant_move_alt_info(self):
+    variant = self._get_sample_variant()
+    header_fields = vcf_header_parser.HeaderFields({}, {})
+    factory = processed_variant.ProcessedVariantFactory(
+        header_fields,
+        split_alternate_allele_info_fields=True)
+    proc_var = factory.create_processed_variant(variant)
+    alt1 = processed_variant.AlternateBaseData('A')
+    alt1._info = {'A2': 'data1'}
+    alt2 = processed_variant.AlternateBaseData('TT')
+    alt2._info = {'A2': 'data2'}
+    self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
+    self.assertFalse(proc_var.non_alt_info.has_key('A2'))
+
+  def test_create_processed_variant_move_alt_info_and_annotation(self):
+    variant = self._get_sample_variant()
+    variant.info['CSQ'] = vcfio.VariantInfo(
+        data=['A|C1|I1|S1|G1', 'TT|C2|I2|S2|G2', 'A|C3|I3|S3|G3'],
+        field_count='.')
+    csq_info = parser._Info(
+        id=None,
+        num='.',
+        type=None,
+        desc='some desc Allele|Consequence|IMPACT|SYMBOL|Gene',
+        source=None,
+        version=None)
+    header_fields = vcf_header_parser.HeaderFields(
+        infos={'CSQ': csq_info},
+        formats={})
+    factory = processed_variant.ProcessedVariantFactory(
+        header_fields,
+        split_alternate_allele_info_fields=True,
+        annotation_fields=['CSQ'])
+    proc_var = factory.create_processed_variant(variant)
+    alt1 = processed_variant.AlternateBaseData('A')
+    alt1._info = {
+        'A2': 'data1',
+        'CSQ': [
+            {'Consequence': 'C1', 'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'},
+            {'Consequence': 'C3', 'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
+    }
+    alt2 = processed_variant.AlternateBaseData('TT')
+    alt2._info = {
+        'A2': 'data2',
+        'CSQ': [
+            {'Consequence': 'C2', 'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
+    }
+    self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
+    self.assertFalse(proc_var.non_alt_info.has_key('A2'))
+    self.assertFalse(proc_var.non_alt_info.has_key('CSQ'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -105,6 +105,15 @@ class BigQueryWriteOptions(VariantTransformsOptions):
         '--omit_empty_sample_calls',
         type='bool', default=False, nargs='?', const=True,
         help=("If true, samples that don't have a given call will be omitted."))
+    parser.add_argument(
+        '--annotation_fields',
+        default=None, nargs='+',
+        help=('If set, it is a list of field names (separated by space) that '
+              'should be treated as annotation fields. The content of these '
+              'INFO fields will be broken into multiple columns in the output '
+              'BigQuery table and stored as repeated fields with '
+              'corresponding alternate alleles. [EXPERIMENTAL]'))
+
 
   def validate(self, parsed_args, client=None):
     output_table_re_match = re.match(

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_VEP.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_VEP.json
@@ -1,0 +1,15 @@
+{
+  "test_name": "valid-4-2-vep",
+  "table_name": "valid_4_2_VEP",
+  "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2_VEP.vcf",
+  "annotation_field": "CSQ",
+  "runner": "DataflowRunner",
+  "validation_query": [
+    "SELECT COUNT(DISTINCT CSQ.Feature) AS num_features ",
+    "FROM {TABLE_NAME} AS t, t.alternate_bases as alts, alts.CSQ as CSQ ",
+    "WHERE start_position = 1110695 AND alts.alt = 'G'"
+  ],
+  "expected_query_result": {
+    "num_features": 3
+  }
+}

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -50,6 +50,7 @@ from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import vcf_header_parser
 from gcp_variant_transforms.libs.variant_merge import merge_with_non_variants_strategy
 from gcp_variant_transforms.libs.variant_merge import move_to_calls_strategy
+from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.options import variant_transform_options
 from gcp_variant_transforms.transforms import filter_variants
 from gcp_variant_transforms.transforms import merge_headers
@@ -188,7 +189,6 @@ def _validate_args(options, parsed_args):
 
 def run(argv=None):
   """Runs VCF to BigQuery pipeline."""
-
   parser = argparse.ArgumentParser()
   parser.register('type', 'bool', lambda v: v.lower() == 'true')
   command_line_options = [option() for option in _COMMAND_LINE_OPTIONS]
@@ -208,6 +208,10 @@ def run(argv=None):
   # See https://issues.apache.org/jira/browse/BEAM-2801.
   header_fields = vcf_header_parser.get_vcf_headers(
       known_args.representative_header_file)
+  processed_variant_factory = processed_variant.ProcessedVariantFactory(
+      header_fields,
+      known_args.split_alternate_allele_info_fields,
+      known_args.annotation_fields)
 
   pipeline_options = PipelineOptions(pipeline_args)
   with beam.Pipeline(options=pipeline_options) as p:
@@ -217,14 +221,18 @@ def run(argv=None):
     if variant_merger:
       variants |= (
           'MergeVariants' >> merge_variants.MergeVariants(variant_merger))
-    _ = (variants |
+    proc_variants = variants | 'ProcessVaraints' >> beam.Map(
+        processed_variant_factory.create_processed_variant).\
+      with_output_types(processed_variant.ProcessedVariant)
+    _ = (proc_variants |
          'VariantToBigQuery' >> variant_to_bigquery.VariantToBigQuery(
              known_args.output_table,
              header_fields,
              variant_merger,
              known_args.split_alternate_allele_info_fields,
              append=known_args.append,
-             omit_empty_sample_calls=known_args.omit_empty_sample_calls))
+             omit_empty_sample_calls=known_args.omit_empty_sample_calls,
+             annotation_fields=known_args.annotation_fields))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Follow up (i.e., replacement) of PR #107.

Please note that this PR needs more work to fix current unit-test and add new ones (plus other minor clean-ups and documentations) but I am sharing at this point to get early feedback on the design and make sure we are on the same page. In particular, please look at processed_variant module and how Variant objects are transformed into ProcessedVariant.

Tested:
Manually ran the pipeline locally on the new integration test file (see valid_4_2_VEP.json) and checked the output.
Also `./deploy_and_run_tests.sh --keep_image --keep_tables` passed.
Sample query:
`SELECT start_position, end_position, alt.AF, annotations.Consequence
FROM integration_tests_20180210_010224.valid_4_2_VEP AS t, t.alternate_bases as alt LEFT JOIN alt.CSQ AS annotations
ORDER BY start_position, alt.AF, annotations.Consequence`

Issue #81, #59 