### PR TITLE
Uses the macros to replace the common queries.

### DIFF
--- a/gcp_variant_transforms/testing/integration/run_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_tests.py
@@ -41,6 +41,7 @@ import sys
 import time
 
 from datetime import datetime
+from typing import List  # pylint: disable=unused-import
 # TODO(bashir2): Figure out why pylint can't find this.
 # pylint: disable=no-name-in-module,import-error
 from google.cloud import bigquery
@@ -202,13 +203,12 @@ class QueryFormatter(object):
     self._table_name = table_name
 
   def format_query(self, query):
-    # type: (list[str]) -> str
+    # type: (List[str]) -> str
     """Formats the given ``query``.
 
     Formatting logic is as follows:
     - Concatenates ``query`` parts into one string.
-    - Replaces macro NUM_ROWS_QUERY/SUM_START_QUERY/SUM_END_QUERY with the
-    corresponding value defined in _QueryMacros.
+    - Replaces macro with the corresponding value defined in _QueryMacros.
     - Replaces TABLE_NAME with the table associated for the query.
     """
     return self._replace_variables(self._replace_macros((' ').join(query)))

--- a/gcp_variant_transforms/testing/integration/run_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_tests.py
@@ -148,7 +148,6 @@ class TestCase(object):
   def validate_table(self):
     """Runs queries against the output table and verifies results."""
     client = bigquery.Client(project=self._project)
-    # TODO(yifangchen): Create macros for common queries
     query_formatter = QueryFormatter(self._table_name)
     for assertion_config in self._assertion_configs:
       query = query_formatter.format_query(assertion_config['query'])
@@ -188,22 +187,31 @@ class QueryAssertion(object):
 class QueryFormatter(object):
   """Formats a query.
 
-  Replaces keyword TABLE_NAME and eventually macros in the query.
+  Replaces keyword TABLE_NAME and macros in the query.
   """
+
+  NUM_ROWS = 'SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}'
+  SUM_START = 'SELECT SUM(start_position) AS sum_start FROM {TABLE_NAME}'
+  SUM_END = 'SELECT SUM(end_position) AS sum_end FROM {TABLE_NAME}'
 
   def __init__(self, table_name):
     # type: (str) -> None
     self._table_name = table_name
 
   def format_query(self, query):
-    # type: (List[str]) -> str
+    # type: (list[str]) -> str
     """Formats the given ``query``.
 
     Formatting logic is as follows:
     - Concatenates ``query`` parts into one string.
+    - Replaces NUM_ROWS/SUM_START/SUM_END with the corresponding query.
     - Replaces TABLE_NAME with the table associated for the query.
     """
-    return (' ').join(query).format(TABLE_NAME=self._table_name)
+    return (' ').join(query).format(NUM_ROWS=self.NUM_ROWS,
+                                    SUM_START=self.SUM_START,
+                                    SUM_END=self.SUM_END,
+                                    TABLE_NAME=self._table_name).format(
+                                        TABLE_NAME=self._table_name)
 
 
 class TestContextManager(object):

--- a/gcp_variant_transforms/testing/integration/run_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_tests.py
@@ -189,13 +189,13 @@ class QueryAssertion(object):
 class QueryFormatter(object):
   """Formats a query.
 
-  Replaces macros and variable TABLE_NAME in the query.
+  Replaces macros and variables in the query.
   """
 
   class _QueryMacros(enum.Enum):
     NUM_ROWS_QUERY = 'SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}'
-    SUM_START_QUERY = ('SELECT SUM(start_position) AS sum_start FROM {'
-                       'TABLE_NAME}')
+    SUM_START_QUERY = (
+        'SELECT SUM(start_position) AS sum_start FROM {TABLE_NAME}')
     SUM_END_QUERY = 'SELECT SUM(end_position) AS sum_end FROM {TABLE_NAME}'
 
   def __init__(self, table_name):
@@ -209,9 +209,9 @@ class QueryFormatter(object):
     Formatting logic is as follows:
     - Concatenates ``query`` parts into one string.
     - Replaces macro with the corresponding value defined in _QueryMacros.
-    - Replaces TABLE_NAME with the table associated for the query.
+    - Replaces variables associated for the query.
     """
-    return self._replace_variables(self._replace_macros((' ').join(query)))
+    return self._replace_variables(self._replace_macros(' '.join(query)))
 
   def _replace_variables(self, query):
     return query.format(TABLE_NAME=self._table_name)

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0.json
@@ -5,28 +5,16 @@
   "runner": "DataflowRunner",
   "assertion_configs": [
     {
-      "query": [
-        "{NUM_ROWS}"
-      ],
-      "expected_result": {
-        "num_rows": 5
-      }
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 5}
     },
     {
-      "query": [
-        "{SUM_START}"
-      ],
-      "expected_result": {
-        "sum_start": 3607195
-      }
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 3607195}
     },
     {
-      "query": [
-        "{SUM_END}"
-      ],
-      "expected_result": {
-        "sum_end": 3607203
-      }
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 3607203}
     }
   ]
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0.json
@@ -6,14 +6,25 @@
   "assertion_configs": [
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows, ",
-        "  SUM(start_position) AS sum_start, ",
-        "  SUM(end_position) AS sum_end ",
-        "FROM {TABLE_NAME}"
+        "{NUM_ROWS}"
       ],
       "expected_result": {
-        "num_rows": 5,
-        "sum_start": 3607195,
+        "num_rows": 5
+      }
+    },
+    {
+      "query": [
+        "{SUM_START}"
+      ],
+      "expected_result": {
+        "sum_start": 3607195
+      }
+    },
+    {
+      "query": [
+        "{SUM_END}"
+      ],
+      "expected_result": {
         "sum_end": 3607203
       }
     }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_bz2.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_bz2.json
@@ -5,28 +5,16 @@
   "runner": "DataflowRunner",
   "assertion_configs": [
     {
-      "query": [
-        "{NUM_ROWS}"
-      ],
-      "expected_result": {
-        "num_rows": 5
-      }
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 5}
     },
     {
-      "query": [
-        "{SUM_START}"
-      ],
-      "expected_result": {
-        "sum_start": 3607195
-      }
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 3607195}
     },
     {
-      "query": [
-        "{SUM_END}"
-      ],
-      "expected_result": {
-        "sum_end": 3607203
-      }
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 3607203}
     }
   ]
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_bz2.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_bz2.json
@@ -6,14 +6,25 @@
   "assertion_configs": [
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows, ",
-        "  SUM(start_position) AS sum_start, ",
-        "  SUM(end_position) AS sum_end ",
-        "FROM {TABLE_NAME}"
+        "{NUM_ROWS}"
       ],
       "expected_result": {
-        "num_rows": 5,
-        "sum_start": 3607195,
+        "num_rows": 5
+      }
+    },
+    {
+      "query": [
+        "{SUM_START}"
+      ],
+      "expected_result": {
+        "sum_start": 3607195
+      }
+    },
+    {
+      "query": [
+        "{SUM_END}"
+      ],
+      "expected_result": {
         "sum_end": 3607203
       }
     }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_gz.json
@@ -5,28 +5,16 @@
   "runner": "DataflowRunner",
   "assertion_configs": [
     {
-      "query": [
-        "{NUM_ROWS}"
-      ],
-      "expected_result": {
-        "num_rows": 5
-      }
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 5}
     },
     {
-      "query": [
-        "{SUM_START}"
-      ],
-      "expected_result": {
-        "sum_start": 3607195
-      }
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 3607195}
     },
     {
-      "query": [
-        "{SUM_END}"
-      ],
-      "expected_result": {
-        "sum_end": 3607203
-      }
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 3607203}
     }
   ]
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_0_gz.json
@@ -6,14 +6,25 @@
   "assertion_configs": [
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows, ",
-        "  SUM(start_position) AS sum_start, ",
-        "  SUM(end_position) AS sum_end ",
-        "FROM {TABLE_NAME}"
+        "{NUM_ROWS}"
       ],
       "expected_result": {
-        "num_rows": 5,
-        "sum_start": 3607195,
+        "num_rows": 5
+      }
+    },
+    {
+      "query": [
+        "{SUM_START}"
+      ],
+      "expected_result": {
+        "sum_start": 3607195
+      }
+    },
+    {
+      "query": [
+        "{SUM_END}"
+      ],
+      "expected_result": {
         "sum_end": 3607203
       }
     }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_1.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_1.json
@@ -5,28 +5,16 @@
   "runner": "DataflowRunner",
   "assertion_configs": [
     {
-      "query": [
-        "{NUM_ROWS}"
-      ],
-      "expected_result": {
-        "num_rows": 9882
-      }
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 9882}
     },
     {
-      "query": [
-        "{SUM_START}"
-      ],
-      "expected_result": {
-        "sum_start": 5434957328
-      }
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 5434957328}
     },
     {
-      "query": [
-        "{SUM_END}"
-      ],
-      "expected_result": {
-        "sum_end": 5435327553
-      }
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 5435327553}
     }
   ]
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_1.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_1.json
@@ -6,14 +6,25 @@
   "assertion_configs": [
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows, ",
-        "  SUM(start_position) AS sum_start, ",
-        "  SUM(end_position) AS sum_end ",
-        "FROM {TABLE_NAME}"
+        "{NUM_ROWS}"
       ],
       "expected_result": {
-        "num_rows": 9882,
-        "sum_start": 5434957328,
+        "num_rows": 9882
+      }
+    },
+    {
+      "query": [
+        "{SUM_START}"
+      ],
+      "expected_result": {
+        "sum_start": 5434957328
+      }
+    },
+    {
+      "query": [
+        "{SUM_END}"
+      ],
+      "expected_result": {
         "sum_end": 5435327553
       }
     }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_1_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_1_gz.json
@@ -5,28 +5,16 @@
   "runner": "DataflowRunner",
   "assertion_configs": [
     {
-      "query": [
-        "{NUM_ROWS}"
-      ],
-      "expected_result": {
-        "num_rows": 9882
-      }
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 9882}
     },
     {
-      "query": [
-        "{SUM_START}"
-      ],
-      "expected_result": {
-        "sum_start": 5434957328
-      }
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 5434957328}
     },
     {
-      "query": [
-        "{SUM_END}"
-      ],
-      "expected_result": {
-        "sum_end": 5435327553
-      }
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 5435327553}
     }
   ]
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_1_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_1_gz.json
@@ -6,14 +6,25 @@
   "assertion_configs": [
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows, ",
-        "  SUM(start_position) AS sum_start, ",
-        "  SUM(end_position) AS sum_end ",
-        "FROM {TABLE_NAME}"
+        "{NUM_ROWS}"
       ],
       "expected_result": {
-        "num_rows": 9882,
-        "sum_start": 5434957328,
+        "num_rows": 9882
+      }
+    },
+    {
+      "query": [
+        "{SUM_START}"
+      ],
+      "expected_result": {
+        "sum_start": 5434957328
+      }
+    },
+    {
+      "query": [
+        "{SUM_END}"
+      ],
+      "expected_result": {
         "sum_end": 5435327553
       }
     }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2.json
@@ -6,14 +6,25 @@
   "assertion_configs": [
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows, ",
-        "  SUM(start_position) AS sum_start, ",
-        "  SUM(end_position) AS sum_end ",
-        "FROM {TABLE_NAME}"
+        "{NUM_ROWS}"
       ],
       "expected_result": {
-        "num_rows": 13,
-        "sum_start": 23031929,
+        "num_rows": 13
+      }
+    },
+    {
+      "query": [
+        "{SUM_START}"
+      ],
+      "expected_result": {
+        "sum_start": 23031929
+      }
+    },
+    {
+      "query": [
+        "{SUM_END}"
+      ],
+      "expected_result": {
         "sum_end": 23033052
       }
     }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2.json
@@ -5,28 +5,16 @@
   "runner": "DataflowRunner",
   "assertion_configs": [
     {
-      "query": [
-        "{NUM_ROWS}"
-      ],
-      "expected_result": {
-        "num_rows": 13
-      }
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 13}
     },
     {
-      "query": [
-        "{SUM_START}"
-      ],
-      "expected_result": {
-        "sum_start": 23031929
-      }
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 23031929}
     },
     {
-      "query": [
-        "{SUM_END}"
-      ],
-      "expected_result": {
-        "sum_end": 23033052
-      }
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 23033052}
     }
   ]
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_VEP.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_VEP.json
@@ -6,28 +6,16 @@
   "runner": "DataflowRunner",
   "assertion_configs": [
     {
-      "query": [
-        "{NUM_ROWS}"
-      ],
-      "expected_result": {
-        "num_rows": 11
-      }
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 11}
     },
     {
-      "query": [
-        "{SUM_START}"
-      ],
-      "expected_result": {
-        "sum_start": 21801693
-      }
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 21801693}
     },
     {
-      "query": [
-        "{SUM_END}"
-      ],
-      "expected_result": {
-        "sum_end": 21802814
-      }
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 21802814}
     },
     {
       "query": [
@@ -35,9 +23,7 @@
         "FROM {TABLE_NAME} AS t, t.alternate_bases as alts, alts.CSQ as CSQ ",
         "WHERE start_position = 1110695 AND alts.alt = 'G'"
       ],
-      "expected_result": {
-        "num_features": 3
-      }
+      "expected_result": {"num_features": 3}
     }
   ]
 }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_VEP.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_VEP.json
@@ -7,14 +7,25 @@
   "assertion_configs": [
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows, ",
-        "  SUM(start_position) AS sum_start, ",
-        "  SUM(end_position) AS sum_end ",
-        "FROM {TABLE_NAME}"
+        "{NUM_ROWS}"
       ],
       "expected_result": {
-        "num_rows": 11,
-        "sum_start": 21801693,
+        "num_rows": 11
+      }
+    },
+    {
+      "query": [
+        "{SUM_START}"
+      ],
+      "expected_result": {
+        "sum_start": 21801693
+      }
+    },
+    {
+      "query": [
+        "{SUM_END}"
+      ],
+      "expected_result": {
         "sum_end": 21802814
       }
     },

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_gz.json
@@ -6,14 +6,25 @@
   "assertion_configs": [
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows, ",
-        "  SUM(start_position) AS sum_start, ",
-        "  SUM(end_position) AS sum_end ",
-        "FROM {TABLE_NAME}"
+        "{NUM_ROWS}"
       ],
       "expected_result": {
-        "num_rows": 13,
-        "sum_start": 23031929,
+        "num_rows": 13
+      }
+    },
+    {
+      "query": [
+        "{SUM_START}"
+      ],
+      "expected_result": {
+        "sum_start": 23031929
+      }
+    },
+    {
+      "query": [
+        "{SUM_END}"
+      ],
+      "expected_result": {
         "sum_end": 23033052
       }
     }

--- a/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_gz.json
+++ b/gcp_variant_transforms/testing/integration/small_tests/valid_4_2_gz.json
@@ -5,28 +5,16 @@
   "runner": "DataflowRunner",
   "assertion_configs": [
     {
-      "query": [
-        "{NUM_ROWS}"
-      ],
-      "expected_result": {
-        "num_rows": 13
-      }
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 13}
     },
     {
-      "query": [
-        "{SUM_START}"
-      ],
-      "expected_result": {
-        "sum_start": 23031929
-      }
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 23031929}
     },
     {
-      "query": [
-        "{SUM_END}"
-      ],
-      "expected_result": {
-        "sum_end": 23033052
-      }
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 23033052}
     }
   ]
 }


### PR DESCRIPTION
Define  NUM_ROWS, SUM_START, SUM_END in QueryFormatter, and replaces them in the query to avoid duplicate code.

TESTED:
deploy_and_run_tests.