### PR TITLE
Fixing BigQuery "Too many sources provided" error

### DIFF
--- a/gcp_variant_transforms/transforms/limit_write.py
+++ b/gcp_variant_transforms/transforms/limit_write.py
@@ -1,0 +1,54 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A PTransform to limit BQ sink from producing too many files (shards)
+
+This is a work around to avoid the following failure:
+    BigQuery execution failed., Error:
+    Message: Too many sources provided: xxxxx. Limit is 10000.
+To limit sink we generate a random dummy key and group by input elements (which
+are BigQuery rows) based on that key before writing them to output table.
+"""
+
+from __future__ import absolute_import
+
+import random
+import apache_beam as beam
+
+
+class _RoundRobinKeyFn(beam.DoFn):
+  def __init__(self, count):
+    self._count = count
+    # This attribute will be properly initiated at each worker by start_bundle()
+    self._counter = 0
+
+  def start_bundle(self):
+    self._counter = random.randint(0, self._count - 1)
+
+  def process(self, element):
+    self._counter += 1
+    if self._counter >= self._count:
+      self._counter -= self._count
+    yield self._counter, element
+
+
+class LimitWrite(beam.PTransform):
+  def __init__(self, count):
+    self._count = count
+
+  def expand(self, pcoll):
+    return (pcoll
+            | beam.ParDo(_RoundRobinKeyFn(self._count))
+            | beam.GroupByKey()
+            | beam.FlatMap(lambda kv: kv[1]))

--- a/gcp_variant_transforms/transforms/limit_write_test.py
+++ b/gcp_variant_transforms/transforms/limit_write_test.py
@@ -1,0 +1,76 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for limit_write module."""
+
+from __future__ import absolute_import
+
+import unittest
+
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+from apache_beam.transforms import Create
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.transforms import limit_write
+
+
+class LimitWriteTest(unittest.TestCase):
+  """Test cases for the ``LimitWrite`` PTransform."""
+
+  def _get_sample_variants(self):
+    variant1 = vcfio.Variant(
+        reference_name='chr19', start=11, end=12, reference_bases='C')
+    variant2 = vcfio.Variant(
+        reference_name='20', start=123, end=125, reference_bases='CT')
+    variant3 = vcfio.Variant(
+        reference_name='20', start=None, end=None, reference_bases=None)
+    variant4 = vcfio.Variant(
+        reference_name='20', start=123, end=125, reference_bases='CT')
+    return [variant1, variant2, variant3, variant4]
+
+
+  def test_limit_write_default_shard_limit(self):
+    variants = self._get_sample_variants()
+    input_pcoll = Create(variants)
+    pipeline = TestPipeline()
+    output_pcoll = (
+        pipeline
+        | input_pcoll
+        | 'LimitWrite' >> limit_write.LimitWrite(4500))
+    assert_that(output_pcoll, equal_to(variants))
+    pipeline.run()
+
+  def test_limit_write_shard_limit_4(self):
+    variants = self._get_sample_variants()
+    input_pcoll = Create(variants)
+    pipeline = TestPipeline()
+    output_pcoll = (
+        pipeline
+        | input_pcoll
+        | 'LimitWrite' >> limit_write.LimitWrite(4))
+    assert_that(output_pcoll, equal_to(variants))
+    pipeline.run()
+
+  def test_limit_write_shard_limit_1(self):
+    variants = self._get_sample_variants()
+    input_pcoll = Create(variants)
+    pipeline = TestPipeline()
+    output_pcoll = (
+        pipeline
+        | input_pcoll
+        | 'LimitWrite' >> limit_write.LimitWrite(1))
+    assert_that(output_pcoll, equal_to(variants))
+    pipeline.run()

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -191,7 +191,8 @@ def run(argv=None):
            processed_variant_factory,
            append=known_args.append,
            allow_incompatible_records=known_args.allow_incompatible_records,
-           omit_empty_sample_calls=known_args.omit_empty_sample_calls))
+           omit_empty_sample_calls=known_args.omit_empty_sample_calls,
+           limited_write=known_args.optimize_for_large_inputs))
   result = pipeline.run()
   result.wait_until_finish()
 


### PR DESCRIPTION
We observed during multiple runs of VT pipeline whenever we set the --num_workers to
high number (for example 256), it fails with the following error
message:

    BigQuery execution failed., Error:
    Message: Too many sources provided: xxxxx. Limit is 10000
In this change we implemented a solution there was proposed here:
https://stackoverflow.com/questions/44255924/error-message-too-many-sources-provided-15285-limit-is-10000

#199 
Tested:2 test run finished successfully, Platinum_10 and Plantinum_1000