### PR TITLE
Remove workarounds for Beam 2.2.0 now that Beam 2.4.0 is released.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,6 @@ source venv/bin/activate
 git clone https://github.com/googlegenomics/gcp-variant-transforms.git
 cd gcp-variant-transforms
 pip install --upgrade .
-# Workaround needed until Beam 2.3.0 is released. See Issue #65.
-pip install --upgrade apache_beam[gcp]
 ```
 
 You may use the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,14 +21,11 @@ RUN mkdir -p /opt/gcp_variant_transforms/bin && mkdir -p /opt/gcp_variant_transf
 ADD / /opt/gcp_variant_transforms/src/
 
 # Install dependencies.
-# TODO(arostamianfar): Remove explicit installation of Beam once Issue #65
-# is resolved.
 RUN pip install --upgrade pip && pip install --upgrade virtualenv && \
     virtualenv /opt/gcp_variant_transforms/venv && \
     . /opt/gcp_variant_transforms/venv/bin/activate && \
     cd /opt/gcp_variant_transforms/src && \
-    pip install --upgrade . && \
-    pip install --upgrade apache_beam[gcp]
+    pip install --upgrade .
 
 RUN printf '#!/bin/bash\n%s\n%s' \
       ". /opt/gcp_variant_transforms/venv/bin/activate && cd /opt/gcp_variant_transforms/src" \

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,7 @@
 import setuptools
 
 REQUIRED_PACKAGES = [
-    # TODO(arostamianfar): Remove once Beam 2.3.0 pip package is launched.
-    # This is needed due to https://issues.apache.org/jira/browse/BEAM-3357.
-    'grpcio>=1.3.5,<=1.7.3',
-    'apache-beam[gcp]>=2.2',
+    'apache-beam[gcp]>=2.3',
     # Note that adding 'google-api-python-client>=1.6' causes some dependency
     # mismatch issues. This is fatal if using 'setup.py install', but works on
     # 'pip install .' as it ignores conflicting versions. See Issue #71.


### PR DESCRIPTION
Fixes #65
Tested: ran integration tests