### PR TITLE
Add the preprocess pipeline #178

### DIFF
--- a/gcp_variant_transforms/libs/conflicts_reporter.py
+++ b/gcp_variant_transforms/libs/conflicts_reporter.py
@@ -39,17 +39,17 @@ _NO_SOLUTION_MESSAGE = 'Not resolved.'
 _UNDEFINED_HEADER_MESSAGE = 'Undefined header.'
 
 
-def generate_conflicts_report(file_path,
-                              header_definitions,
+def generate_conflicts_report(header_definitions,
+                              file_path,
                               resolved_headers=None,
                               inferred_headers=None):
-  # type: (str, VcfHeaderDefinitions, VcfHeader, VcfHeader) -> None
+  # type: (VcfHeaderDefinitions, str, VcfHeader, VcfHeader) -> None
   """Generates a report.
 
   Args:
-    file_path: The location where the conflicts report is saved.
     header_definitions: The container which contains all header definitions and
       the corresponding file names.
+    file_path: The location where the conflicts report is saved.
     resolved_headers: The ``VcfHeader`` that provides the resolutions for the
       fields that have conflicting definitions.
     inferred_headers: The ``VcfHeader`` that contains the inferred header

--- a/gcp_variant_transforms/libs/conflicts_reporter_test.py
+++ b/gcp_variant_transforms/libs/conflicts_reporter_test.py
@@ -43,8 +43,8 @@ class ConflictsReporterTest(unittest.TestCase):
     # type: (List[str], VcfHeaderDefinitions, VcfHeader, VcfHeader) -> None
     with temp_dir.TempDir() as tempdir:
       file_path = FileSystems.join(tempdir.get_path(), self._REPORT_NAME)
-      conflicts_reporter.generate_conflicts_report(file_path,
-                                                   header_definitions,
+      conflicts_reporter.generate_conflicts_report(header_definitions,
+                                                   file_path,
                                                    resolved_headers,
                                                    inferred_headers)
       with FileSystems.open(file_path) as f:

--- a/gcp_variant_transforms/libs/vcf_field_conflict_resolver.py
+++ b/gcp_variant_transforms/libs/vcf_field_conflict_resolver.py
@@ -37,8 +37,9 @@ class FieldConflictResolver(object):
     Args:
       split_alternate_allele_info_fields: Whether INFO fields with `Number=A`
         are stored under the alternate_bases record.
-     split_alternate_allele_info_fields: Whether INFO fields with
-       `Number=A` are stored under the alternate_bases record.
+      resolve_always: Always find a solution for the conflicts. When the
+        conflicts are incompatible, convert all type conflicts to `String` and
+        number conflicts to `.`.
     """
     self._split_alternate_allele_info_fields = (
         split_alternate_allele_info_fields)

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -305,13 +305,14 @@ class PreprocessOptions(VariantTransformsOptions):
               'If true, it also reports the undefined headers and malformed '
               'records.'))
     parser.add_argument(
-        '--report_name',
+        '--report_path',
         required=True,
-        help=('The full path of the conflicts report. If runs locally, a local '
-              'path must be provided. Otherwise, a cloud path is required.'))
+        help=('The full path of the preprocessor report. If run locally, a '
+              'local path must be provided. Otherwise, a cloud path is '
+              'required.'))
     parser.add_argument(
-        '--resolved_headers_name',
+        '--resolved_headers_path',
         default='',
-        help=('The full path of the resolved headers. The file will not '
-              'generate if unspecified. Otherwise, please provide a local '
-              'path if runs locally, or a cloud path if runs on Dataflow.'))
+        help=('The full path of the resolved headers. The file will not be'
+              'generated if unspecified. Otherwise, please provide a local '
+              'path if run locally, or a cloud path if run on Dataflow.'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -296,26 +296,22 @@ class MergeOptions(VariantTransformsOptions):
 
 class PreprocessOptions(VariantTransformsOptions):
   """Options for preprocess."""
-  _REPORT_NAME = 'conflicts_report.csv'
-  _RESOLVED_HEADERS_FILE_NAME = 'resolved_headers.vcf'
 
   def add_arguments(self, parser):
     parser.add_argument(
         '--report_all',
-        type='bool', default=True, nargs='?', const=False,
+        type='bool', default=False, nargs='?', const=True,
         help=('By default, only the incompatible VCF headers will be reported. '
               'If true, it also reports the undefined headers and malformed '
-              'recorded.'))
-    parser.add_argument(
-        '--directory',
-        default='',
-        help=('The local directory where the conflicts report and the resolved '
-              'headers are saved if running locally.'))
+              'records.'))
     parser.add_argument(
         '--report_name',
-        default=self._REPORT_NAME,
-        help=('The file name for the conflicts report.'))
+        required=True,
+        help=('The full path of the conflicts report. If runs locally, a local '
+              'path must be provided. Otherwise, a cloud path is required.'))
     parser.add_argument(
         '--resolved_headers_name',
-        default=self._RESOLVED_HEADERS_FILE_NAME,
-        help=('The file name for the resolved headers.'))
+        default='',
+        help=('The full path of the resolved headers. The file will not '
+              'generate if unspecified. Otherwise, please provide a local '
+              'path if runs locally, or a cloud path if runs on Dataflow.'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -21,10 +21,6 @@ from apitools.base.py import exceptions
 from oauth2client.client import GoogleCredentials
 
 
-__all__ = ['VariantTransformsOptions', 'VcfReadOptions', 'BigQueryWriteOptions',
-           'FilterOptions', 'MergeOptions', 'PreprocessOptions']
-
-
 class VariantTransformsOptions(object):
   """Base class for defining groups of options for Variant Transforms.
 
@@ -311,18 +307,9 @@ class PreprocessOptions(VariantTransformsOptions):
               'If true, it also reports the undefined headers and malformed '
               'recorded.'))
     parser.add_argument(
-        '--split_alternate_allele_info_fields',
-        type='bool', default=True, nargs='?', const=True,
-        help=('If true, all INFO fields with Number=A (i.e. one value for each '
-              'alternate allele) will be stored under the alternate_bases '
-              'record. If false, they will be stored with the rest of the INFO '
-              'fields. Setting this option to true makes querying the data '
-              'easier, because it avoids having to map each field with the '
-              'corresponding alternate record while querying.'))
-    parser.add_argument(
         '--directory',
         default='',
-        help=('The directory where the conflicts report and the resolved '
+        help=('The local directory where the conflicts report and the resolved '
               'headers are saved if running locally.'))
     parser.add_argument(
         '--report_name',

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -22,7 +22,7 @@ from oauth2client.client import GoogleCredentials
 
 
 __all__ = ['VariantTransformsOptions', 'VcfReadOptions', 'BigQueryWriteOptions',
-           'FilterOptions', 'MergeOptions']
+           'FilterOptions', 'MergeOptions', 'PreprocessOptions']
 
 
 class VariantTransformsOptions(object):
@@ -296,3 +296,39 @@ class MergeOptions(VariantTransformsOptions):
             '--variant_merge_strategy {}|{}'.format(
                 MergeOptions.MOVE_TO_CALLS,
                 MergeOptions.MERGE_WITH_NON_VARIANTS))
+
+
+class PreprocessOptions(VariantTransformsOptions):
+  """Options for preprocess."""
+  _REPORT_NAME = 'conflicts_report.csv'
+  _RESOLVED_HEADERS_FILE_NAME = 'resolved_headers.vcf'
+
+  def add_arguments(self, parser):
+    parser.add_argument(
+        '--report_all',
+        type='bool', default=True, nargs='?', const=False,
+        help=('By default, only the incompatible VCF headers will be reported. '
+              'If true, it also reports the undefined headers and malformed '
+              'recorded.'))
+    parser.add_argument(
+        '--split_alternate_allele_info_fields',
+        type='bool', default=True, nargs='?', const=True,
+        help=('If true, all INFO fields with Number=A (i.e. one value for each '
+              'alternate allele) will be stored under the alternate_bases '
+              'record. If false, they will be stored with the rest of the INFO '
+              'fields. Setting this option to true makes querying the data '
+              'easier, because it avoids having to map each field with the '
+              'corresponding alternate record while querying.'))
+    parser.add_argument(
+        '--directory',
+        default='',
+        help=('The directory where the conflicts report and the resolved '
+              'headers are saved if running locally.'))
+    parser.add_argument(
+        '--report_name',
+        default=self._REPORT_NAME,
+        help=('The file name for the conflicts report.'))
+    parser.add_argument(
+        '--resolved_headers_name',
+        default=self._RESOLVED_HEADERS_FILE_NAME,
+        help=('The file name for the resolved headers.'))

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -34,7 +34,6 @@ python -m gcp_variant_transforms.vcf_to_bq \
 from __future__ import absolute_import
 
 import argparse  # pylint: disable=unused-import
-import datetime
 import logging
 import sys
 import tempfile
@@ -42,7 +41,6 @@ from typing import List, Optional  # pylint: disable=unused-import
 
 import apache_beam as beam
 from apache_beam import pvalue  # pylint: disable=unused-import
-from apache_beam.io import filesystems
 from apache_beam.options import pipeline_options
 
 from gcp_variant_transforms import vcf_to_bq_common
@@ -55,7 +53,6 @@ from gcp_variant_transforms.libs.variant_merge import move_to_calls_strategy
 from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy  # pylint: disable=unused-import
 from gcp_variant_transforms.options import variant_transform_options
 from gcp_variant_transforms.transforms import filter_variants
-from gcp_variant_transforms.transforms import merge_headers
 from gcp_variant_transforms.transforms import merge_variants
 from gcp_variant_transforms.transforms import variant_to_bigquery
 
@@ -93,21 +90,6 @@ def _get_variant_merge_strategy(known_args  # type: argparse.Namespace
     raise ValueError('Merge strategy is not supported.')
 
 
-def _add_inferred_headers(pipeline,  # type: beam.Pipeline
-                          known_args,  # type: argparse.Namespace
-                          merged_header  # type: pvalue.PCollection
-                         ):
-  # type: (...) -> pvalue.PCollection
-  inferred_headers = vcf_to_bq_common.get_inferred_headers(pipeline, known_args,
-                                                           merged_header)
-  merged_header = (
-      (inferred_headers, merged_header)
-      | beam.Flatten()
-      | 'MergeHeadersFromVcfAndVariants' >> merge_headers.MergeHeaders(
-          known_args.split_alternate_allele_info_fields))
-  return merged_header
-
-
 def _merge_headers(known_args, pipeline_args, pipeline_mode):
   # type: (argparse.Namespace, List[str], int) -> None
   """Merges VCF headers using beam based on pipeline_mode."""
@@ -128,20 +110,19 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
     google_cloud_options.job_name = _MERGE_HEADERS_JOB_NAME
 
   temp_directory = google_cloud_options.temp_location or tempfile.mkdtemp()
-  # Add a time prefix to ensure files are unique in case multiple
-  # pipelines are run at the same time.
-  temp_merged_headers_file_name = '-'.join([
-      datetime.datetime.now().strftime('%Y%m%d-%H%M%S'),
-      google_cloud_options.job_name,
-      _MERGE_HEADERS_FILE_NAME])
-  known_args.representative_header_file = filesystems.FileSystems.join(
-      temp_directory, temp_merged_headers_file_name)
+  known_args.representative_header_file = (
+      vcf_to_bq_common.form_absolute_file_name(temp_directory,
+                                               google_cloud_options.job_name,
+                                               _MERGE_HEADERS_FILE_NAME))
 
   with beam.Pipeline(options=options) as p:
     headers = vcf_to_bq_common.read_headers(p, pipeline_mode, known_args)
-    merged_header = vcf_to_bq_common.get_merged_headers(headers, known_args)
+    merged_header = vcf_to_bq_common.get_merged_headers(
+        headers, known_args, known_args.allow_incompatible_records)
     if known_args.infer_undefined_headers:
-      merged_header = _add_inferred_headers(p, known_args, merged_header)
+      _, merged_header = vcf_to_bq_common.add_inferred_headers(p,
+                                                               known_args,
+                                                               merged_header)
     vcf_to_bq_common.write_headers(merged_header,
                                    known_args.representative_header_file)
 

--- a/gcp_variant_transforms/vcf_to_bq_common.py
+++ b/gcp_variant_transforms/vcf_to_bq_common.py
@@ -20,7 +20,6 @@ PTransforms and writing the output.
 
 from typing import List  # pylint: disable=unused-import
 import argparse
-import datetime
 import enum
 
 import apache_beam as beam
@@ -83,17 +82,6 @@ def get_pipeline_mode(known_args):
   elif total_files > _SMALL_DATA_THRESHOLD:
     return PipelineModes.MEDIUM
   return PipelineModes.SMALL
-
-
-def form_absolute_file_name(directory, job_name, file_name):
-  # type: (str, str, str) -> str
-  """Returns the absolute file name."""
-  # Adds a time prefix to ensure files are unique in case multiple pipelines are
-  # run at the same time.
-  file_name = '-'.join([datetime.datetime.now().strftime('%Y%m%d-%H%M%S'),
-                        job_name,
-                        file_name])
-  return filesystems.FileSystems.join(directory, file_name)
 
 
 def read_variants(pipeline, known_args):

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -1,0 +1,113 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Pipeline for preprocessing the VCF files.
+
+This pipeline is aimed to help the user to easily identify and further import
+the malformed/incompatible VCF files to BigQuery. It generates two files as the
+output:
+- Conflicts report: A file that lists the incompatible headers, undefined header
+  fields, the suggested resolutions and eventually malformed records.
+- Resolved headers file: A VCF file that contains the resolved fields
+  definitions.
+
+The files are generated in the "temp_location" if it is provided. Otherwise,
+they will be saved in the ``directory``.
+
+Run locally:
+python -m gcp_variant_transforms.vcf_to_bq_preprocess \
+  --input_pattern <path to VCF file(s)>
+
+Run on Dataflow:
+python -m gcp_variant_transforms.vcf_to_bq_preprocess \
+  --input_pattern <path to VCF file(s)>
+  --report_all True \
+  --project gcp-variant-transforms-test \
+  --job_name preprocess \
+  --staging_location "gs://integration_test_runs/staging" \
+  --temp_location "gs://integration_test_runs/temp" \
+  --runner DataflowRunner \
+  --setup_file ./setup.py
+"""
+
+import logging
+import sys
+
+import apache_beam as beam
+from apache_beam.options import pipeline_options
+
+from gcp_variant_transforms import vcf_to_bq_common
+from gcp_variant_transforms.libs import conflicts_reporter
+from gcp_variant_transforms.options import variant_transform_options
+from gcp_variant_transforms.transforms import merge_header_definitions
+
+_COMMAND_LINE_OPTIONS = [
+    variant_transform_options.FilterOptions,
+    variant_transform_options.PreprocessOptions,
+    variant_transform_options.VcfReadOptions
+]
+
+_PREPROCESS_JOB_NAME = 'preprocess-vcf-files'
+
+
+# TODO(yifangchen): Add an integration test for this pipeline.
+def run(argv=None):
+  # type: (List[str]) -> (str, str)
+  """Runs preprocess pipeline."""
+  logging.info('Command: %s', ' '.join(argv or sys.argv))
+  known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
+                                                          _COMMAND_LINE_OPTIONS)
+  options = pipeline_options.PipelineOptions(pipeline_args)
+  pipeline_mode = vcf_to_bq_common.get_pipeline_mode(known_args)
+  if (pipeline_mode == vcf_to_bq_common.PipelineModes.SMALL and
+      not known_args.report_all):
+    options.view_as(pipeline_options.StandardOptions).runner = 'DirectRunner'
+  google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)
+  if google_cloud_options.job_name:
+    google_cloud_options.job_name += '-' + _PREPROCESS_JOB_NAME
+  else:
+    google_cloud_options.job_name = _PREPROCESS_JOB_NAME
+
+  directory = google_cloud_options.temp_location or known_args.directory
+  abs_report_name = vcf_to_bq_common.form_absolute_file_name(
+      directory, google_cloud_options.job_name, known_args.report_name)
+  abs_resolved_headers_name = vcf_to_bq_common.form_absolute_file_name(
+      directory,
+      google_cloud_options.job_name,
+      known_args.resolved_headers_name)
+
+  with beam.Pipeline(options=options) as p:
+    headers = vcf_to_bq_common.read_headers(p, pipeline_mode, known_args)
+    merged_headers = vcf_to_bq_common.get_merged_headers(headers, known_args,
+                                                         True)
+    merged_definitions = (headers | 'MergeDefinitions'
+                          >> merge_header_definitions.MergeDefinitions())
+    inferred_headers_side_input = None
+    if known_args.report_all:
+      inferred_headers, merged_headers = vcf_to_bq_common.add_inferred_headers(
+          p, known_args, merged_headers)
+      inferred_headers_side_input = beam.pvalue.AsSingleton(inferred_headers)
+
+    _ = (merged_definitions | 'GenerateConflictsReport' >>
+         beam.ParDo(conflicts_reporter.generate_conflicts_report,
+                    abs_report_name,
+                    beam.pvalue.AsSingleton(merged_headers),
+                    inferred_headers_side_input))
+    vcf_to_bq_common.write_headers(merged_headers, abs_resolved_headers_name)
+  return abs_report_name, abs_resolved_headers_name
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  run()

--- a/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
@@ -22,17 +22,25 @@ from gcp_variant_transforms.testing import temp_dir
 
 
 class PreprocessTest(unittest.TestCase):
+  _REPORT_NAME = 'header_conflicts_report.csv'
+  _RESOLVED_HEADERS_FILE_NAME = 'resolved_headers.vcf'
 
   def test_preprocess_run_locally(self):
     with temp_dir.TempDir() as tempdir:
+      report_name = filesystems.FileSystems.join(tempdir.get_path(),
+                                                 self._REPORT_NAME)
+      resolved_headers_name = filesystems.FileSystems.join(
+          tempdir.get_path(), self._RESOLVED_HEADERS_FILE_NAME)
       argv = [
           '--input_pattern',
           'gs://gcp-variant-transforms-testfiles/small_tests/infer-undefined'
           '-header-fields.vcf',
-          '--directory',
-          tempdir.get_path()
+          '--report_all',
+          '--report_name',
+          report_name,
+          '--resolved_headers_name',
+          resolved_headers_name
       ]
-      abs_report_name, abs_resolved_headers_name = (
-          vcf_to_bq_preprocess.run(argv))
-      assert filesystems.FileSystems.exists(abs_report_name)
-      assert filesystems.FileSystems.exists(abs_resolved_headers_name)
+      vcf_to_bq_preprocess.run(argv)
+      assert filesystems.FileSystems.exists(report_name)
+      assert filesystems.FileSystems.exists(resolved_headers_name)

--- a/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for vcf_to_bq_preprocess script."""
+
+import unittest
+
+from apache_beam.io import filesystems
+from gcp_variant_transforms import vcf_to_bq_preprocess
+from gcp_variant_transforms.testing import temp_dir
+
+
+class PreprocessTest(unittest.TestCase):
+
+  def test_preprocess_run_locally(self):
+    with temp_dir.TempDir() as tempdir:
+      argv = [
+          '--input_pattern',
+          'gs://gcp-variant-transforms-testfiles/small_tests/infer-undefined'
+          '-header-fields.vcf',
+          'directory',
+          tempdir.get_path()
+      ]
+    abs_report_name, abs_resolved_headers_name = vcf_to_bq_preprocess.run(argv)
+
+    assert filesystems.FileSystems.exists(abs_report_name)
+    assert filesystems.FileSystems.exists(abs_resolved_headers_name)

--- a/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
@@ -29,10 +29,10 @@ class PreprocessTest(unittest.TestCase):
           '--input_pattern',
           'gs://gcp-variant-transforms-testfiles/small_tests/infer-undefined'
           '-header-fields.vcf',
-          'directory',
+          '--directory',
           tempdir.get_path()
       ]
-    abs_report_name, abs_resolved_headers_name = vcf_to_bq_preprocess.run(argv)
-
-    assert filesystems.FileSystems.exists(abs_report_name)
-    assert filesystems.FileSystems.exists(abs_resolved_headers_name)
+      abs_report_name, abs_resolved_headers_name = (
+          vcf_to_bq_preprocess.run(argv))
+      assert filesystems.FileSystems.exists(abs_report_name)
+      assert filesystems.FileSystems.exists(abs_resolved_headers_name)

--- a/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
@@ -27,20 +27,20 @@ class PreprocessTest(unittest.TestCase):
 
   def test_preprocess_run_locally(self):
     with temp_dir.TempDir() as tempdir:
-      report_name = filesystems.FileSystems.join(tempdir.get_path(),
-                                                 self._REPORT_NAME)
-      resolved_headers_name = filesystems.FileSystems.join(
-          tempdir.get_path(), self._RESOLVED_HEADERS_FILE_NAME)
+      report_path = filesystems.FileSystems.join(tempdir.get_path(),
+                                                 PreprocessTest._REPORT_NAME)
+      resolved_headers_path = filesystems.FileSystems.join(
+          tempdir.get_path(), PreprocessTest._RESOLVED_HEADERS_FILE_NAME)
       argv = [
           '--input_pattern',
           'gs://gcp-variant-transforms-testfiles/small_tests/infer-undefined'
           '-header-fields.vcf',
           '--report_all',
-          '--report_name',
-          report_name,
-          '--resolved_headers_name',
-          resolved_headers_name
+          '--report_path',
+          report_path,
+          '--resolved_headers_path',
+          resolved_headers_path
       ]
       vcf_to_bq_preprocess.run(argv)
-      assert filesystems.FileSystems.exists(report_name)
-      assert filesystems.FileSystems.exists(resolved_headers_name)
+      assert filesystems.FileSystems.exists(report_path)
+      assert filesystems.FileSystems.exists(resolved_headers_path)


### PR DESCRIPTION
First version of the preprocess pipeline.
- You may check [1000 genomes preprocess](https://console.cloud.google.com/storage/browser/integration_test_runs/temp?project=gcp-variant-transforms-test&prefix=20180420-11) as an example of the output.
- It roughly took one hour to run the pipeline with the following settings:
 worker_machine_type: n1-standard-64
 num_workers: 20

Tested: manually ran the scripts.
Issue: [178](https://github.com/googlegenomics/gcp-variant-transforms/issues/178)