### PR TITLE
Add inferred headers to the conflicts report

### DIFF
--- a/gcp_variant_transforms/libs/conflicts_reporter.py
+++ b/gcp_variant_transforms/libs/conflicts_reporter.py
@@ -16,8 +16,8 @@
 
 The report is aimed to help the user to easily import the malformed/incompatible
 VCF files. It contains two parts. The first part reports the header fields that
-have conflicted definitions across multiple VCF files, by providing the
-conflicted definitions, the corresponding file paths, and the suggested
+have conflicting definitions across multiple VCF files, by providing the
+conflicting definitions, the corresponding file paths, and the suggested
 resolutions. The second part contains the undefined header fields and the
 inferred definitions.
 TODO(yifangchen): Eventually, it also contains the malformed records.
@@ -51,16 +51,16 @@ def generate_conflicts_report(file_path,
     header_definitions: The container which contains all header definitions and
       the corresponding file names.
     resolved_headers: The ``VcfHeader`` that provides the resolutions for the
-      fields that have conflicted definitions.
+      fields that have conflicting definitions.
     inferred_headers: The ``VcfHeader`` that contains the inferred header
       definitions of the undefined header fields.
   """
   resolved_headers = resolved_headers or VcfHeader()
   inferred_headers = inferred_headers or VcfHeader()
   content_lines = []
-  content_lines.extend(_generate_conflicted_headers_lines(
+  content_lines.extend(_generate_conflicting_headers_lines(
       _extract_conflicts(header_definitions.formats), resolved_headers.formats))
-  content_lines.extend(_generate_conflicted_headers_lines(
+  content_lines.extend(_generate_conflicting_headers_lines(
       _extract_conflicts(header_definitions.infos), resolved_headers.infos))
   content_lines.extend(_generate_inferred_headers_lines(inferred_headers.infos))
   content_lines.extend(_generate_inferred_headers_lines(
@@ -72,24 +72,24 @@ def _extract_conflicts(
     definitions  # type: Dict[str, Dict[Definition, List[str]]]
     ):
   # type: (...) -> Dict[str, Dict[Definition, List[str]]]
-  """Extracts the fields that have conflicted definitions.
+  """Extracts the fields that have conflicting definitions.
 
   Returns:
-    A dictionary that maps field id with conflicted definitions to a dictionary
+    A dictionary that maps field id with conflicting definitions to a dictionary
     which maps ``Definition`` to a list of file names.
   """
-  # len(v) > 1 means there are conflicted definitions for this field.
+  # len(v) > 1 means there are conflicting definitions for this field.
   return dict([(k, v) for k, v in definitions.items() if len(v) > 1])
 
 
-def _generate_conflicted_headers_lines(
+def _generate_conflicting_headers_lines(
     conflicts,  # type: Dict[str, Dict[Definition, List[str]]]
     resolved_headers  # type: Dict[str, Dict[str, Union[str, int]]
     ):
   # type: (...) -> List[str]
-  """Returns the conflicted headers lines for the report.
+  """Returns the conflicting headers lines for the report.
 
-  The conflicted definitions, the file names and the resolutions are included
+  The conflicting definitions, the file names and the resolutions are included
   in the contents.
   Output example:
   (NS;num=1 type=Float in ['file1','file2'], num=1 type=Integer in ['file3'];
@@ -97,11 +97,9 @@ def _generate_conflicted_headers_lines(
   """
   content_lines = []
   for field_id, definitions_to_files_map in conflicts.iteritems():
-    row = [
-        field_id,
-        _extract_definitions_and_file_names(definitions_to_files_map),
-        _extract_resolution(resolved_headers, field_id)
-    ]
+    row = [field_id,
+           _extract_definitions_and_file_names(definitions_to_files_map),
+           _extract_resolution(resolved_headers, field_id)]
     content_lines.append(';'.join(row))
   return content_lines
 
@@ -116,11 +114,9 @@ def _generate_inferred_headers_lines(inferred_headers):
   """
   content_lines = []
   for field_id in inferred_headers.keys():
-    row = [
-        field_id,
-        _UNDEFINED_HEADER_MESSAGE,
-        _extract_resolution(inferred_headers, field_id)
-    ]
+    row = [field_id,
+           _UNDEFINED_HEADER_MESSAGE,
+           _extract_resolution(inferred_headers, field_id)]
     content_lines.append(';'.join(row))
   return content_lines
 

--- a/gcp_variant_transforms/libs/conflicts_reporter.py
+++ b/gcp_variant_transforms/libs/conflicts_reporter.py
@@ -15,10 +15,12 @@
 """Generates conflicts report.
 
 The report is aimed to help the user to easily import the malformed/incompatible
-VCF files. It contains the conflicted header definitions, the corresponding file
-paths, and the suggested resolutions.
-TODO(yifangchen): Eventually, it also contains the inferred header definitions
-and the malformed records.
+VCF files. It contains two parts. The first part reports the header fields that
+have conflicted definitions across multiple VCF files, by providing the
+conflicted definitions, the corresponding file paths, and the suggested
+resolutions. The second part contains the undefined header fields and the
+inferred definitions.
+TODO(yifangchen): Eventually, it also contains the malformed records.
 """
 
 from typing import Dict, List, Union  # pylint: disable=unused-import
@@ -34,24 +36,35 @@ from gcp_variant_transforms.transforms.merge_header_definitions import VcfHeader
 _HEADER_LINE = 'ID;Conflicts;Proposed Resolution\n'
 _NO_CONFLICTS_MESSAGE = 'No conflicts found.'
 _NO_SOLUTION_MESSAGE = 'Not resolved.'
+_UNDEFINED_HEADER_MESSAGE = 'Undefined header.'
 
 
 def generate_conflicts_report(file_path,
                               header_definitions,
-                              resolved_headers=None):
-  # type: (str, VcfHeaderDefinitions, VcfHeader) -> None
+                              resolved_headers=None,
+                              inferred_headers=None):
+  # type: (str, VcfHeaderDefinitions, VcfHeader, VcfHeader) -> None
   """Generates a report.
 
-  Combines the conflicts extracted from ``header_definitions`` and their
-  resolutions from ``resolved_headers`` to generate a conflicts report.
-  ``file_path`` specifies the location where the conflicts report is saved.
+  Args:
+    file_path: The location where the conflicts report is saved.
+    header_definitions: The container which contains all header definitions and
+      the corresponding file names.
+    resolved_headers: The ``VcfHeader`` that provides the resolutions for the
+      fields that have conflicted definitions.
+    inferred_headers: The ``VcfHeader`` that contains the inferred header
+      definitions of the undefined header fields.
   """
   resolved_headers = resolved_headers or VcfHeader()
+  inferred_headers = inferred_headers or VcfHeader()
   content_lines = []
-  content_lines.extend(_generate_contents(
+  content_lines.extend(_generate_conflicted_headers_lines(
       _extract_conflicts(header_definitions.formats), resolved_headers.formats))
-  content_lines.extend(_generate_contents(
+  content_lines.extend(_generate_conflicted_headers_lines(
       _extract_conflicts(header_definitions.infos), resolved_headers.infos))
+  content_lines.extend(_generate_inferred_headers_lines(inferred_headers.infos))
+  content_lines.extend(_generate_inferred_headers_lines(
+      inferred_headers.formats))
   _write_to_report(content_lines, file_path)
 
 
@@ -69,12 +82,12 @@ def _extract_conflicts(
   return dict([(k, v) for k, v in definitions.items() if len(v) > 1])
 
 
-def _generate_contents(
+def _generate_conflicted_headers_lines(
     conflicts,  # type: Dict[str, Dict[Definition, List[str]]]
     resolved_headers  # type: Dict[str, Dict[str, Union[str, int]]
     ):
   # type: (...) -> List[str]
-  """Generates the report contents.
+  """Returns the conflicted headers lines for the report.
 
   The conflicted definitions, the file names and the resolutions are included
   in the contents.
@@ -82,15 +95,34 @@ def _generate_contents(
   (NS;num=1 type=Float in ['file1','file2'], num=1 type=Integer in ['file3'];
   num=1 type=Float)
   """
-  contents = []
+  content_lines = []
   for field_id, definitions_to_files_map in conflicts.iteritems():
     row = [
         field_id,
         _extract_definitions_and_file_names(definitions_to_files_map),
         _extract_resolution(resolved_headers, field_id)
     ]
-    contents.append(';'.join(row))
-  return contents
+    content_lines.append(';'.join(row))
+  return content_lines
+
+
+def _generate_inferred_headers_lines(inferred_headers):
+  # type: (Dict[str, Dict[str, Union[str, int]]]) -> List[str]
+  """Returns the inferred headers lines for the report.
+
+  The field ID and the inferred header definitions are included in the contents.
+  Output example:
+  NS;Undefined header;num=1 type=Float
+  """
+  content_lines = []
+  for field_id in inferred_headers.keys():
+    row = [
+        field_id,
+        _UNDEFINED_HEADER_MESSAGE,
+        _extract_resolution(inferred_headers, field_id)
+    ]
+    content_lines.append(';'.join(row))
+  return content_lines
 
 
 def _extract_definitions_and_file_names(definition_to_files_map):
@@ -137,6 +169,7 @@ def _write_to_report(contents, file_path):
   ID;Conflicts;Proposed Resolution
   (NS;num=1 type=Float in ['file1','file2'], num=1 type=Integer in ['file3'];
   num=1 type=Float)
+  DP;Undefined header;num=1 type=Float
   """
   with FileSystems.create(file_path) as file_to_write:
     if not contents:


### PR DESCRIPTION
- Add the inferred headers to the report by providing the inferred headers.
- Update the unit tests.

Tested: unit tests.
Issue: [issue 178](https://github.com/googlegenomics/gcp-variant-transforms/issues/178)