### PR TITLE
Add integration test for option optimize for large inputs #106

### DIFF
--- a/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
+++ b/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
@@ -1,0 +1,47 @@
+{
+  "test_name": "option-optimize-for-large-inputs",
+  "table_name": "option_optimize_for_large_inputs",
+  "input_pattern": "gs://gcp-variant-transforms-testfiles/large_tests/valid-70000-copies/*.vcf",
+  "variant_merge_strategy": "MOVE_TO_CALLS",
+  "optimize_for_large_inputs": true,
+  "runner": "DataflowRunner",
+  "worker_machine_type": "n1-standard-16",
+  "max_num_workers": "20",
+  "num_workers": "20",
+  "assertion_configs": [
+    {
+      "query": ["NUM_ROWS_QUERY"],
+      "expected_result": {"num_rows": 26}
+    },
+    {
+      "query": ["SUM_START_QUERY"],
+      "expected_result": {"sum_start": 46063858}
+    },
+    {
+      "query": ["SUM_END_QUERY"],
+      "expected_result": {"sum_end": 46066104}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_rows FROM ( ",
+        "SELECT reference_name, start_position, end_position ",
+        "FROM  {TABLE_NAME} GROUP BY 1, 2, 3)"
+      ],
+      "expected_result": {"num_rows": 13}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_rows FROM {TABLE_NAME} AS t, t.call AS call ",
+        "WHERE start_position = 17329"
+      ],
+      "expected_result": {"num_rows": 420000}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_rows FROM {TABLE_NAME} AS t, t.call AS call "
+      ],
+      "expected_result": {"num_rows": 2730000}
+    }
+  ]
+}
+

--- a/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
+++ b/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
@@ -23,24 +23,45 @@
     },
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows FROM ( ",
+        "SELECT COUNT(0) AS num_unique_rows FROM ( ",
         "SELECT reference_name, start_position, end_position ",
         "FROM  {TABLE_NAME} GROUP BY 1, 2, 3)"
       ],
-      "expected_result": {"num_rows": 13}
+      "expected_result": {"num_unique_rows": 13}
     },
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows FROM {TABLE_NAME} AS t, t.call AS call ",
-        "WHERE start_position = 17329"
+        "SELECT COUNT(0) AS num_ref_calls FROM {TABLE_NAME} AS t, ",
+        "t.call AS call, call.genotype AS genotype WHERE genotype = 0"
       ],
-      "expected_result": {"num_rows": 420000}
+      "expected_result": {"num_ref_calls": 2310000}
     },
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows FROM {TABLE_NAME} AS t, t.call AS call "
+        "SELECT COUNT(0) AS num_alt_calls FROM {TABLE_NAME} AS t, ",
+        "t.call AS call, call.genotype AS genotype WHERE genotype > 0"
       ],
-      "expected_result": {"num_rows": 2730000}
+      "expected_result": {"num_alt_calls": 2800000}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_no_calls FROM {TABLE_NAME} AS t, ",
+        "t.call AS call, call.genotype AS genotype WHERE genotype < 0"
+      ],
+      "expected_result": {"num_no_calls": 140000}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_calls FROM {TABLE_NAME} AS t, t.call AS call ",
+        "WHERE reference_name = 'Y'"
+      ],
+      "expected_result": {"num_calls": 210000}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_calls FROM {TABLE_NAME} AS t, t.call AS call "
+      ],
+      "expected_result": {"num_calls": 2730000}
     }
   ]
 }

--- a/gcp_variant_transforms/testing/integration/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_with_merge.json
+++ b/gcp_variant_transforms/testing/integration/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_with_merge.json
@@ -22,16 +22,37 @@
     },
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows FROM {TABLE_NAME} AS t, t.call AS call ",
-        "WHERE start_position = 17329"
+        "SELECT COUNT(0) AS num_ref_calls FROM {TABLE_NAME} AS t, ",
+        "t.call AS call, call.genotype AS genotype WHERE genotype = 0"
       ],
-      "expected_result": {"num_rows": 6000}
+      "expected_result": {"num_ref_calls": 33000}
     },
     {
       "query": [
-        "SELECT COUNT(0) AS num_rows FROM {TABLE_NAME} AS t, t.call AS call "
+        "SELECT COUNT(0) AS num_alt_calls FROM {TABLE_NAME} AS t, ",
+        "t.call AS call, call.genotype AS genotype WHERE genotype > 0"
       ],
-      "expected_result": {"num_rows": 39000}
+      "expected_result": {"num_alt_calls": 40000}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_no_calls FROM {TABLE_NAME} AS t, ",
+        "t.call AS call, call.genotype AS genotype WHERE genotype < 0"
+      ],
+      "expected_result": {"num_no_calls": 2000}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_calls FROM {TABLE_NAME} AS t, t.call AS call ",
+        "WHERE reference_name = 'Y'"
+      ],
+      "expected_result": {"num_calls": 3000}
+    },
+    {
+      "query": [
+        "SELECT COUNT(0) AS num_calls FROM {TABLE_NAME} AS t, t.call AS call "
+      ],
+      "expected_result": {"num_calls": 39000}
     }
   ]
 }


### PR DESCRIPTION
- Create a folder in `gcp-variant-transforms-testfiles/large_tests` with 70000 copies of file `valid_4_2` to test `LARGE_DATA_THRESHOLD = 50000` pipeline.
- Option `--optimize_for_large_inputs` is included.

Tested: Manually ran deploy_and_run_tests.sh --run_presubmit_tests
Issue: #106 