### PR TITLE
Fix time out issue of the integration test.

### DIFF
--- a/cloudbuild_CI.yaml
+++ b/cloudbuild_CI.yaml
@@ -54,4 +54,4 @@ steps:
       # - '--gs_dir bashir-variant_integration_test_runs'
 images:
   - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-timeout: 20m
+timeout: 15m

--- a/cloudbuild_CI.yaml
+++ b/cloudbuild_CI.yaml
@@ -54,4 +54,4 @@ steps:
       # - '--gs_dir bashir-variant_integration_test_runs'
 images:
   - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-timeout: 15m
+timeout: 40m

--- a/cloudbuild_CI.yaml
+++ b/cloudbuild_CI.yaml
@@ -54,4 +54,4 @@ steps:
       # - '--gs_dir bashir-variant_integration_test_runs'
 images:
   - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-timeout: 40m
+timeout: 45m


### PR DESCRIPTION
It seems the integration test has timed out a few time since PR #132. This should fix it.

Tested: Tirggered the build in my test project. It failed at the end because of file permissions but that should be okay when run under `gcp-variant-transforms-test` project.