### PR TITLE
Fix integration tests.

### DIFF
--- a/gcp_variant_transforms/testing/integration/run_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_tests.py
@@ -263,11 +263,10 @@ class TestContextManager(object):
       # Delete tables, otherwise dataset deletion will fail because it is still
       # "in use".
       for table in tables:
-        # The returned tables are of type TableListItem which has similar
-        # properties like Table with the exception of a few missing ones.
-        # This seems to be the easiest (but not cleanest) way of creating a
-        # Table instance from a TableListItem.
-        client.delete_table(bigquery.Table(table))
+        # The returned tables are of type TableListItem, but delete_table
+        # needs Table or TableReference.
+        client.delete_table(
+            bigquery.TableReference(dataset_ref, table.table_id))
       client.delete_dataset(dataset)
 
 


### PR DESCRIPTION
BigQuery API v0.32.0 (released on April 4, 2018) no longer accepts bigquery.Table as an argument when deleting. I confirmed that bigquery.TableReference works with both 0.31.0 and 0.32.0, so there is no need to change our requirements in setup.py

Tested:
manual run.