### PR TITLE
Tools and Dockerfile for running VEP and setting up databases.

### DIFF
--- a/vep/Dockerfile
+++ b/vep/Dockerfile
@@ -1,0 +1,61 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This is branched from batch/build_annotator/Dockerfile.vep file of the
+# verilylifesciences/variant-annotation GitHub repo.
+#
+# Example:
+#
+# docker build . --build-arg ENSEMBL_RELEASE=91 --tag vep_91
+#
+# To run vep through containers created by this file, the VEP cache has to be
+# downloaded separately and made available through command line arguments.
+# The script for doing so is build_vep_cache.sh, see README.md for details.
+
+# Start from this container so that gcloud and all its dependencies are already
+# available.
+FROM gcr.io/cloud-builders/gcloud
+
+ARG ENSEMBL_RELEASE=91
+ARG VEP_BASE=/opt/variant_effect_predictor
+
+RUN apt-get -y update && apt-get install -y \
+    build-essential \
+    git \
+    libarchive-zip-perl \
+    libdbd-mysql-perl \
+    libdbi-perl \
+    libfile-copy-recursive-perl \
+    libhts1 \
+    libjson-perl \
+    libmodule-build-perl \
+    tabix \
+    unzip \
+    zlib1g-dev
+
+# Install VEP per the instructions at:
+# http://www.ensembl.org/info/docs/tools/vep/script/vep_download.html#installer
+RUN git clone https://github.com/Ensembl/ensembl-vep.git ${VEP_BASE}
+
+WORKDIR ${VEP_BASE}
+
+RUN git checkout release/${ENSEMBL_RELEASE}
+
+RUN perl INSTALL.pl \
+    --AUTO a \
+    --NO_UPDATE
+
+ADD run_vep.sh ${VEP_BASE}/run_vep.sh
+
+ENTRYPOINT ["bash"]

--- a/vep/README.md
+++ b/vep/README.md
@@ -1,0 +1,111 @@
+# Annotating input files with VEP
+
+This directory includes tools and utilities for running
+[Ensembl's Variant Effect Predictor](
+https://ensembl.org/info/docs/tools/vep/index.html) (VEP) on input VCF files
+of [Variant Transforms](../README.md).
+
+## Overview
+
+With tools provided in this directory, one can:
+* Create a docker image of VEP.
+* Download and package VEP's database (a.k.a.
+[cache](https://.ensembl.org/info/docs/tools/vep/script/vep_cache.html)) for
+different species, reference sequences and versions of VEP.
+* Run VEP on VCF input files and create output VCF files that are annotated.
+
+Note that, this is a useful standalone tool for running VEP in the cloud but the
+main goal is to be able to run VEP as a preprocessor through Variant Transforms
+and then import the annotated variants into BigQuery with proper handling of
+annotations.
+
+## How to create and push VEP docker images
+
+Inside this directory, run:
+
+`docker build . -t [IMAGE_TAG]`
+
+This will download the source from
+[VEP GitHub repo](https://github.com/Ensembl/ensembl-vep) and build VEP from
+that source. By default, it uses version 91 of VEP. This can be changed by
+`ENSEMBL_RELEASE` build argument, e.g.,
+
+`docker build . -t [IMAGE_TAG] --build-arg ENSEMBL_RELEASE=90`
+
+Let's say we want to push this image to the
+[Container Registry](https://cloud.google.com/container-registry/) of `my-project`
+on Google Cloud, se we can pick `[IMAGE_TAG]` as `gcr.io/my-project/vep_91`.
+Then push this image by:
+
+`gcloud docker -- push gcr.io/my-project/vep_91`
+
+**TODO**: Add `cloudbuild.yaml` files for both easy push and integration test.
+
+## How to download and package VEP databases
+
+Choose a local directory with enough space (e.g., ~20GB for homo_sapiens) to
+download and integrate different pieces of the VEP database or cache files.
+Then from within that directory run the
+[`build_vep_cache.sh`](build_vep_cache.sh) script. By default this script
+creates the database for human (homo_sapiens), referenec sequence `GRCh38`,
+and release 91 of VEP. These values can be overwritten by the following
+environment variables (note you should use the same VEP release
+that you used for creating VEP docker image above):
+
+* `VEP_SPECIES`
+* `GENOME_ASSEMBLY`
+* `ENSEMBL_RELEASE`
+
+## How to run VEP on GCP
+
+There is the helper script [`run_vep.sh`](run_vep.sh) that is added to the VEP
+docker image and can be used to run VEP. One way of running it on
+Google Cloud Platform (GCP) is through the [Pipelines API](
+https://cloud.google.com/genomics/v1alpha2/pipelines-api-command-line). For a
+sample `yaml` job description check
+[`sample_pipeline.yaml`](sample_pipeline.yaml).
+Here is a sample `gcloud` command that uses that file:
+
+```
+gcloud alpha genomics pipelines run
+  --project my-project
+  --pipeline-file sample_pipeline.yaml
+  --logging gs://my_bucket/logs
+  --inputs VCF_INFO_FILED=CSQ_RERUN
+```
+
+Note the `vep_cache_homo_sapiens_GRCh38_91.tar.gz` file that is referenced in
+the sample `yaml` file, is the output file that you get from the above database
+creation step.
+
+The [`run_vep.sh`](run_vep.sh) script relies on several environment variables
+that can be set to change the default behaviour. In the above example
+`VCF_INFO_FILED` is changed to `CSQ_RERUN` (the default is `CSQ_VT`).
+
+This is the full list of supported environment variables:
+
+* `SPECIES`: default is `homo_sapiens`
+* `GENOME_ASSEMBLY`: default is `GRCh38`
+* `NUM_FORKS`: The value to be set for
+[`--fork` option of VEP](
+http://.ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_fork).
+default is 1.
+* `OTHER_VEP_OPTS`: Other options to be set for the VEP invocation, default is
+[`--everything`](
+http://ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_everything)
+* `VCF_INFO_FILED`: The name of the info field to be used for annotations,
+default is `CSQ_VT`. See
+[`--vcf_info_field`](
+http://ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_vcf_info_field)
+
+The following environment variables have to be set and point to valid storage
+locations:
+
+* `VEP_CACHE`: Where the tar.gz file, created in the above database creation
+step, is located.
+* `INPUT_FILE`: Note this can be either a VCF file or a compressed VCF file
+(`.gz` or `.bgz`). If it is a compressed file, the `run_vep.sh` script will
+decompress it before sending it to VEP.
+* `OUTPUT_VCF`: The name of the output file which is always a VCF file.
+
+

--- a/vep/README.md
+++ b/vep/README.md
@@ -33,9 +33,9 @@ that source. By default, it uses version 91 of VEP. This can be changed by
 `docker build . -t [IMAGE_TAG] --build-arg ENSEMBL_RELEASE=90`
 
 Let's say we want to push this image to the
-[Container Registry](https://cloud.google.com/container-registry/) of `my-project`
-on Google Cloud, se we can pick `[IMAGE_TAG]` as `gcr.io/my-project/vep_91`.
-Then push this image by:
+[Container Registry](https://cloud.google.com/container-registry/) of
+`my-project` on Google Cloud, se we can pick `[IMAGE_TAG]` as
+`gcr.io/my-project/vep_91`. Then push this image by:
 
 `gcloud docker -- push gcr.io/my-project/vep_91`
 

--- a/vep/README.md
+++ b/vep/README.md
@@ -10,7 +10,7 @@ of [Variant Transforms](../README.md).
 With tools provided in this directory, one can:
 * Create a docker image of VEP.
 * Download and package VEP's database (a.k.a.
-[cache](https://.ensembl.org/info/docs/tools/vep/script/vep_cache.html)) for
+[cache](https://ensembl.org/info/docs/tools/vep/script/vep_cache.html)) for
 different species, reference sequences and versions of VEP.
 * Run VEP on VCF input files and create output VCF files that are annotated.
 
@@ -34,7 +34,7 @@ that source. By default, it uses version 91 of VEP. This can be changed by
 
 Let's say we want to push this image to the
 [Container Registry](https://cloud.google.com/container-registry/) of
-`my-project` on Google Cloud, se we can pick `[IMAGE_TAG]` as
+`my-project` on Google Cloud, so we can pick `[IMAGE_TAG]` as
 `gcr.io/my-project/vep_91`. Then push this image by:
 
 `gcloud docker -- push gcr.io/my-project/vep_91`
@@ -88,7 +88,7 @@ This is the full list of supported environment variables:
 * `GENOME_ASSEMBLY`: default is `GRCh38`
 * `NUM_FORKS`: The value to be set for
 [`--fork` option of VEP](
-http://.ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_fork).
+http://ensembl.org/info/docs/tools/vep/script/vep_options.html#opt_fork).
 default is 1.
 * `OTHER_VEP_OPTS`: Other options to be set for the VEP invocation, default is
 [`--everything`](

--- a/vep/README.md
+++ b/vep/README.md
@@ -104,6 +104,6 @@ locations:
 * `VEP_CACHE`: Where the tar.gz file, created in the above database creation
 step, is located.
 * `INPUT_FILE`: Note this can be either a VCF file or a compressed VCF file
-(`.gz` or `.bgz`). If it is a compressed file, the `run_vep.sh` script will
-decompress it before sending it to VEP.
+(`.gz` or `.bgz`). Treatment of compressed and uncompressed files is the same,
+i.e., the input file is directly fed into VEP.
 * `OUTPUT_VCF`: The name of the output file which is always a VCF file.

--- a/vep/README.md
+++ b/vep/README.md
@@ -67,10 +67,10 @@ sample `yaml` job description check
 Here is a sample `gcloud` command that uses that file:
 
 ```
-gcloud alpha genomics pipelines run
-  --project my-project
-  --pipeline-file sample_pipeline.yaml
-  --logging gs://my_bucket/logs
+gcloud alpha genomics pipelines run \
+  --project my-project \
+  --pipeline-file sample_pipeline.yaml \
+  --logging gs://my_bucket/logs \
   --inputs VCF_INFO_FILED=CSQ_RERUN
 ```
 
@@ -107,5 +107,3 @@ step, is located.
 (`.gz` or `.bgz`). If it is a compressed file, the `run_vep.sh` script will
 decompress it before sending it to VEP.
 * `OUTPUT_VCF`: The name of the output file which is always a VCF file.
-
-

--- a/vep/build_vep_cache.sh
+++ b/vep/build_vep_cache.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This is a script for downloading VEP cache files, decompressing and placing
+# them in the appropriate directory structure that is expected by VEP script.
+# At the end, the whole structure is compressed to generate a single tar.gz
+# file that can be used in run_vep.sh invocations.
+#
+# This script creates a 'vep_cache' sub-directory and does every other file
+# operations and downloads inside that directory. The final cache file will be
+# stored in that directory as well.
+#
+# Capital letter variables refer to environment variables that can be set from
+# outside. Internal variables have small letters. All environment variables
+# have a default value as well to set up cache for homo_sapiens with reference
+# GRCh38 and release 91 of VEP.
+#
+# More details on cache files can be found here:
+# https://ensembl.org/info/docs/tools/vep/script/vep_cache.html
+
+set -euo pipefail
+
+readonly release="${ENSEMBL_RELEASE:-91}"
+readonly species="${VEP_SPECIES:-homo_sapiens}"
+readonly assembly="${GENOME_ASSEMBLY:-GRCh38}"
+readonly work_dir="vep_cache"
+
+mkdir -p "${work_dir}"
+pushd "${work_dir}"
+readonly cache_file="${species}_vep_${release}_${assembly}.tar.gz"
+readonly ftp_base="ftp://ftp.ensembl.org/pub/release-${release}"
+readonly remote_cache="${ftp_base}/variation/VEP/${cache_file}"
+echo "Downloading ${remote_cache} ..."
+curl -O "${remote_cache}"
+
+# The fasta file name depends on the species and assembly but not the version.
+# Also the first letter of the file is capital while it is small for the actual
+# cache file (above). For example: "Homo_sapiens.GRCh38.dna.toplevel.fa.gz"
+readonly fasta_file="${species^?}.${assembly}.dna.toplevel.fa.gz"
+readonly remote_fasta="${ftp_base}/fasta/homo_sapiens/dna_index/${fasta_file}"
+echo "Downloading ${remote_fasta} and its index files ..."
+curl -O "${remote_fasta}"
+curl -O "${remote_fasta}.fai"
+curl -O "${remote_fasta}.gzi"
+
+echo "Decompressing cache files ..."
+tar xzf "${cache_file}"
+
+echo "Moving fasta files to the cache structure ..."
+mv ${fasta_file}* "${species}/${release}_${assembly}"
+
+echo "Creating single tar.gz file for the whole cache ..."
+readonly output_cache="vep_cache_${species}_${assembly}_${release}.tar.gz"
+tar czf "${output_cache}" "${species}"
+if [[ -r "${output_cache}" ]]; then
+  echo "Cleaning up ..."
+  rm -rf "${species}"
+  rm -f "${cache_file}"
+fi
+popd
+
+if [[ -r "${work_dir}/${output_cache}" ]]; then
+  echo "Successfully created cache file at ${work_dir}/${output_cache}"
+else
+  echo "ERROR: Something went wrong when creating ${work_dir}/${output_cache} !"
+fi
+
+# TODO(bashir2): Experiment with the convert_cache.pl script of VEP and measure performance
+# improvements. If the change is significant then this script has to run convert_cache.pl too.
+

--- a/vep/run_vep.sh
+++ b/vep/run_vep.sh
@@ -51,22 +51,8 @@ fi
 
 # TODO(bashir2): Add support for multiple input and output files.
 
-# Check if the input is .gz or .bgz and uncompress it if needed. Note that
-# gzip is supposed to be able to decompress .bgz files as well.
-echo "Checking if ${INPUT_FILE} needs to be decompressed, started at $(date)"
-input_vcf="${INPUT_FILE%.bgz}"
-if [[ "${input_vcf}" != "${INPUT_FILE}" ]]; then
-  gzip -d -S .bgz "${INPUT_FILE}"
-else
-  input_vcf="${INPUT_FILE%.gz}"
-  if [[ "${input_vcf}" != "${INPUT_FILE}" ]]; then
-    gzip -d "${INPUT_FILE}"
-  else
-    input_vcf=${INPUT_FILE}
-  fi
-fi
-echo "Input VCF is ready at $(date)"
-ls -l "${input_vcf}"
+echo "Checking input file at $(date)"
+ls -l "${INPUT_FILE}"
 
 # Make sure output file does not exist and can be written.
 if [[ -e ${OUTPUT_VCF:?OUTPUT_VCF is not set!} ]]; then
@@ -87,7 +73,7 @@ if [[ ! -d "${species}" ]]; then
 fi
 popd
 
-readonly vep_command="./vep -i ${input_vcf} -o ${OUTPUT_VCF} \
+readonly vep_command="./vep -i ${INPUT_FILE} -o ${OUTPUT_VCF} \
   --dir ${vep_cache_dir} --offline --species ${species} --assembly ${assembly} \
   --vcf --allele_number --vcf_info_field ${annotation_field_name} ${fork_opt} \
   ${other_vep_opts}"

--- a/vep/run_vep.sh
+++ b/vep/run_vep.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script is intended to be used in the Docker image built for VEP.
+# Note that the arguments are passed through environment variables and to log
+# useful error messages when they are not properly set, we always check their
+# existence the first time they are being accessed.
+#
+# The only enviroment variables that have to be set are (others are optional):
+#
+# VEP_CACHE: The path of the VEP cache which is a single .tar.gz file.
+# INPUT_FILE: The path of the input file (might be a VCF or a compressed VCF).
+# OUTPUT_VCF: The path of the output file which is always a VCF file.
+#
+# For the full list of supported environment variables and their documentation
+# check README.md.
+# Capital letter variables refer to environment variables that can be set from
+# outside. Internal variables have small letters.
+
+set -euo pipefail
+
+readonly species="${SPECIES:-homo_sapiens}"
+readonly assembly="${GENOME_ASSEMBLY:-GRCh38}"
+readonly fork_opt="--fork ${NUM_FORKS:-1}"
+readonly other_vep_opts="${OTHER_VEP_OPTS:---everything}"
+readonly annotation_field_name="${VCF_INFO_FILED:-CSQ_VT}"
+
+if [[ ! -r "${VEP_CACHE:?VEP_CACHE is not set!}" ]]; then
+  echo "ERRPR: Cannot read ${VEP_CACHE}"
+  exit 1
+fi
+
+# Check INPUT_FILE is set and is a readable file.
+if [[ ! -r "${INPUT_FILE:?INPUT_FILE is not set!}" ]]; then
+  echo "ERRPR: Cannot read ${INPUT_FILE}"
+  exit 1
+fi
+
+# TODO(bashir2): Add support for multiple input and output files.
+
+# Check if the input is .gz or .bgz and uncompress it if needed. Note that
+# gzip is supposed to be able to decompress .bgz files as well.
+echo "Checking if ${INPUT_FILE} needs to be decompressed, started at $(date)"
+input_vcf="${INPUT_FILE%.bgz}"
+if [[ "${input_vcf}" != "${INPUT_FILE}" ]]; then
+  gzip -d -S .bgz "${INPUT_FILE}"
+else
+  input_vcf="${INPUT_FILE%.gz}"
+  if [[ "${input_vcf}" != "${INPUT_FILE}" ]]; then
+    gzip -d "${INPUT_FILE}"
+  else
+    input_vcf=${INPUT_FILE}
+  fi
+fi
+echo "Input VCF is ready at $(date)"
+ls -l "${input_vcf}"
+
+# Make sure output file does not exist and can be written.
+if [[ -e ${OUTPUT_VCF:?OUTPUT_VCF is not set!} ]]; then
+  echo "ERROR: ${OUTPUT_VCF} already exits!"
+  exit 1
+fi
+touch ${OUTPUT_VCF}
+rm ${OUTPUT_VCF}
+
+readonly vep_cache_dir="$(dirname ${VEP_CACHE})"
+readonly vep_cache_file="$(basename ${VEP_CACHE})"
+pushd ${vep_cache_dir}
+echo "Decompressing the cache file ${vep_cache_file} started at $(date)"
+tar xzvf "${vep_cache_file}"
+if [[ ! -d "${species}" ]]; then
+  echo "Cannot find directory ${species} after decompressing ${vep_cache_file}!"
+  exit 1
+fi
+popd
+
+readonly vep_command="./vep -i ${input_vcf} -o ${OUTPUT_VCF} \
+  --dir ${vep_cache_dir} --offline --species ${species} --assembly ${assembly} \
+  --vcf --allele_number --vcf_info_field ${annotation_field_name} ${fork_opt} \
+  ${other_vep_opts}"
+echo "VEP command is: ${vep_command}"
+
+echo "Running vep started at $(date)"
+# The next line should not be quoted since we want word splitting to happen.
+${vep_command}

--- a/vep/sample_pipeline.yaml
+++ b/vep/sample_pipeline.yaml
@@ -1,0 +1,32 @@
+name: run-vep
+resources:
+  disks:
+    - name: datadisk
+      mountPoint: /mnt/data
+      type: PERSISTENT_HDD
+      sizeGb: 300
+  minimumCpuCores: 12
+inputParameters:
+  - name: VEP_CACHE
+    defaultValue: gs://my_bucket/vep_cache_homo_sapiens_GRCh38_91.tar.gz
+    localCopy:
+      disk: datadisk
+      path: vep_cache_91.tar.gz
+  - name: INPUT_FILE
+    defaultValue: gs://my_bucket/input.vcf
+    localCopy:
+      disk: datadisk
+      path: input.vcf
+  - name: VCF_INFO_FILED
+    defaultValue: CSQ_VT
+  - name: NUM_FORKS
+    defaultValue: "12"
+outputParameters:
+  - name: OUTPUT_VCF
+    defaultValue: gs://my_bucket/output.vcf
+    localCopy:
+      disk: datadisk
+      path: output.vcf
+docker:
+  imageName: gcr.io/my-project/vep_91
+  cmd: /opt/variant_effect_predictor/run_vep.sh

--- a/vep/sample_pipeline.yaml
+++ b/vep/sample_pipeline.yaml
@@ -1,3 +1,4 @@
+# TODO(bashir2): Update this example with v2alpha1 required changes.
 name: run-vep
 resources:
   disks:


### PR DESCRIPTION
Tested:
* Created VEP databases by `./build_vep_cache.sh` and copied the generated file to GCS.
* Ran VEP on a sample using a job config similar to the `sample_pipeline.yaml` (input was `gnomad.genomes.r2.0.2.sites.chr1_500_lines.vcf`).
* Compared the generated output with a VEP run locally with databases set up with VEP installation script.

Issue #81 

Some stats for future reference:
* The generated cache file `vep_cache_homo_sapiens_GRCh38_91.tar.gz` is ~7.6 GB; I still have TODOs for cache generation and the size may increase.
* In a sample successful run here are the timings of events:
```
$ gcloud alpha genomics operations describe ENaMrdKnLBj_jqeB3ZHUmTMgieyWs58bKg9wcm9kdWN0aW9uUXVldWU --format='yaml(done, error,
 metadata.events)' ; date
done: true
metadata:
  events:
  - description: start
    startTime: '2018-03-31T04:23:57.540276929Z'
  - description: pulling-image
    startTime: '2018-03-31T04:23:57.540368063Z'
  - description: localizing-files
    startTime: '2018-03-31T04:25:15.310553313Z'
  - description: running-docker
    startTime: '2018-03-31T04:27:06.286241032Z'
  - description: delocalizing-files
    startTime: '2018-03-31T04:28:39.248332945Z'
  - description: copied 1 file(s) to "gs://vep_test_files/gnomad.genomes.r2.0.2.sites.chr1_5000_lines_OUTPUT_91_fork_12.vcf"
    startTime: '2018-03-31T04:28:41.274267227Z'
  - description: ok
    startTime: '2018-03-31T04:28:43.197603332Z'
```
In the `running-docker` step, here are more timings and stats from log files:
```
Checking if /mnt/data/input.vcf needs to be decompressed, started at Sat Mar 31 04:27:17 UTC 2018
Input VCF is ready at Sat Mar 31 04:27:17 UTC 2018
-rw-r--r-- 1 root root 13762777 Mar 31 04:25 /mnt/data/input.vcf
/mnt/data /opt/variant_effect_predictor
Decompressing the cache file vep_cache_91.tar.gz started at Sat Mar 31 04:27:17 UTC 2018
...
VEP command is: ./vep -i /mnt/data/input.vcf -o /mnt/data/output.vcf --dir /mnt/data --offline   --species homo_sapiens --assembly GRCh38 --vcf --allele_number   --vcf_info_field CSQ_RERUN --fork 12 --everything 
Running vep started at Sat Mar 31 04:28:15 UTC 2018
```
So decompressing cache took ~58 seconds and running VEP took ~24 seconds.