### PR TITLE
Replace HeaderFields with VcfHeader.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_header_io.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io.py
@@ -65,18 +65,17 @@ class VcfHeader(object):
               ):
     """Initializes a VcfHeader object.
 
+    It keeps the order of values in the input dictionaries. Order is important
+    in some fields like `contigs` and for ensuring order is unchanged in
+    VCF->VCF pipelines.
+
     Args:
-      infos: A dictionary mapping info keys (str) to vcf info metadata
-        values (:class:`~vcf.parser._Info`).
-      filters: A dictionary mapping filter keys (str) to vcf filter
-        metadata values (:class:`~vcf.parser._Filter`).
-      alts: A dictionary mapping alt keys (str) to vcf alt metadata
-        values (:class:`~vcf.parser._Alt`).
-      formats: A dictionary mapping format keys (str) to vcf format
-        metadata values (:class:`~vcf.parser._Format`).
-      contigs: A dictionary mapping contig keys (str) to vcf contig
-        metadata values (:class:`~vcf.parser._Contig`).
-      file_name: A str representing the file name of the vcf file.
+      infos: A dictionary mapping info keys to vcf info metadata values.
+      filters: A dictionary mapping filter keys to vcf filter metadata values.
+      alts: A dictionary mapping alt keys to vcf alt metadata values.
+      formats: A dictionary mapping format keys to vcf format metadata values.
+      contigs: A dictionary mapping contig keys to vcf contig metadata values.
+      file_name: The file name of the vcf file.
     """
     self.infos = self._values_asdict(infos or {})
     self.filters = self._values_asdict(filters or {})
@@ -100,11 +99,11 @@ class VcfHeader(object):
                                                  self.contigs]])
 
   def _values_asdict(self, header):
-    """Converts PyVCF header values to dictionaries."""
+    """Converts PyVCF header values to ordered dictionaries."""
     ordered_dict = OrderedDict()
     for key in header:
       # These methods were not designed to be protected. They start with an
-      # underscore to avoid confilcts with field names. For more info, see
+      # underscore to avoid conflicts with field names. For more info, see
       # https://docs.python.org/2/library/collections.html#collections.namedtuple
       ordered_dict[key] = header[key]._asdict()  # pylint: disable=W0212
     return ordered_dict

--- a/gcp_variant_transforms/libs/bigquery_row_generator.py
+++ b/gcp_variant_transforms/libs/bigquery_row_generator.py
@@ -25,7 +25,6 @@ from gcp_variant_transforms.libs import bigquery_schema_descriptor  # pylint: di
 from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs import processed_variant  # pylint: disable=unused-import
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver  # pylint: disable=unused-import
-from gcp_variant_transforms.libs import vcf_header_parser # pylint: disable=unused-import
 
 
 # Maximum size of a BigQuery row is 10MB. See

--- a/gcp_variant_transforms/libs/bigquery_row_generator_test.py
+++ b/gcp_variant_transforms/libs/bigquery_row_generator_test.py
@@ -24,11 +24,11 @@ import mock
 from apache_beam.io.gcp.internal.clients import bigquery
 
 from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import bigquery_schema_descriptor
 from gcp_variant_transforms.libs import bigquery_row_generator
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
-from gcp_variant_transforms.libs import vcf_header_parser
 from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
 from gcp_variant_transforms.libs.bigquery_util import TableFieldConstants
 from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy
@@ -150,7 +150,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     # ProcessedVariant instances directly (instead of Variant) and avoid calling
     # create_processed_variant here. Then we should also add cases that
     # have annotation fields.
-    header_fields = vcf_header_parser.HeaderFields({}, {})
+    header_fields = vcf_header_io.VcfHeader()
     proc_var = processed_variant.ProcessedVariantFactory(
         header_fields).create_processed_variant(variant)
 

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -73,7 +73,7 @@ _FALLBACK_FIELD_NAME_PREFIX = 'field_'
 
 
 def get_bigquery_sanitized_field_name(field_name):
-  # (str) -> str
+  # type: (str) -> str
   """Returns the sanitized field name according to BigQuery restrictions.
 
   BigQuery field names must follow `[a-zA-Z][a-zA-Z0-9_]*`. This method converts

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -73,6 +73,7 @@ _FALLBACK_FIELD_NAME_PREFIX = 'field_'
 
 
 def get_bigquery_sanitized_field_name(field_name):
+  # (str) -> str
   """Returns the sanitized field name according to BigQuery restrictions.
 
   BigQuery field names must follow `[a-zA-Z][a-zA-Z0-9_]*`. This method converts
@@ -93,16 +94,28 @@ def get_bigquery_sanitized_field_name(field_name):
 
 
 def get_bigquery_type_from_vcf_type(vcf_type):
+  # type: (str) -> str
   vcf_type = vcf_type.lower()
   if vcf_type not in _VCF_TYPE_TO_BIG_QUERY_TYPE_MAP:
     raise ValueError('Invalid VCF type: %s' % vcf_type)
   return _VCF_TYPE_TO_BIG_QUERY_TYPE_MAP[vcf_type]
+
+
+def get_bigquery_mode_from_vcf_num(vcf_num):
+  # type: (int) -> str
+  """Returns mode (`repeated` or `nullable`) based on VCF field number."""
+  if vcf_num in (0, 1):
+    return TableFieldConstants.MODE_NULLABLE
+  else:
+    return TableFieldConstants.MODE_REPEATED
+
 
 def get_python_type_from_bigquery_type(bigquery_type):
   # type: (str) -> Union[str, int, bool, float]
   if bigquery_type not in _BIG_QUERY_TYPE_TO_PYTHON_TYPE_MAP:
     raise ValueError('Invalid BigQuery type: %s' % bigquery_type)
   return _BIG_QUERY_TYPE_TO_PYTHON_TYPE_MAP[bigquery_type]
+
 
 def get_bigquery_sanitized_field(
     field, null_numeric_value_replacement=-sys.maxint):

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_test.py
@@ -25,9 +25,9 @@ from vcf.parser import _Format as Format
 from vcf.parser import _Info as Info
 from vcf.parser import field_counts
 
+from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import bigquery_vcf_schema
 from gcp_variant_transforms.libs import processed_variant
-from gcp_variant_transforms.libs import vcf_header_parser
 from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
 from gcp_variant_transforms.libs.bigquery_util import TableFieldConstants
 from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy
@@ -86,7 +86,7 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
                      self._get_fields_from_schema(actual_schema))
 
   def test_no_header_fields(self):
-    header_fields = vcf_header_parser.HeaderFields({}, {})
+    header_fields = vcf_header_io.VcfHeader()
     self._assert_fields_equal(
         self._generate_expected_fields(),
         bigquery_vcf_schema.generate_schema_from_header_fields(
@@ -104,7 +104,7 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
         ('IA2', Info('IA2', field_counts['A'], 'Float', 'desc', 'src', 'v')),
         ('END',  # END should not be included in the generated schema.
          Info('END', 1, 'Integer', 'Special END key', 'src', 'v'))])
-    header_fields = vcf_header_parser.HeaderFields(infos, {})
+    header_fields = vcf_header_io.VcfHeader(infos=infos)
 
     self._assert_fields_equal(
         self._generate_expected_fields(
@@ -158,7 +158,7 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
         ('FU', Format('FU', field_counts['.'], 'Float', 'desc')),
         ('GT', Format('GT', 2, 'Integer', 'Special GT key')),
         ('PS', Format('PS', 1, 'Integer', 'Special PS key'))])
-    header_fields = vcf_header_parser.HeaderFields(infos, formats)
+    header_fields = vcf_header_io.VcfHeader(infos=infos, formats=formats)
     self._assert_fields_equal(
         self._generate_expected_fields(
             alt_fields=['IA'],
@@ -179,7 +179,7 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
     formats = OrderedDict([
         ('a^b', Format('a^b', 1, 'String', 'desc')),
         ('OK_format_09', Format('OK_format_09', 1, 'String', 'desc'))])
-    header_fields = vcf_header_parser.HeaderFields(infos, formats)
+    header_fields = vcf_header_io.VcfHeader(infos=infos, formats=formats)
     self._assert_fields_equal(
         self._generate_expected_fields(
             alt_fields=['I_A'],
@@ -195,7 +195,7 @@ class GenerateSchemaFromHeaderFieldsTest(unittest.TestCase):
         ('I1', Info('I1', 1, 'String', 'desc', 'src', 'v')),
         ('IA', Info('IA', field_counts['A'], 'Integer', 'desc', 'src', 'v'))])
     formats = OrderedDict([('F1', Format('F1', 1, 'String', 'desc'))])
-    header_fields = vcf_header_parser.HeaderFields(infos, formats)
+    header_fields = vcf_header_io.VcfHeader(infos=infos, formats=formats)
     self._assert_fields_equal(
         self._generate_expected_fields(
             alt_fields=['IA'],

--- a/gcp_variant_transforms/libs/processed_variant_test.py
+++ b/gcp_variant_transforms/libs/processed_variant_test.py
@@ -20,12 +20,13 @@ import unittest
 from vcf import parser
 
 from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import metrics_util
 from gcp_variant_transforms.libs import processed_variant
 # This is intentionally breaking the style guide because without this the lines
 # referencing the counter names are too long and hard to read.
 from gcp_variant_transforms.libs.processed_variant import _CounterEnum as CEnum
-from gcp_variant_transforms.libs import vcf_header_parser
+
 
 class _CounterSpy(metrics_util.CounterInterface):
 
@@ -68,7 +69,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
 
   def test_create_processed_variant_no_change(self):
     variant = self._get_sample_variant()
-    header_fields = vcf_header_parser.HeaderFields({}, {})
+    header_fields = vcf_header_io.VcfHeader()
     counter_factory = _CounterSpyFactory()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,
@@ -94,7 +95,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
 
   def test_create_processed_variant_move_alt_info(self):
     variant = self._get_sample_variant()
-    header_fields = vcf_header_parser.HeaderFields({}, {})
+    header_fields = vcf_header_io.VcfHeader()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,
         split_alternate_allele_info_fields=True)
@@ -118,9 +119,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         desc='some desc Allele|Consequence|IMPACT|SYMBOL|Gene',
         source=None,
         version=None)
-    header_fields = vcf_header_parser.HeaderFields(
-        infos={'CSQ': csq_info},
-        formats={})
+    header_fields = vcf_header_io.VcfHeader(infos={'CSQ': csq_info})
     return variant, header_fields
 
   def test_create_processed_variant_move_alt_info_and_annotation(self):
@@ -402,8 +401,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         id=None, num='.', type=None,
         desc='some desc Allele|Consequence|IMPACT|ALLELE_NUM',
         source=None, version=None)
-    header_fields = vcf_header_parser.HeaderFields(
-        infos={'CSQ': csq_info}, formats={})
+    header_fields = vcf_header_io.VcfHeader(infos={'CSQ': csq_info})
     variant = vcfio.Variant(
         reference_name='19', start=11, end=12, reference_bases='C',
         # The following represent a SNV and an insertion, resp.

--- a/gcp_variant_transforms/libs/vcf_header_parser.py
+++ b/gcp_variant_transforms/libs/vcf_header_parser.py
@@ -16,32 +16,23 @@
 
 from __future__ import absolute_import
 
-from collections import namedtuple
-from apache_beam.io.filesystems import FileSystems
-
 import vcf
 
-__all__ = ['HeaderFields', 'get_vcf_headers']
-
-
-# Stores parsed header information.
-#   - infos: Stores all `##INFO` header lines. Type is a ``dict`` with values
-#     equal to ``namedtuple`` defined in ``vcf.parser._Info``.
-#   - formats: Stores all `##FORMAT` header lines. Type is a ``dict`` with
-#     values equal to ``namedtuple`` defined in ``vcf.parser._Formats``.
-HeaderFields = namedtuple('HeaderFields', ['infos', 'formats'])
+from apache_beam.io.filesystems import FileSystems
+from gcp_variant_transforms.beam_io import vcf_header_io
 
 
 def get_vcf_headers(input_file):
-  """Returns VCF headers (FORMAT and INFO) from ``input_file``.
+  # type: (str) -> vcf_header_io.VcfHeader
+  """Returns VCF headers from ``input_file``.
 
   Args:
     input_file (str): A string specifying the path to the representative VCF
-    file, i.e., the VCF file that contains a header representative of all VCF
-    files matching the input_pattern of the job. It can be local or remote (e.g.
-    on GCS).
+      file, i.e., the VCF file that contains a header representative of all VCF
+      files matching the input_pattern of the job. It can be local or
+      remote (e.g. on GCS).
   Returns:
-    ``HeaderFields`` specifying header info.
+    :class:`vcf_header_io.VcfHeader` specifying header info.
   Raises:
     ValueError: If ``input_file`` is not a valid VCF file (e.g. bad format,
     empty, non-existent).
@@ -52,7 +43,12 @@ def get_vcf_headers(input_file):
     vcf_reader = vcf.Reader(fsock=_line_generator(input_file))
   except (SyntaxError, StopIteration) as e:
     raise ValueError('Invalid VCF header: %s' % str(e))
-  return HeaderFields(vcf_reader.infos, vcf_reader.formats)
+  return vcf_header_io.VcfHeader(infos=vcf_reader.infos,
+                                 filters=vcf_reader.filters,
+                                 alts=vcf_reader.alts,
+                                 formats=vcf_reader.formats,
+                                 contigs=vcf_reader.contigs,
+                                 file_name=input_file)
 
 
 def _line_generator(file_name):

--- a/gcp_variant_transforms/libs/vcf_header_parser.py
+++ b/gcp_variant_transforms/libs/vcf_header_parser.py
@@ -32,7 +32,7 @@ def get_vcf_headers(input_file):
       files matching the input_pattern of the job. It can be local or
       remote (e.g. on GCS).
   Returns:
-    :class:`vcf_header_io.VcfHeader` specifying header info.
+    VCF header info.
   Raises:
     ValueError: If ``input_file`` is not a valid VCF file (e.g. bad format,
     empty, non-existent).

--- a/gcp_variant_transforms/testing/asserts.py
+++ b/gcp_variant_transforms/testing/asserts.py
@@ -16,7 +16,9 @@
 
 from __future__ import absolute_import
 
+from typing import Callable, List  # pylint: disable=unused-import
 from apache_beam.testing.util import BeamAssertException
+from gcp_variant_transforms.beam_io import vcf_header_io  # pylint: disable=unused-import
 
 
 def items_equal(expected):
@@ -63,3 +65,19 @@ def header_vars_equal(expected):
     actual_vars = [vars(header) for header in actual]
     items_equal(expected_vars)(actual_vars)
   return _vars_equal
+
+
+def header_fields_equal_ignore_order(expected):
+  # type: (List[vcf_header_io.VcfHeader]) -> Callable
+  """Returns a function for checking presence of headers ignoring order.
+
+  Header fields have type `OrderedDict`, so this method essentially converts
+  them to `dict`, so that we can verify values ignoring order.
+  """
+  def _fields_equal(actual):
+    fields_to_check = ['alts', 'contigs', 'filters', 'formats', 'infos']
+    for field in fields_to_check:
+      expected_fields = [dict(getattr(header, field)) for header in expected]
+      actual_fields = [dict(getattr(header, field)) for header in actual]
+      items_equal(expected_fields)(actual_fields)
+  return _fields_equal

--- a/gcp_variant_transforms/transforms/infer_undefined_headers_test.py
+++ b/gcp_variant_transforms/transforms/infer_undefined_headers_test.py
@@ -30,7 +30,9 @@ from vcf.parser import field_counts
 
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.testing import asserts
 from gcp_variant_transforms.transforms import infer_undefined_headers
+
 
 class InferUndefinedHeaderFieldsTest(unittest.TestCase):
   """ Test case for ``InferUndefinedHeaderFields`` DoFn."""
@@ -143,7 +145,8 @@ class InferUndefinedHeaderFieldsTest(unittest.TestCase):
 
       expected = vcf_header_io.VcfHeader(
           infos=expected_infos, formats=expected_formats)
-      assert_that(inferred_headers, equal_to([expected]))
+      assert_that(inferred_headers,
+                  asserts.header_fields_equal_ignore_order([expected]))
       p.run()
 
   def test_defined_fields_filtered_two_variants(self):
@@ -165,5 +168,6 @@ class InferUndefinedHeaderFieldsTest(unittest.TestCase):
       expected_formats = {'FI_2': Format('FI_2', 1, 'Integer', '')}
       expected = vcf_header_io.VcfHeader(
           infos=expected_infos, formats=expected_formats)
-      assert_that(inferred_headers, equal_to([expected]))
+      assert_that(inferred_headers,
+                  asserts.header_fields_equal_ignore_order([expected]))
       p.run()

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -18,13 +18,14 @@ from __future__ import absolute_import
 
 import apache_beam as beam
 
+from gcp_variant_transforms.beam_io import vcf_header_io  # pylint: disable=unused-import
 from gcp_variant_transforms.libs import bigquery_row_generator
-from gcp_variant_transforms.libs import bigquery_schema_descriptor  #pylint: disable=unused-import
+from gcp_variant_transforms.libs import bigquery_schema_descriptor  # pylint: disable=unused-import
 from gcp_variant_transforms.libs import bigquery_vcf_schema
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
-from gcp_variant_transforms.libs import vcf_header_parser  #pylint: disable=unused-import
-from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy  #pylint: disable=unused-import
+from gcp_variant_transforms.libs import vcf_header_parser  # pylint: disable=unused-import
+from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy  # pylint: disable=unused-import
 from gcp_variant_transforms.transforms import limit_write
 
 
@@ -59,7 +60,7 @@ class VariantToBigQuery(beam.PTransform):
   def __init__(
       self,
       output_table,  # type: str
-      header_fields,  # type: vcf_header_parser.HeaderFields
+      header_fields,  # type: vcf_header_io.VcfHeader
       variant_merger=None,  # type: variant_merge_strategy.VariantMergeStrategy
       proc_var_factory=None,  # type: processed_variant.ProcessedVariantFactory
       append=False,  # type: bool
@@ -71,8 +72,8 @@ class VariantToBigQuery(beam.PTransform):
 
     Args:
       output_table: Full path of the output BigQuery table.
-      header_fields: A `namedtuple` containing representative header fields for
-        all variants. This is needed for dynamically generating the schema.
+      header_fields: Representative header fields for all variants. This is
+        needed for dynamically generating the schema.
       variant_merger: The strategy used for merging variants (if any). Some
         strategies may change the schema, which is why this may be needed here.
       proc_var_factory: The factory class that knows how to convert Variant

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -24,7 +24,6 @@ from gcp_variant_transforms.libs import bigquery_schema_descriptor  # pylint: di
 from gcp_variant_transforms.libs import bigquery_vcf_schema
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
-from gcp_variant_transforms.libs import vcf_header_parser  # pylint: disable=unused-import
 from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy  # pylint: disable=unused-import
 from gcp_variant_transforms.transforms import limit_write
 

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -26,11 +26,11 @@ from apache_beam.testing.util import equal_to
 from apache_beam.transforms import Create
 
 from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import bigquery_schema_descriptor
 from gcp_variant_transforms.libs import bigquery_row_generator
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
-from gcp_variant_transforms.libs import vcf_header_parser
 from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
 from gcp_variant_transforms.libs.bigquery_util import TableFieldConstants
 from gcp_variant_transforms.transforms.variant_to_bigquery import _ConvertToBigQueryTableRow as ConvertToBigQueryTableRow
@@ -229,7 +229,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     variant_1, row_1 = self._get_sample_variant_1()
     variant_2, row_2 = self._get_sample_variant_2()
     variant_3, row_3 = self._get_sample_variant_3()
-    header_fields = vcf_header_parser.HeaderFields({}, {})
+    header_fields = vcf_header_io.VcfHeader()
     proc_var_1 = processed_variant.ProcessedVariantFactory(
         header_fields).create_processed_variant(variant_1)
     proc_var_2 = processed_variant.ProcessedVariantFactory(
@@ -247,7 +247,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
 
   def test_convert_variant_to_bigquery_row_omit_empty_calls(self):
     variant, row = self._get_sample_variant_with_empty_calls()
-    header_fields = vcf_header_parser.HeaderFields({}, {})
+    header_fields = vcf_header_io.VcfHeader()
     proc_var = processed_variant.ProcessedVariantFactory(
         header_fields).create_processed_variant(variant)
     pipeline = TestPipeline(blocking=True)
@@ -261,7 +261,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
 
   def test_convert_variant_to_bigquery_row_allow_incompatible_recoreds(self):
     variant, row = self._get_sample_variant_with_incompatible_records()
-    header_fields = vcf_header_parser.HeaderFields({}, {})
+    header_fields = vcf_header_io.VcfHeader()
     proc_var = processed_variant.ProcessedVariantFactory(
         header_fields).create_processed_variant(variant)
     pipeline = TestPipeline(blocking=True)


### PR DESCRIPTION
Note that VcfHeader itself would be replaced with Nucleus' proto later on (which will make referencing fields like `num`, `desc`, and `type` much more native rather than a dict lookup). This PR makes that transition easier so that at least we have a unified representation of headers throughout the code.

Fixes #111.

Tested:
unit + integration tests.