### PR TITLE
 Adds support for --minimal option of VEP with related schema chagnes.

### DIFF
--- a/gcp_variant_transforms/libs/processed_variant.py
+++ b/gcp_variant_transforms/libs/processed_variant.py
@@ -45,11 +45,11 @@ _FIELD_COUNT_ALTERNATE_ALLELE = 'A'
 _COMPLETELY_DELETED_ALT = '-'
 
 # The field name in the BigQuery table that holds annotation ALT.
-_ANNOTATION_ALT = 'allele_string'
+_ANNOTATION_ALT = 'allele'
 
 # The field name in the BigQuery table that indicates whether the annotation ALT
 # matching was ambiguous or not.
-_ANNOTATION_ALT_AMBIGUOUS = 'ambiguous_allele_string'
+_ANNOTATION_ALT_AMBIGUOUS = 'ambiguous_allele'
 
 
 # Counter names
@@ -401,7 +401,8 @@ class _AnnotationProcessor(object):
       alt, ambiguous = self._find_matching_alt(
           proc_var, common_prefix, alt_bases, annotation_field_name)
       if alt:
-        self._add_ambiguous_fields(annotations_list, ambiguous)
+        if self._minimal_match:
+          self._add_ambiguous_fields(annotations_list, ambiguous)
         alt._info[annotation_field_name] = annotations_list
 
   def _find_common_alt_ref_prefix(self, proc_var):
@@ -459,9 +460,8 @@ class _AnnotationProcessor(object):
 
   def _add_ambiguous_fields(self, annotations_list, ambiguous):
     # type: (List[Dict[str, str]], bool) -> None
-    if self._minimal_match:
-      for annotation_map in annotations_list:
-        annotation_map[_ANNOTATION_ALT_AMBIGUOUS] = ambiguous
+    for annotation_map in annotations_list:
+      annotation_map[_ANNOTATION_ALT_AMBIGUOUS] = ambiguous
 
   def _find_matching_alt(self,
                          proc_var,  # type: ProcessedVariant

--- a/gcp_variant_transforms/libs/processed_variant_test.py
+++ b/gcp_variant_transforms/libs/processed_variant_test.py
@@ -136,16 +136,16 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1._info = {
         'A2': 'data1',
         'CSQ': [
-            {'ALT': 'A', 'ambiguous_ALT': False, 'Consequence': 'C1',
+            {processed_variant._ANNOTATION_ALT: 'A', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'},
-            {'ALT': 'A', 'ambiguous_ALT': False, 'Consequence': 'C3',
+            {processed_variant._ANNOTATION_ALT: 'A', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     alt2 = processed_variant.AlternateBaseData('TT')
     alt2._info = {
         'A2': 'data2',
         'CSQ': [
-            {'ALT': 'TT', 'ambiguous_ALT': False, 'Consequence': 'C2',
+            {processed_variant._ANNOTATION_ALT: 'TT', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
@@ -179,16 +179,16 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1._info = {
         'A2': 'data1',
         'CSQ': [
-            {'ALT': 'A', 'ambiguous_ALT': False, 'Consequence': 'C1',
+            {processed_variant._ANNOTATION_ALT: 'A', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'},
-            {'ALT': 'A', 'ambiguous_ALT': False, 'Consequence': 'C3',
+            {processed_variant._ANNOTATION_ALT: 'A', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     alt2 = processed_variant.AlternateBaseData('TT')
     alt2._info = {
         'A2': 'data2',
         'CSQ': [
-            {'ALT': 'TT', 'ambiguous_ALT': False, 'Consequence': 'C2',
+            {processed_variant._ANNOTATION_ALT: 'TT', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
@@ -225,19 +225,19 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('<SYMBOLIC>')
     alt1._info = {
         'CSQ': [
-            {'ALT': 'SYMBOLIC', 'ambiguous_ALT': False, 'Consequence': 'C1',
+            {processed_variant._ANNOTATION_ALT: 'SYMBOLIC', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
     }
     alt2 = processed_variant.AlternateBaseData('[13:123457[.')
     alt2._info = {
         'CSQ': [
-            {'ALT': '[13', 'ambiguous_ALT': False, 'Consequence': 'C2',
+            {processed_variant._ANNOTATION_ALT: '[13', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     alt3 = processed_variant.AlternateBaseData('C[10:10357[.')
     alt3._info = {
         'CSQ': [
-            {'ALT': 'C[10', 'ambiguous_ALT': False, 'Consequence': 'C3',
+            {processed_variant._ANNOTATION_ALT: 'C[10', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2, alt3])
@@ -272,19 +272,19 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('CT')
     alt1._info = {
         'CSQ': [
-            {'ALT': 'T', 'ambiguous_ALT': False, 'Consequence': 'C1',
+            {processed_variant._ANNOTATION_ALT: 'T', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
     }
     alt2 = processed_variant.AlternateBaseData('CC')
     alt2._info = {
         'CSQ': [
-            {'ALT': 'C', 'ambiguous_ALT': False, 'Consequence': 'C2',
+            {processed_variant._ANNOTATION_ALT: 'C', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     alt3 = processed_variant.AlternateBaseData('CCC')
     alt3._info = {
         'CSQ': [
-            {'ALT': 'CC', 'ambiguous_ALT': False, 'Consequence': 'C3',
+            {processed_variant._ANNOTATION_ALT: 'CC', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2, alt3])
@@ -319,13 +319,13 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('AA')
     alt1._info = {
         'CSQ': [
-            {'ALT': 'AA', 'ambiguous_ALT': False, 'Consequence': 'C1',
+            {processed_variant._ANNOTATION_ALT: 'AA', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
     }
     alt2 = processed_variant.AlternateBaseData('AAA')
     alt2._info = {
         'CSQ': [
-            {'ALT': 'AAA', 'ambiguous_ALT': False, 'Consequence': 'C2',
+            {processed_variant._ANNOTATION_ALT: 'AAA', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
@@ -370,14 +370,16 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt2 = processed_variant.AlternateBaseData('CCT')
     alt2._info = {
         'CSQ': [
-            {'ALT': 'T', 'ambiguous_ALT': True, 'Consequence': 'C1',
-             'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
+            {processed_variant._ANNOTATION_ALT: 'T',
+             processed_variant._ANNOTATION_ALT_AMBIGUOUS: True,
+             'Consequence': 'C1', 'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
     }
     alt3 = processed_variant.AlternateBaseData('C')
     alt3._info = {
         'CSQ': [
-            {'ALT': '-', 'ambiguous_ALT': False, 'Consequence': 'C2',
-             'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
+            {processed_variant._ANNOTATION_ALT: '-',
+             processed_variant._ANNOTATION_ALT_AMBIGUOUS: False,
+             'Consequence': 'C2', 'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2, alt3])
     self.assertFalse(proc_var.non_alt_info.has_key('CSQ'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -152,7 +152,7 @@ class AnnotationOptions(VariantTransformsOptions):
               'BigQuery table and stored as repeated fields with '
               'corresponding alternate alleles. [EXPERIMENTAL]'))
     parser.add_argument(
-        '--minimal_VEP_alt_matching',
+        '--minimal_vep_alt_matching',
         type='bool', default=False, nargs='?', const=True,
         help=('If true, for ALT matching of annotation fields, the --minimal '
               'mode of VEP is simulated. Note that this can lead to ambiguous '

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -85,6 +85,7 @@ class VcfReadOptions(VariantTransformsOptions):
               'variants. This is useful when there are header fields in '
               'variants not defined in the header sections.'))
 
+
 class BigQueryWriteOptions(VariantTransformsOptions):
   """Options for writing Variant records to BigQuery."""
 
@@ -111,15 +112,6 @@ class BigQueryWriteOptions(VariantTransformsOptions):
         '--omit_empty_sample_calls',
         type='bool', default=False, nargs='?', const=True,
         help=("If true, samples that don't have a given call will be omitted."))
-    parser.add_argument(
-        '--annotation_fields',
-        default=None, nargs='+',
-        help=('If set, it is a list of field names (separated by space) that '
-              'should be treated as annotation fields. The content of these '
-              'INFO fields will be broken into multiple columns in the output '
-              'BigQuery table and stored as repeated fields with '
-              'corresponding alternate alleles. [EXPERIMENTAL]'))
-
 
   def validate(self, parsed_args, client=None):
     output_table_re_match = re.match(
@@ -145,6 +137,31 @@ class BigQueryWriteOptions(VariantTransformsOptions):
       else:
         # For the rest of the errors, use BigQuery error message.
         raise
+
+
+class AnnotationOptions(VariantTransformsOptions):
+  """Options for how to treat annotation fields."""
+
+  def add_arguments(self, parser):
+    parser.add_argument(
+        '--annotation_fields',
+        default=None, nargs='+',
+        help=('If set, it is a list of field names (separated by space) that '
+              'should be treated as annotation fields. The content of these '
+              'INFO fields will be broken into multiple columns in the output '
+              'BigQuery table and stored as repeated fields with '
+              'corresponding alternate alleles. [EXPERIMENTAL]'))
+    parser.add_argument(
+        '--minimal_VEP_alt_matching',
+        type='bool', default=False, nargs='?', const=True,
+        help=('If true, for ALT matching of annotation fields, the --minimal '
+              'mode of VEP is simulated. Note that this can lead to ambiguous '
+              'matches so by default this is False but if the VCF files are '
+              'generated with VEP in --minimal mode, then this option should '
+              'be turned on. The ambiguous cases are logged and counted.'
+              'See the "Complext VCF Entries" of this doc for details:'
+              'http://www.ensembl.org/info/docs/tools/vep/online/'
+              'VEP_web_documentation.pdf'))
 
 
 class FilterOptions(VariantTransformsOptions):

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -63,6 +63,7 @@ from gcp_variant_transforms.transforms import infer_undefined_headers
 _COMMAND_LINE_OPTIONS = [
     variant_transform_options.VcfReadOptions,
     variant_transform_options.BigQueryWriteOptions,
+    variant_transform_options.AnnotationOptions,
     variant_transform_options.FilterOptions,
     variant_transform_options.MergeOptions,
 ]
@@ -236,6 +237,7 @@ def run(argv=None):
       header_fields,
       known_args.split_alternate_allele_info_fields,
       known_args.annotation_fields,
+      known_args.minimal_VEP_alt_matching,
       counter_factory)
 
   pipeline_options = PipelineOptions(pipeline_args)

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -237,7 +237,7 @@ def run(argv=None):
       header_fields,
       known_args.split_alternate_allele_info_fields,
       known_args.annotation_fields,
-      known_args.minimal_VEP_alt_matching,
+      known_args.minimal_vep_alt_matching,
       counter_factory)
 
   pipeline_options = PipelineOptions(pipeline_args)


### PR DESCRIPTION
Please note that this PR is on top of the previous two PRs #125 and #126 so it includes three commits where only the last one is for this PR. Please only review the last commit.

Tested:
Added/updated unit-tests.
Also ran the pipeline on a small subset of gnomAD with --minimal_VEP_alt_matching and checked the output table's schema, counters, and logs for ambiguous ALTs.

Issue #81 