### PR TITLE
Convert special FORMAT fields to list.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -859,7 +859,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
           # is unknown. This is to ensure consistent types across all records.
           # Note: this is already done for INFO fields in PyVCF.
           if (field in formats and
-              formats[field].num is None and
+              formats[field].num not in (0, 1) and
               isinstance(data, (int, float, long, basestring, bool))):
             data = [data]
           call.info[field] = data

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -514,21 +514,28 @@ class VcfSourceTest(unittest.TestCase):
   def test_format_numbers(self):
     format_headers = [
         '##FORMAT=<ID=FU,Number=.,Type=String,Description="Format_variable">\n',
-        '##FORMAT=<ID=F1,Number=1,Type=Integer,Description="Format_one">\n',
-        '##FORMAT=<ID=F2,Number=2,Type=Character,Description="Format_two">\n']
+        '##FORMAT=<ID=F1,Number=1,Type=Integer,Description="Format_1">\n',
+        '##FORMAT=<ID=F2,Number=2,Type=Character,Description="Format_2">\n',
+        '##FORMAT=<ID=AO,Number=A,Type=Integer,Description="Format_3">\n',
+        '##FORMAT=<ID=AD,Number=G,Type=Integer,Description="Format_4">\n',]
+
     record_lines = [
-        '19	2	.	A	T,C	.	.	.	GT:FU:F1:F2	1/0:a1:3:a,b	0/1:a2,a3:4:b,c\n']
+        ('19	2	.	A	T,C	.	.	.	'
+         'GT:FU:F1:F2:AO:AD	1/0:a1:3:a,b:1:3,4	'
+         '0/1:a2,a3:4:b,c:1,2:3')]
     expected_variant = Variant(
         reference_name='19', start=1, end=2, reference_bases='A',
         alternate_bases=['T', 'C'])
     expected_variant.calls.append(VariantCall(
         name='Sample1',
         genotype=[1, 0],
-        info={'FU': ['a1'], 'F1': 3, 'F2': ['a', 'b']}))
+        info={'FU': ['a1'], 'F1': 3, 'F2': ['a', 'b'], 'AO': [1],
+              'AD': [3, 4]}))
     expected_variant.calls.append(VariantCall(
         name='Sample2',
         genotype=[0, 1],
-        info={'FU': ['a2', 'a3'], 'F1': 4, 'F2': ['b', 'c']}))
+        info={'FU': ['a2', 'a3'], 'F1': 4, 'F2': ['b', 'c'], 'AO': [1, 2],
+              'AD':[3]}))
     read_data = self._create_temp_file_and_read_records(
         format_headers + _SAMPLE_HEADER_LINES[1:] + record_lines)
     self.assertEqual(1, len(read_data))


### PR DESCRIPTION
FORMAT fileds with Number=A,G,R are converted to list even when they are
single valued.

Fixes issue  #122 

TESTED:
  unit test