### PR TITLE
Moves alternate bases schema mutation to ProcessedVariantFactory.

### DIFF
--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -1,0 +1,209 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Constants and simple utility functions related to BigQuery."""
+
+import re
+import math
+import sys
+
+from gcp_variant_transforms.beam_io import vcfio
+
+
+class ColumnKeyConstants(object):
+  """Constants for column names in the BigQuery schema."""
+  REFERENCE_NAME = 'reference_name'
+  START_POSITION = 'start_position'
+  END_POSITION = 'end_position'
+  REFERENCE_BASES = 'reference_bases'
+  ALTERNATE_BASES = 'alternate_bases'
+  ALTERNATE_BASES_ALT = 'alt'
+  NAMES = 'names'
+  QUALITY = 'quality'
+  FILTER = 'filter'
+  CALLS = 'call'  # Column name is singular for consistency with Variants API.
+  CALLS_NAME = 'name'
+  CALLS_GENOTYPE = 'genotype'
+  CALLS_PHASESET = 'phaseset'
+
+
+class TableFieldConstants(object):
+  """Constants for field modes/types in the BigQuery schema."""
+  TYPE_STRING = 'string'
+  TYPE_INTEGER = 'integer'
+  TYPE_RECORD = 'record'
+  TYPE_FLOAT = 'float'
+  TYPE_BOOLEAN = 'boolean'
+  MODE_NULLABLE = 'nullable'
+  MODE_REPEATED = 'repeated'
+
+
+# A map to convert from VCF types to their equivalent BigQuery types.
+_VCF_TYPE_TO_BIG_QUERY_TYPE_MAP = {
+    'integer': TableFieldConstants.TYPE_INTEGER,
+    'string': TableFieldConstants.TYPE_STRING,
+    'character': TableFieldConstants.TYPE_STRING,
+    'float': TableFieldConstants.TYPE_FLOAT,
+    'flag': TableFieldConstants.TYPE_BOOLEAN,
+}
+
+
+# Prefix to use when the first character of the field name is not [a-zA-Z]
+# as required by BigQuery.
+_FALLBACK_FIELD_NAME_PREFIX = 'field_'
+
+
+def get_bigquery_sanitized_field_name(field_name):
+  """Returns the sanitized field name according to BigQuery restrictions.
+
+  BigQuery field names must follow `[a-zA-Z][a-zA-Z0-9_]*`. This method converts
+  any unsupported characters to an underscore. Also, if the first character does
+  not match `[a-zA-Z]`, it prepends ``_FALLBACK_FIELD_NAME_PREFIX`` to the name.
+
+  Args:
+    field_name (str): Name of the field to sanitize.
+  Returns:
+    Sanitized field name with unsupported characters replaced with an
+    underscore. It also prepends the name with ``_FALLBACK_FIELD_NAME_PREFIX``
+    if the first character does not match `[a-zA-Z]`.
+  """
+  assert field_name  # field_name must not be empty by this stage.
+  if not re.match('[a-zA-Z]', field_name[0]):
+    field_name = _FALLBACK_FIELD_NAME_PREFIX + field_name
+  return re.sub('[^a-zA-Z0-9_]', '_', field_name)
+
+
+def get_bigquery_type_from_vcf_type(vcf_type):
+  vcf_type = vcf_type.lower()
+  if vcf_type not in _VCF_TYPE_TO_BIG_QUERY_TYPE_MAP:
+    raise ValueError('Invalid VCF type: %s' % vcf_type)
+  return _VCF_TYPE_TO_BIG_QUERY_TYPE_MAP[vcf_type]
+
+
+def get_bigquery_sanitized_field(
+    field, null_numeric_value_replacement=-sys.maxint):
+  """Returns sanitized field according to BigQuery restrictions.
+
+  This method only sanitizes lists and strings. It returns the same
+  ``field`` for all other types (including None).
+
+  For lists, null values are replaced with reasonable defaults since the
+  BgiQuery API does not allow null values in lists (note that the entire
+  list is allowed to be null). For instance, [0, None, 1] becomes
+  [0, ``null_numeric_value_replacement``, 1].
+  Null value replacements are:
+    - `False` for bool.
+    - `.` for string (null string values should not exist in Variants parsed
+      using PyVCF though).
+    - ``null_numeric_value_replacement`` for float/int/long.
+  TODO: Expose ``null_numeric_value_replacement`` as a flag.
+
+  For strings, it returns its unicode representation. The BigQuery API does not
+  support strings that are UTF-8 encoded.
+
+  Args:
+    field: Field to sanitize. It can be of any type.
+    null_numeric_value_replacement (int): Value to use instead of null for
+      numeric (float/int/long) lists.
+  Raises:
+    ValueError: If the field could not be sanitized (e.g. unsupported types in
+      lists).
+  """
+  if not field:
+    return field
+  if isinstance(field, basestring):
+    return _get_bigquery_sanitized_string(field)
+  elif isinstance(field, float):
+    return _get_bigquery_sanitized_float(field)
+  elif isinstance(field, list):
+    return _get_bigquery_sanitized_list(field, null_numeric_value_replacement)
+  else:
+    return field
+
+
+def _get_bigquery_sanitized_list(input_list, null_numeric_value_replacement):
+  """Returns sanitized list according to BigQuery restrictions.
+
+  Null values are replaced with reasonable defaults since the
+  BgiQuery API does not allow null values in lists (note that the entire
+  list is allowed to be null). For instance, [0, None, 1] becomes
+  [0, ``null_numeric_value_replacement``, 1].
+  Null value replacements are:
+    - `False` for bool.
+    - `.` for string (null string values should not exist in Variants parsed
+      using PyVCF though).
+    - ``null_numeric_value_replacement`` for float/int/long.
+  Lists that contain strings are also sanitized according to the
+  ``_get_bigquery_sanitized_string`` method.
+
+  Args:
+    input_list: List to sanitize.
+    null_numeric_value_replacement (int): Value to use instead of null for
+      numeric (float/int/long) lists.
+  Raises:
+    ValueError: If a list contains unsupported values. Supported types are
+      basestring, bool, int, long, and float.
+  """
+  null_replacement_value = None
+  for i in input_list:
+    if i is None:
+      continue
+    if isinstance(i, basestring):
+      null_replacement_value = vcfio.MISSING_FIELD_VALUE
+    elif isinstance(i, bool):
+      null_replacement_value = False
+    elif isinstance(i, (int, long, float)):
+      null_replacement_value = null_numeric_value_replacement
+    else:
+      raise ValueError('Unsupported value for input: %s' % str(i))
+    break  # Assumption is that all fields have the same type.
+  if null_replacement_value is None:  # Implies everything was None.
+    return []
+  sanitized_list = []
+  for i in input_list:
+    if i is None:
+      i = null_replacement_value
+    elif isinstance(i, basestring):
+      i = _get_bigquery_sanitized_string(i)
+    elif isinstance(i, float):
+      sanitized_float = _get_bigquery_sanitized_float(i)
+      i = (sanitized_float if sanitized_float is not None
+           else null_replacement_value)
+    sanitized_list.append(i)
+  return sanitized_list
+
+
+def _get_bigquery_sanitized_float(input_float):
+  """Returns a sanitized float for BigQuery.
+
+  This method replaces INF with sys.maxint, -INF with -sys.maxint, and NaN
+  with None. It returns the same value for all other values.
+  """
+  if input_float == float('inf'):
+    return sys.maxint
+  elif input_float == float('-inf'):
+    return -sys.maxint
+  elif math.isnan(input_float):
+    return None
+  else:
+    return input_float
+
+
+def _get_bigquery_sanitized_string(input_str):
+  """Returns a unicode string as BigQuery API does not support UTF-8 strings."""
+  try:
+    return (input_str if isinstance(input_str, unicode)
+            else input_str.decode('utf-8'))
+  except UnicodeDecodeError:
+    raise ValueError('input_str is not UTF-8: %s ' % (input_str))

--- a/gcp_variant_transforms/libs/bigquery_util_test.py
+++ b/gcp_variant_transforms/libs/bigquery_util_test.py
@@ -1,0 +1,56 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import unittest
+
+from gcp_variant_transforms.libs import bigquery_util
+
+class BigqueryUtilTest(unittest.TestCase):
+
+  def test_get_bigquery_sanitized_field_name(self):
+    self.assertEqual('AA',
+                     bigquery_util.get_bigquery_sanitized_field_name('AA'))
+    self.assertEqual('field__AA',
+                     bigquery_util.get_bigquery_sanitized_field_name('_AA'))
+    self.assertEqual('field_1A1A',
+                     bigquery_util.get_bigquery_sanitized_field_name('1A1A'))
+
+  def test_get_bigquery_type_from_vcf_type(self):
+    self.assertEqual(bigquery_util.TableFieldConstants.TYPE_INTEGER,
+                     bigquery_util.get_bigquery_type_from_vcf_type('integer'))
+    self.assertEqual(bigquery_util.TableFieldConstants.TYPE_STRING,
+                     bigquery_util.get_bigquery_type_from_vcf_type('string'))
+    self.assertEqual(bigquery_util.TableFieldConstants.TYPE_STRING,
+                     bigquery_util.get_bigquery_type_from_vcf_type('character'))
+    self.assertEqual(bigquery_util.TableFieldConstants.TYPE_FLOAT,
+                     bigquery_util.get_bigquery_type_from_vcf_type('float'))
+    self.assertEqual(bigquery_util.TableFieldConstants.TYPE_BOOLEAN,
+                     bigquery_util.get_bigquery_type_from_vcf_type('flag'))
+    self.assertRaises(
+        ValueError,
+        bigquery_util.get_bigquery_type_from_vcf_type, 'DUMMY')
+
+  def test_get_bigquery_sanitized_field(self):
+    self.assertEqual(u'valid',
+                     bigquery_util.get_bigquery_sanitized_field('valid'))
+    self.assertRaises(
+        ValueError,
+        bigquery_util.get_bigquery_sanitized_field, '\x81DUMMY')
+    self.assertEqual([1, 2],
+                     bigquery_util.get_bigquery_sanitized_field([1, 2]))
+    self.assertEqual([1, -1, 2],
+                     bigquery_util.get_bigquery_sanitized_field(
+                         [1, None, 2], null_numeric_value_replacement=-1))

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema.py
@@ -18,62 +18,19 @@ from __future__ import absolute_import
 
 import copy
 import json
-import math
-import re
-import sys
 from typing import Dict, Any  #pylint: disable=unused-import
-
-import vcf
 
 from apache_beam.io.gcp.internal.clients import bigquery
 from gcp_variant_transforms.beam_io import vcfio
-from gcp_variant_transforms.libs import processed_variant
+from gcp_variant_transforms.libs import bigquery_util
+from gcp_variant_transforms.libs import vcf_header_parser  #pylint: disable=unused-import
+from gcp_variant_transforms.libs import processed_variant  #pylint: disable=unused-import
+from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy  #pylint: disable=unused-import
 
 
-__all__ = ['generate_schema_from_header_fields', 'get_rows_from_variant',
-           'ColumnKeyConstants']
+__all__ = ['generate_schema_from_header_fields', 'get_rows_from_variant']
 
 
-class ColumnKeyConstants(object):
-  """Constants for column names in the BigQuery schema."""
-  REFERENCE_NAME = 'reference_name'
-  START_POSITION = 'start_position'
-  END_POSITION = 'end_position'
-  REFERENCE_BASES = 'reference_bases'
-  ALTERNATE_BASES = 'alternate_bases'
-  ALTERNATE_BASES_ALT = 'alt'
-  NAMES = 'names'
-  QUALITY = 'quality'
-  FILTER = 'filter'
-  CALLS = 'call'  # Column name is singular for consistency with Variants API.
-  CALLS_NAME = 'name'
-  CALLS_GENOTYPE = 'genotype'
-  CALLS_PHASESET = 'phaseset'
-
-
-class _TableFieldConstants(object):
-  """Constants for field modes/types in the BigQuery schema."""
-  TYPE_STRING = 'string'
-  TYPE_INTEGER = 'integer'
-  TYPE_RECORD = 'record'
-  TYPE_FLOAT = 'float'
-  TYPE_BOOLEAN = 'boolean'
-  MODE_NULLABLE = 'nullable'
-  MODE_REPEATED = 'repeated'
-
-
-# A map to convert from VCF types to their equivalent BigQuery types.
-_VCF_TYPE_TO_BIG_QUERY_TYPE_MAP = {
-    'integer': _TableFieldConstants.TYPE_INTEGER,
-    'string': _TableFieldConstants.TYPE_STRING,
-    'character': _TableFieldConstants.TYPE_STRING,
-    'float': _TableFieldConstants.TYPE_FLOAT,
-    'flag': _TableFieldConstants.TYPE_BOOLEAN,
-}
-_FIELD_COUNT_ALTERNATE_ALLELE = 'A'
-# Prefix to use when the first character of the field name is not [a-zA-Z]
-# as required by BigQuery.
-_FALLBACK_FIELD_NAME_PREFIX = 'field_'
 # Maximum size of a BigQuery row is 10MB. See
 # https://cloud.google.com/bigquery/quotas#import for details.
 # We set it to 10MB - 10KB to leave a bit of room for error in case jsonifying
@@ -84,130 +41,89 @@ _MAX_BIGQUERY_ROW_SIZE_BYTES = 10 * 1024 * 1024 - 10 * 1024
 _JSON_CONCATENATION_OVERHEAD_BYTES = 5
 
 
-def generate_schema_from_header_fields(header_fields, variant_merger=None,
-                                       split_alternate_allele_info_fields=True,
-                                       annotation_fields=None):
+def generate_schema_from_header_fields(
+    header_fields,  # type: vcf_header_parser.HeaderFields
+    proc_variant_factory,  # type: processed_variant.ProcessedVariantFactory
+    variant_merger=None  # type: variant_merge_strategy.VariantMergeStrategy
+    ):
   """Returns a ``TableSchema`` for the BigQuery table storing variants.
 
   Args:
-    header_fields (``HeaderFields``): A ``namedtuple`` containing representative
-      header fields for all ``Variant`` records. This specifies custom INFO and
-      FORMAT fields in the VCF file(s).
-    variant_merger (``VariantMergeStrategy``): The strategy used for merging
-      variants (if any). Some strategies may change the schema, which is why
-      this may be needed here.
-    split_alternate_allele_info_fields (bool): If true, all INFO fields with
-      `Number=A` (i.e. one value for each alternate allele) will be stored under
-      the `alternate_bases` record. If false, they will be stored with the rest
-      of the INFO fields.
-    annotation_fields (List[str]): If provided, it is the list of annotation
-      INFO fields.
+    header_fields: A `namedtuple` containing representative header fields for
+      all variant records. This specifies custom INFO and FORMAT fields in the
+      VCF file(s).
+    proc_variant_factory: The factory class that knows how to convert Variant
+      instances to ProcessedVariant. As a side effect it also knows how to
+      modify BigQuery schema based on the ProcessedVariants that it generates.
+      The latter functionality is what is needed here.
+    variant_merger: The strategy used for merging variants (if any). Some
+      strategies may change the schema, which is why this may be needed here.
   """
   schema = bigquery.TableSchema()
   schema.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.REFERENCE_NAME,
-      type=_TableFieldConstants.TYPE_STRING,
-      mode=_TableFieldConstants.MODE_NULLABLE,
+      name=bigquery_util.ColumnKeyConstants.REFERENCE_NAME,
+      type=bigquery_util.TableFieldConstants.TYPE_STRING,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description='Reference name.'))
   schema.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.START_POSITION,
-      type=_TableFieldConstants.TYPE_INTEGER,
-      mode=_TableFieldConstants.MODE_NULLABLE,
+      name=bigquery_util.ColumnKeyConstants.START_POSITION,
+      type=bigquery_util.TableFieldConstants.TYPE_INTEGER,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description=('Start position (0-based). Corresponds to the first base '
                    'of the string of reference bases.')))
   schema.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.END_POSITION,
-      type=_TableFieldConstants.TYPE_INTEGER,
-      mode=_TableFieldConstants.MODE_NULLABLE,
+      name=bigquery_util.ColumnKeyConstants.END_POSITION,
+      type=bigquery_util.TableFieldConstants.TYPE_INTEGER,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description=('End position (0-based). Corresponds to the first base '
                    'after the last base in the reference allele.')))
   schema.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.REFERENCE_BASES,
-      type=_TableFieldConstants.TYPE_STRING,
-      mode=_TableFieldConstants.MODE_NULLABLE,
+      name=bigquery_util.ColumnKeyConstants.REFERENCE_BASES,
+      type=bigquery_util.TableFieldConstants.TYPE_STRING,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description='Reference bases.'))
 
-  # Add alternate bases.
-  alternate_bases_record = bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.ALTERNATE_BASES,
-      type=_TableFieldConstants.TYPE_RECORD,
-      mode=_TableFieldConstants.MODE_REPEATED,
-      description='One record for each alternate base (if any).')
-  alternate_bases_record.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.ALTERNATE_BASES_ALT,
-      type=_TableFieldConstants.TYPE_STRING,
-      mode=_TableFieldConstants.MODE_NULLABLE,
-      description='Alternate base.'))
-  if split_alternate_allele_info_fields:
-    for key, field in header_fields.infos.iteritems():
-      if field.num == vcf.parser.field_counts[_FIELD_COUNT_ALTERNATE_ALLELE]:
-        alternate_bases_record.fields.append(bigquery.TableFieldSchema(
-            name=_get_bigquery_sanitized_field_name(key),
-            type=_get_bigquery_type_from_vcf_type(field.type),
-            mode=_TableFieldConstants.MODE_NULLABLE,
-            description=_get_bigquery_sanitized_field(field.desc)))
-
-  for annot_field in annotation_fields or []:
-    if not annot_field in header_fields.infos:
-      raise ValueError('Annotation field {} not found'.format(annot_field))
-    annotation_names = processed_variant.extract_annotation_names(
-        header_fields.infos[annot_field].desc)
-    annotation_record = bigquery.TableFieldSchema(
-        name=_get_bigquery_sanitized_field(annot_field),
-        type=_TableFieldConstants.TYPE_RECORD,
-        mode=_TableFieldConstants.MODE_REPEATED,
-        description='List of {} annotations for this alternate.'.format(
-            annot_field))
-    for annotation_name in annotation_names:
-      annotation_record.fields.append(bigquery.TableFieldSchema(
-          name=_get_bigquery_sanitized_field(annotation_name),
-          type=_TableFieldConstants.TYPE_STRING,
-          mode=_TableFieldConstants.MODE_NULLABLE,
-          # TODO(bashir2): Add descriptions of well known annotations, e.g.,
-          # from VEP.
-          description=''))
-    alternate_bases_record.fields.append(annotation_record)
-  schema.fields.append(alternate_bases_record)
+  schema.fields.append(proc_variant_factory.create_alt_bases_field_schema())
 
   schema.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.NAMES,
-      type=_TableFieldConstants.TYPE_STRING,
-      mode=_TableFieldConstants.MODE_REPEATED,
+      name=bigquery_util.ColumnKeyConstants.NAMES,
+      type=bigquery_util.TableFieldConstants.TYPE_STRING,
+      mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
       description='Variant names (e.g. RefSNP ID).'))
   schema.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.QUALITY,
-      type=_TableFieldConstants.TYPE_FLOAT,
-      mode=_TableFieldConstants.MODE_NULLABLE,
+      name=bigquery_util.ColumnKeyConstants.QUALITY,
+      type=bigquery_util.TableFieldConstants.TYPE_FLOAT,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description=('Phred-scaled quality score (-10log10 prob(call is wrong)). '
                    'Higher values imply better quality.')))
   schema.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.FILTER,
-      type=_TableFieldConstants.TYPE_STRING,
-      mode=_TableFieldConstants.MODE_REPEATED,
+      name=bigquery_util.ColumnKeyConstants.FILTER,
+      type=bigquery_util.TableFieldConstants.TYPE_STRING,
+      mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
       description=('List of failed filters (if any) or "PASS" indicating the '
                    'variant has passed all filters.')))
 
   # Add calls.
   calls_record = bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.CALLS,
-      type=_TableFieldConstants.TYPE_RECORD,
-      mode=_TableFieldConstants.MODE_REPEATED,
+      name=bigquery_util.ColumnKeyConstants.CALLS,
+      type=bigquery_util.TableFieldConstants.TYPE_RECORD,
+      mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
       description='One record for each call.')
   calls_record.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.CALLS_NAME,
-      type=_TableFieldConstants.TYPE_STRING,
-      mode=_TableFieldConstants.MODE_NULLABLE,
+      name=bigquery_util.ColumnKeyConstants.CALLS_NAME,
+      type=bigquery_util.TableFieldConstants.TYPE_STRING,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description='Name of the call.'))
   calls_record.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.CALLS_GENOTYPE,
-      type=_TableFieldConstants.TYPE_INTEGER,
-      mode=_TableFieldConstants.MODE_REPEATED,
+      name=bigquery_util.ColumnKeyConstants.CALLS_GENOTYPE,
+      type=bigquery_util.TableFieldConstants.TYPE_INTEGER,
+      mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
       description=('Genotype of the call. "-1" is used in cases where the '
                    'genotype is not called.')))
   calls_record.fields.append(bigquery.TableFieldSchema(
-      name=ColumnKeyConstants.CALLS_PHASESET,
-      type=_TableFieldConstants.TYPE_STRING,
-      mode=_TableFieldConstants.MODE_NULLABLE,
+      name=bigquery_util.ColumnKeyConstants.CALLS_PHASESET,
+      type=bigquery_util.TableFieldConstants.TYPE_STRING,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description=('Phaseset of the call (if any). "*" is used in cases where '
                    'the genotype is phased, but no phase set ("PS" in FORMAT) '
                    'was specified.')))
@@ -216,27 +132,24 @@ def generate_schema_from_header_fields(header_fields, variant_merger=None,
     if key in (vcfio.GENOTYPE_FORMAT_KEY, vcfio.PHASESET_FORMAT_KEY):
       continue
     calls_record.fields.append(bigquery.TableFieldSchema(
-        name=_get_bigquery_sanitized_field_name(key),
-        type=_get_bigquery_type_from_vcf_type(field.type),
+        name=bigquery_util.get_bigquery_sanitized_field_name(key),
+        type=bigquery_util.get_bigquery_type_from_vcf_type(field.type),
         mode=_get_bigquery_mode_from_vcf_num(field.num),
-        description=_get_bigquery_sanitized_field(field.desc)))
+        description=bigquery_util.get_bigquery_sanitized_field(field.desc)))
   schema.fields.append(calls_record)
 
   # Add info fields.
   info_keys = set()
-  annotation_fields_set = set(annotation_fields or [])
   for key, field in header_fields.infos.iteritems():
     # END info is already included by modifying the end_position.
     if (key == vcfio.END_INFO_KEY or
-        (split_alternate_allele_info_fields and
-         field.num == vcf.parser.field_counts[_FIELD_COUNT_ALTERNATE_ALLELE]) or
-        key in annotation_fields_set):
+        proc_variant_factory.info_is_in_alt_bases(key)):
       continue
     schema.fields.append(bigquery.TableFieldSchema(
-        name=_get_bigquery_sanitized_field_name(key),
-        type=_get_bigquery_type_from_vcf_type(field.type),
+        name=bigquery_util.get_bigquery_sanitized_field_name(key),
+        type=bigquery_util.get_bigquery_type_from_vcf_type(field.type),
         mode=_get_bigquery_mode_from_vcf_num(field.num),
-        description=_get_bigquery_sanitized_field(field.desc)))
+        description=bigquery_util.get_bigquery_sanitized_field(field.desc)))
     info_keys.add(key)
   if variant_merger:
     variant_merger.modify_bigquery_schema(schema, info_keys)
@@ -281,7 +194,7 @@ def get_rows_from_variant(variant, omit_empty_sample_calls=False):
       yield row
       row = copy.deepcopy(base_row)
       row_size_in_bytes = base_row_size_in_bytes
-    row[ColumnKeyConstants.CALLS].append(call_record)
+    row[bigquery_util.ColumnKeyConstants.CALLS].append(call_record)
     row_size_in_bytes += call_record_size_in_bytes
   yield row
 
@@ -296,16 +209,18 @@ def _get_call_record(call):
     BigQuery call value (dict).
   """
   call_record = {
-      ColumnKeyConstants.CALLS_NAME: _get_bigquery_sanitized_field(call.name),
-      ColumnKeyConstants.CALLS_PHASESET: call.phaseset,
-      ColumnKeyConstants.CALLS_GENOTYPE: call.genotype or []
+      bigquery_util.ColumnKeyConstants.CALLS_NAME:
+          bigquery_util.get_bigquery_sanitized_field(call.name),
+      bigquery_util.ColumnKeyConstants.CALLS_PHASESET: call.phaseset,
+      bigquery_util.ColumnKeyConstants.CALLS_GENOTYPE: call.genotype or []
   }
   is_empty = (not call.genotype or
               set(call.genotype) == set((vcfio.MISSING_GENOTYPE_VALUE,)))
   for key, field in call.info.iteritems():
     if field is not None:
-      sanitized = _get_bigquery_sanitized_field(field)
-      call_record[_get_bigquery_sanitized_field_name(key)] = sanitized
+      sanitized = bigquery_util.get_bigquery_sanitized_field(field)
+      call_record[
+          bigquery_util.get_bigquery_sanitized_field_name(key)] = sanitized
       is_empty = is_empty and _is_empty_field(sanitized)
   return call_record, is_empty
 
@@ -314,191 +229,43 @@ def _get_base_row_from_variant(variant):
   # type: (processed_variant.ProcessedVariant) -> Dict[str, Any]
   """A helper method for ``get_rows_from_variant`` to get row without calls."""
   row = {
-      ColumnKeyConstants.REFERENCE_NAME: variant.reference_name,
-      ColumnKeyConstants.START_POSITION: variant.start,
-      ColumnKeyConstants.END_POSITION: variant.end,
-      ColumnKeyConstants.REFERENCE_BASES: variant.reference_bases
+      bigquery_util.ColumnKeyConstants.REFERENCE_NAME: variant.reference_name,
+      bigquery_util.ColumnKeyConstants.START_POSITION: variant.start,
+      bigquery_util.ColumnKeyConstants.END_POSITION: variant.end,
+      bigquery_util.ColumnKeyConstants.REFERENCE_BASES: variant.reference_bases
   }  # type: Dict[str, Any]
   if variant.names:
-    row[ColumnKeyConstants.NAMES] = _get_bigquery_sanitized_field(
-        variant.names)
+    row[bigquery_util.ColumnKeyConstants.NAMES] = (
+        bigquery_util.get_bigquery_sanitized_field(variant.names))
   if variant.quality is not None:
-    row[ColumnKeyConstants.QUALITY] = variant.quality
+    row[bigquery_util.ColumnKeyConstants.QUALITY] = variant.quality
   if variant.filters:
-    row[ColumnKeyConstants.FILTER] = _get_bigquery_sanitized_field(
-        variant.filters)
+    row[bigquery_util.ColumnKeyConstants.FILTER] = (
+        bigquery_util.get_bigquery_sanitized_field(variant.filters))
   # Add alternate bases.
-  row[ColumnKeyConstants.ALTERNATE_BASES] = []
+  row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES] = []
   for alt in variant.alternate_data_list:
-    alt_record = {ColumnKeyConstants.ALTERNATE_BASES_ALT:
+    alt_record = {bigquery_util.ColumnKeyConstants.ALTERNATE_BASES_ALT:
                   alt.alternate_bases}
     for key, data in alt.info.iteritems():
-      alt_record[_get_bigquery_sanitized_field_name(key)] = data
-    row[ColumnKeyConstants.ALTERNATE_BASES].append(alt_record)
+      alt_record[bigquery_util.get_bigquery_sanitized_field_name(key)] = data
+    row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES].append(alt_record)
   # Add info.
   for key, data in variant.non_alt_info.iteritems():
     if data is not None:
-      row[_get_bigquery_sanitized_field_name(key)] = (
-          _get_bigquery_sanitized_field(data))
+      row[bigquery_util.get_bigquery_sanitized_field_name(key)] = (
+          bigquery_util.get_bigquery_sanitized_field(data))
   # Set calls to empty for now (will be filled later).
-  row[ColumnKeyConstants.CALLS] = []
+  row[bigquery_util.ColumnKeyConstants.CALLS] = []
   return row
 
-
-def _get_bigquery_sanitized_field_name(field_name):
-  """Returns the sanitized field name according to BigQuery restrictions.
-
-  BigQuery field names must follow `[a-zA-Z][a-zA-Z0-9_]*`. This method converts
-  any unsupported characters to an underscore. Also, if the first character does
-  not match `[a-zA-Z]`, it prepends ``_FALLBACK_FIELD_NAME_PREFIX`` to the name.
-
-  Args:
-    field_name (str): Name of the field to sanitize.
-  Returns:
-    Sanitized field name with unsupported characters replaced with an
-    underscore. It also prepends the name with ``_FALLBACK_FIELD_NAME_PREFIX``
-    if the first character does not match `[a-zA-Z]`.
-  """
-  assert field_name  # field_name must not be empty by this stage.
-  if not re.match('[a-zA-Z]', field_name[0]):
-    field_name = _FALLBACK_FIELD_NAME_PREFIX + field_name
-  return re.sub('[^a-zA-Z0-9_]', '_', field_name)
-
-
-def _get_bigquery_sanitized_field(
-    field, null_numeric_value_replacement=-sys.maxint):
-  """Returns sanitized field according to BigQuery restrictions.
-
-  This method only sanitizes lists and strings. It returns the same
-  ``field`` for all other types (including None).
-
-  For lists, null values are replaced with reasonable defaults since the
-  BgiQuery API does not allow null values in lists (note that the entire
-  list is allowed to be null). For instance, [0, None, 1] becomes
-  [0, ``null_numeric_value_replacement``, 1].
-  Null value replacements are:
-    - `False` for bool.
-    - `.` for string (null string values should not exist in Variants parsed
-      using PyVCF though).
-    - ``null_numeric_value_replacement`` for float/int/long.
-  TODO: Expose ``null_numeric_value_replacement`` as a flag.
-
-  For strings, it returns its unicode representation. The BigQuery API does not
-  support strings that are UTF-8 encoded.
-
-  Args:
-    field: Field to sanitize. It can be of any type.
-    null_numeric_value_replacement (int): Value to use instead of null for
-      numeric (float/int/long) lists.
-  Raises:
-    ValueError: If the field could not be sanitized (e.g. unsupported types in
-      lists).
-  """
-  if not field:
-    return field
-  if isinstance(field, basestring):
-    return _get_bigquery_sanitized_string(field)
-  elif isinstance(field, float):
-    return _get_bigquery_sanitized_float(field)
-  elif isinstance(field, list):
-    return _get_bigquery_sanitized_list(field, null_numeric_value_replacement)
-  else:
-    return field
-
-
-def _get_bigquery_sanitized_list(input_list, null_numeric_value_replacement):
-  """Returns sanitized list according to BigQuery restrictions.
-
-  Null values are replaced with reasonable defaults since the
-  BgiQuery API does not allow null values in lists (note that the entire
-  list is allowed to be null). For instance, [0, None, 1] becomes
-  [0, ``null_numeric_value_replacement``, 1].
-  Null value replacements are:
-    - `False` for bool.
-    - `.` for string (null string values should not exist in Variants parsed
-      using PyVCF though).
-    - ``null_numeric_value_replacement`` for float/int/long.
-  Lists that contain strings are also sanitized according to the
-  ``_get_bigquery_sanitized_string`` method.
-
-  Args:
-    input_list: List to sanitize.
-    null_numeric_value_replacement (int): Value to use instead of null for
-      numeric (float/int/long) lists.
-  Raises:
-    ValueError: If a list contains unsupported values. Supported types are
-      basestring, bool, int, long, and float.
-  """
-  null_replacement_value = None
-  for i in input_list:
-    if i is None:
-      continue
-    if isinstance(i, basestring):
-      null_replacement_value = vcfio.MISSING_FIELD_VALUE
-    elif isinstance(i, bool):
-      null_replacement_value = False
-    elif isinstance(i, (int, long, float)):
-      null_replacement_value = null_numeric_value_replacement
-    else:
-      raise ValueError('Unsupported value for input: %s' % str(i))
-    break  # Assumption is that all fields have the same type.
-  if null_replacement_value is None:  # Implies everything was None.
-    return []
-  sanitized_list = []
-  for i in input_list:
-    if i is None:
-      i = null_replacement_value
-    elif isinstance(i, basestring):
-      i = _get_bigquery_sanitized_string(i)
-    elif isinstance(i, float):
-      sanitized_float = _get_bigquery_sanitized_float(i)
-      i = (sanitized_float if sanitized_float is not None
-           else null_replacement_value)
-    sanitized_list.append(i)
-  return sanitized_list
-
-
-def _get_bigquery_sanitized_float(input_float):
-  """Returns a sanitized float for BigQuery.
-
-  This method replaces INF with sys.maxint, -INF with -sys.maxint, and NaN
-  with None. It returns the same value for all other values.
-  """
-  if input_float == float('inf'):
-    return sys.maxint
-  elif input_float == float('-inf'):
-    return -sys.maxint
-  elif math.isnan(input_float):
-    return None
-  else:
-    return input_float
-
-
-def _get_bigquery_sanitized_string(input_str):
-  """Returns a unicode string as BigQuery API does not support UTF-8 strings."""
-  try:
-    return (input_str if isinstance(input_str, unicode)
-            else input_str.decode('utf-8'))
-  except UnicodeDecodeError:
-    raise ValueError('input_str is not UTF-8: %s ' % (input_str))
-
-
-def _get_bigquery_type_from_vcf_type(vcf_type):
-  vcf_type = vcf_type.lower()
-  if vcf_type not in _VCF_TYPE_TO_BIG_QUERY_TYPE_MAP:
-    raise ValueError('Invalid VCF type: %s' % vcf_type)
-  return _VCF_TYPE_TO_BIG_QUERY_TYPE_MAP[vcf_type]
 
 
 def _get_bigquery_mode_from_vcf_num(vcf_num):
   if vcf_num in (0, 1):
-    return _TableFieldConstants.MODE_NULLABLE
+    return bigquery_util.TableFieldConstants.MODE_NULLABLE
   else:
-    return _TableFieldConstants.MODE_REPEATED
-
-
-def _is_alternate_allele_count(info_field):
-  return info_field.field_count == _FIELD_COUNT_ALTERNATE_ALLELE
+    return bigquery_util.TableFieldConstants.MODE_REPEATED
 
 
 def _is_empty_field(value):

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_test.py
@@ -31,8 +31,8 @@ from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import bigquery_vcf_schema
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_header_parser
-from gcp_variant_transforms.libs.bigquery_vcf_schema import _TableFieldConstants as TableFieldConstants
-from gcp_variant_transforms.libs.bigquery_vcf_schema import ColumnKeyConstants
+from gcp_variant_transforms.libs.bigquery_util import TableFieldConstants
+from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
 from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy
 
 
@@ -93,7 +93,9 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
     header_fields = vcf_header_parser.HeaderFields({}, {})
     self._assert_fields_equal(
         self._generate_expected_fields(),
-        bigquery_vcf_schema.generate_schema_from_header_fields(header_fields))
+        bigquery_vcf_schema.generate_schema_from_header_fields(
+            header_fields,
+            processed_variant.ProcessedVariantFactory(header_fields)))
 
   def test_info_header_fields(self):
     infos = OrderedDict([
@@ -112,11 +114,16 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
         self._generate_expected_fields(
             alt_fields=['IA', 'IA2'],
             info_fields=['I1', 'I2', 'IU', 'IG', 'I0']),
-        bigquery_vcf_schema.generate_schema_from_header_fields(header_fields))
+        bigquery_vcf_schema.generate_schema_from_header_fields(
+            header_fields,
+            processed_variant.ProcessedVariantFactory(header_fields)))
 
     # Test with split_alternate_allele_info_fields=False.
     actual_schema = bigquery_vcf_schema.generate_schema_from_header_fields(
-        header_fields, split_alternate_allele_info_fields=False)
+        header_fields,
+        processed_variant.ProcessedVariantFactory(
+            header_fields,
+            split_alternate_allele_info_fields=False))
     self._assert_fields_equal(
         self._generate_expected_fields(
             info_fields=['I1', 'I2', 'IA', 'IU', 'IG', 'I0', 'IA2']),
@@ -161,7 +168,9 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
             alt_fields=['IA'],
             call_fields=['F1', 'F2', 'FU'],
             info_fields=['I1']),
-        bigquery_vcf_schema.generate_schema_from_header_fields(header_fields))
+        bigquery_vcf_schema.generate_schema_from_header_fields(
+            header_fields,
+            processed_variant.ProcessedVariantFactory(header_fields)))
 
   def test_bigquery_field_name_sanitize(self):
     infos = OrderedDict([
@@ -181,7 +190,9 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
             call_fields=['a_b', 'OK_format_09'],
             info_fields=['field__', 'field__A', 'field_0a', 'A_B_C',
                          'OK_info_09']),
-        bigquery_vcf_schema.generate_schema_from_header_fields(header_fields))
+        bigquery_vcf_schema.generate_schema_from_header_fields(
+            header_fields,
+            processed_variant.ProcessedVariantFactory(header_fields)))
 
   def test_variant_merger_modify_schema(self):
     infos = OrderedDict([
@@ -195,7 +206,9 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
             call_fields=['F1'],
             info_fields=['I1', 'ADDED_BY_MERGER']),
         bigquery_vcf_schema.generate_schema_from_header_fields(
-            header_fields, variant_merger=_DummyVariantMergeStrategy()))
+            header_fields,
+            processed_variant.ProcessedVariantFactory(header_fields),
+            variant_merger=_DummyVariantMergeStrategy()))
 
 
 class GetRowsFromVariantTest(unittest.TestCase):

--- a/gcp_variant_transforms/libs/processed_variant_test.py
+++ b/gcp_variant_transforms/libs/processed_variant_test.py
@@ -104,3 +104,5 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
     self.assertFalse(proc_var.non_alt_info.has_key('A2'))
     self.assertFalse(proc_var.non_alt_info.has_key('CSQ'))
+
+# TODO(bashir2): Add tests for create_alt_record_for_schema.

--- a/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
@@ -20,7 +20,7 @@ import copy
 import unittest
 
 from gcp_variant_transforms.beam_io import vcfio
-from gcp_variant_transforms.libs.bigquery_vcf_schema import ColumnKeyConstants
+from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
 from gcp_variant_transforms.libs.variant_merge import merge_with_non_variants_strategy
 
 

--- a/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy.py
+++ b/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy.py
@@ -20,7 +20,7 @@ import hashlib
 import re
 
 from gcp_variant_transforms.beam_io.vcfio import Variant
-from gcp_variant_transforms.libs.bigquery_vcf_schema import ColumnKeyConstants
+from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy
 
 __all__ = ['MoveToCallsStrategy']
@@ -71,9 +71,11 @@ class MoveToCallsStrategy(variant_merge_strategy.VariantMergeStrategy):
     """
     additional_call_info = {}
     if self._should_copy_filter_to_calls():
-      additional_call_info[ColumnKeyConstants.FILTER] = variant.filters
+      additional_call_info[
+          bigquery_util.ColumnKeyConstants.FILTER] = variant.filters
     if self._should_copy_quality_to_calls():
-      additional_call_info[ColumnKeyConstants.QUALITY] = variant.quality
+      additional_call_info[
+          bigquery_util.ColumnKeyConstants.QUALITY] = variant.quality
     for info_key, info_value in variant.info.iteritems():
       if self._should_move_info_key_to_calls(info_key):
         additional_call_info[info_key] = info_value.data
@@ -142,7 +144,7 @@ class MoveToCallsStrategy(variant_merge_strategy.VariantMergeStrategy):
     # Find the calls record so that it's easier to reference it below.
     calls_record = None
     for field in schema.fields:
-      if field.name == ColumnKeyConstants.CALLS:
+      if field.name == bigquery_util.ColumnKeyConstants.CALLS:
         calls_record = field
         break
     if not calls_record:
@@ -152,17 +154,19 @@ class MoveToCallsStrategy(variant_merge_strategy.VariantMergeStrategy):
     updated_fields = []
     for field in schema.fields:
       if (self._should_copy_filter_to_calls() and
-          field.name == ColumnKeyConstants.FILTER):
-        if ColumnKeyConstants.FILTER in existing_calls_keys:
-          self._raise_duplicate_key_error(ColumnKeyConstants.FILTER,
-                                          'should_copy_filter_to_calls')
+          field.name == bigquery_util.ColumnKeyConstants.FILTER):
+        if bigquery_util.ColumnKeyConstants.FILTER in existing_calls_keys:
+          self._raise_duplicate_key_error(
+              bigquery_util.ColumnKeyConstants.FILTER,
+              'should_copy_filter_to_calls')
         calls_record.fields.append(field)
         updated_fields.append(field)
       elif (self._should_copy_quality_to_calls() and
-            field.name == ColumnKeyConstants.QUALITY):
-        if ColumnKeyConstants.QUALITY in existing_calls_keys:
-          self._raise_duplicate_key_error(ColumnKeyConstants.QUALITY,
-                                          'should_copy_quality_to_calls')
+            field.name == bigquery_util.ColumnKeyConstants.QUALITY):
+        if bigquery_util.ColumnKeyConstants.QUALITY in existing_calls_keys:
+          self._raise_duplicate_key_error(
+              bigquery_util.ColumnKeyConstants.QUALITY,
+              'should_copy_quality_to_calls')
         calls_record.fields.append(field)
         updated_fields.append(field)
       elif (field.name in info_keys and

--- a/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy_test.py
@@ -21,8 +21,10 @@ import unittest
 from apache_beam.io.gcp.internal.clients import bigquery
 
 from gcp_variant_transforms.beam_io import vcfio
-from gcp_variant_transforms.libs.bigquery_vcf_schema import _TableFieldConstants as TableFieldConstants
-from gcp_variant_transforms.libs.bigquery_vcf_schema import ColumnKeyConstants
+# TODO(bashir2): Style guide suggests not to import individual classes or
+# functions and instead import the whole module. Fix it here and elsewhere.
+from gcp_variant_transforms.libs.bigquery_util import TableFieldConstants
+from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
 from gcp_variant_transforms.libs.variant_merge import move_to_calls_strategy
 
 

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -27,7 +27,7 @@ from apache_beam.transforms import Create
 from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_header_parser
-from gcp_variant_transforms.libs.bigquery_vcf_schema import ColumnKeyConstants
+from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
 from gcp_variant_transforms.transforms.variant_to_bigquery import _ConvertToBigQueryTableRow as ConvertToBigQueryTableRow
 
 

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -249,10 +249,9 @@ def run(argv=None):
              known_args.output_table,
              header_fields,
              variant_merger,
-             known_args.split_alternate_allele_info_fields,
+             processed_variant_factory,
              append=known_args.append,
-             omit_empty_sample_calls=known_args.omit_empty_sample_calls,
-             annotation_fields=known_args.annotation_fields))
+             omit_empty_sample_calls=known_args.omit_empty_sample_calls))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tested: Ran integration tests and updated unit-tests. Also ran the code manually for an annotated VCF and confirmed the generated schema is the same as before.

Issue: #59, #81.