### PR TITLE
Resolve always if allow_incompatible_records=True.

### DIFF
--- a/gcp_variant_transforms/transforms/merge_headers.py
+++ b/gcp_variant_transforms/transforms/merge_headers.py
@@ -118,7 +118,9 @@ class _MergeHeadersFn(beam.CombineFn):
 class MergeHeaders(beam.PTransform):
   """A PTransform to merge VCF file headers."""
 
-  def __init__(self, split_alternate_allele_info_fields=True):
+  def __init__(self,
+               split_alternate_allele_info_fields=True,
+               allow_incompatible_records=False):
     # type: (bool) -> None
     """Initializes :class:`MergeHeaders` object.
 
@@ -128,9 +130,13 @@ class MergeHeaders(beam.PTransform):
         as it changes the header compatibility rules as it changes the schema.
     """
     super(MergeHeaders, self).__init__()
+    # Resolver makes extra efforts to resolve conflict in header definitions
+    # when flag allow_incompatible_records is set. For example, it resolves
+    # type conflict of string and float into string.
     self._header_merger = _HeaderMerger(
         vcf_field_conflict_resolver.FieldConflictResolver(
-            split_alternate_allele_info_fields))
+            split_alternate_allele_info_fields,
+            resolve_always=allow_incompatible_records))
 
   def expand(self, pcoll):
     return pcoll | 'MergeHeaders' >> beam.CombineGlobally(_MergeHeadersFn(

--- a/gcp_variant_transforms/transforms/merge_headers.py
+++ b/gcp_variant_transforms/transforms/merge_headers.py
@@ -121,13 +121,15 @@ class MergeHeaders(beam.PTransform):
   def __init__(self,
                split_alternate_allele_info_fields=True,
                allow_incompatible_records=False):
-    # type: (bool) -> None
+    # type: (bool, bool) -> None
     """Initializes :class:`MergeHeaders` object.
 
     Args:
       split_alternate_allele_info_fields: Whether INFO fields with
         `Number=A` are store under the alternate_bases record. This is relevant
         as it changes the header compatibility rules as it changes the schema.
+      allow_incompatible_records: If true, header definition with type mismatch
+        (e.g., string vs float) are always resolved.
     """
     super(MergeHeaders, self).__init__()
     # Resolver makes extra efforts to resolve conflict in header definitions

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -37,8 +37,11 @@ class _ConvertToBigQueryTableRow(beam.DoFn):
     # type: (bigquery_schema_descriptor.SchemaDescriptor, bool, bool) -> None
     super(_ConvertToBigQueryTableRow, self).__init__()
     self._schema_descriptor = schema_descriptor
+    # Resolver makes extra effort to resolve conflict when flag
+    # allow_incompatible_records is set.
     self._conflict_resolver = (
-        vcf_field_conflict_resolver.FieldConflictResolver())
+        vcf_field_conflict_resolver.FieldConflictResolver(
+            resolve_always=allow_incompatible_records))
     self._allow_incompatible_records = allow_incompatible_records
     self._omit_empty_sample_calls = omit_empty_sample_calls
 

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -192,7 +192,8 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
 
     merged_header = (headers
                      | 'MergeHeaders' >> merge_headers.MergeHeaders(
-                         known_args.split_alternate_allele_info_fields))
+                         known_args.split_alternate_allele_info_fields,
+                         known_args.allow_incompatible_records))
 
     if known_args.infer_undefined_headers:
       merged_header = _add_inferred_headers(p, known_args, merged_header)


### PR DESCRIPTION
If allow_incomptible_records flag is set, we resolve any conflict
in 1) headers, 2) headers and records, and 3) records.