### PR TITLE
Format the report #178

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_header_io.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io.py
@@ -229,7 +229,7 @@ class ReadAllVcfHeaders(PTransform):
     return pvalue | 'ReadAllFiles' >> self._read_all_files
 
 
-class _HeaderTypeConstants(object):
+class HeaderTypeConstants(object):
   INFO = 'INFO'
   FILTER = 'FILTER'
   ALT = 'ALT'
@@ -259,11 +259,11 @@ class _WriteVcfHeaderFn(beam.DoFn):
 
   def process(self, header):
     with FileSystems.create(self._file_path) as self._file_to_write:
-      self._write_headers_by_type(_HeaderTypeConstants.INFO, header.infos)
-      self._write_headers_by_type(_HeaderTypeConstants.FILTER, header.filters)
-      self._write_headers_by_type(_HeaderTypeConstants.ALT, header.alts)
-      self._write_headers_by_type(_HeaderTypeConstants.FORMAT, header.formats)
-      self._write_headers_by_type(_HeaderTypeConstants.CONTIG, header.contigs)
+      self._write_headers_by_type(HeaderTypeConstants.INFO, header.infos)
+      self._write_headers_by_type(HeaderTypeConstants.FILTER, header.filters)
+      self._write_headers_by_type(HeaderTypeConstants.ALT, header.alts)
+      self._write_headers_by_type(HeaderTypeConstants.FORMAT, header.formats)
+      self._write_headers_by_type(HeaderTypeConstants.CONTIG, header.contigs)
       self._file_to_write.write(self.FINAL_HEADER_LINE)
 
   def _write_headers_by_type(self, header_type, headers):

--- a/gcp_variant_transforms/libs/preprocess_reporter.py
+++ b/gcp_variant_transforms/libs/preprocess_reporter.py
@@ -27,7 +27,6 @@ resource estimation.
 from typing import Dict, List, Union  # pylint: disable=unused-import
 
 from apache_beam.io.filesystems import FileSystems
-from apache_beam import pvalue
 
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.beam_io.vcf_header_io import VcfHeader  # pylint: disable=unused-import
@@ -69,11 +68,10 @@ def generate_report(header_definitions,
   content_lines.extend(_generate_conflicting_headers_lines(
       _extract_conflicts(header_definitions.formats), resolved_headers.formats,
       vcf_header_io.HeaderTypeConstants.FORMAT))
-  if not isinstance(inferred_headers, pvalue.EmptySideInput):
-    content_lines.extend(_generate_inferred_headers_lines(
-        inferred_headers.infos, vcf_header_io.HeaderTypeConstants.INFO))
-    content_lines.extend(_generate_inferred_headers_lines(
-        inferred_headers.formats, vcf_header_io.HeaderTypeConstants.FORMAT))
+  content_lines.extend(_generate_inferred_headers_lines(
+      inferred_headers.infos, vcf_header_io.HeaderTypeConstants.INFO))
+  content_lines.extend(_generate_inferred_headers_lines(
+      inferred_headers.formats, vcf_header_io.HeaderTypeConstants.FORMAT))
   _write_to_report(content_lines, file_path)
 
 
@@ -99,18 +97,14 @@ def _generate_conflicting_headers_lines(
   # type: (...) -> List[str]
   """Returns the conflicting headers lines for the report.
 
-  To better align contents in the report so that it can be viewed easily, for
-  every unique ID, generate several rows with the following steps.
-  - Step 1: The first row starts with The ID, the category('FOMRAT' or 'INFO'),
-    one conflicting definition, one file name and the resolution, separated by
-    the ``_DELIMITER ``.
-  - Step 2: If there there are more files having the same definition as the
-    previous step, list each file path in one separate row by filling all other
-    columns using ``_PADDING_CHARACTER``, separated by the ``_DELIMITER ``.
-  - Step 3: If there are more conflicting definitions, generate a new row with
-    one conflicting definition, one file path, and fill the ID, the category and
-    the resolution with `_PADDING_CHARACTER``, separated by the ``_DELIMITER ``.
-  - Repeat step 2 and step 3 until there are no more conflicts.
+  Each conflicting header record is structured into columns(TAB separated
+  values): the ID, the category('FOMRAT' or 'INFO'), conflicting definitions,
+  file names and the resolution. To make the contents more readable (especially
+  the file names can be extremely long and there can be at most 5 of them), the
+  conflicting definitions and the file names are split in the continuous rows
+  such that each row/cell only contains one definition/file name. While
+  splitting, the empty cells are filled by ``_PADDING_CHARACTER`` as a
+  placeholder so it can be easily viewed in both text editor and spreadsheets.
   Output example:
   DP\tFORMAT\tnum=1 type=Float\tfile1\tnum=1 type=Float
    \t \t \tfile2\t

--- a/gcp_variant_transforms/transforms/infer_undefined_headers.py
+++ b/gcp_variant_transforms/transforms/infer_undefined_headers.py
@@ -138,8 +138,7 @@ class _InferUndefinedHeaderFields(beam.DoFn):
     """
     infos = self._infer_undefined_info_fields(variant, defined_headers)
     formats = self._infer_undefined_format_fields(variant, defined_headers)
-    if infos or formats:
-      yield vcf_header_io.VcfHeader(infos=infos, formats=formats)
+    yield vcf_header_io.VcfHeader(infos=infos, formats=formats)
 
 
 class InferUndefinedHeaderFields(beam.PTransform):

--- a/gcp_variant_transforms/transforms/infer_undefined_headers_test.py
+++ b/gcp_variant_transforms/transforms/infer_undefined_headers_test.py
@@ -117,8 +117,8 @@ class InferUndefinedHeaderFieldsTest(unittest.TestCase):
           | 'InferUndefinedHeaderFields' >>
           infer_undefined_headers.InferUndefinedHeaderFields(
               pvalue.AsSingleton(vcf_headers_side_input)))
-
-      assert_that(inferred_headers, equal_to([]))
+      expected = vcf_header_io.VcfHeader()
+      assert_that(inferred_headers, equal_to([expected]))
       p.run()
 
   def test_header_fields_inferred_from_two_variants(self):

--- a/gcp_variant_transforms/transforms/merge_header_definitions.py
+++ b/gcp_variant_transforms/transforms/merge_header_definitions.py
@@ -91,7 +91,7 @@ class _DefinitionsMerger(object):
     for key, definitions_to_files_map in second.iteritems():
       for definition, file_names in definitions_to_files_map.iteritems():
         first[key].setdefault(definition, [])
-        first[key][definition].extend(file_names)
+        first[key][definition].extend(str(s) for s in file_names)
         first[key][definition] = (
             first[key][definition][:self._MAX_NUM_FILE_NAMES])
 

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -53,7 +53,7 @@ import apache_beam as beam
 from apache_beam.options import pipeline_options
 
 from gcp_variant_transforms import vcf_to_bq_common
-from gcp_variant_transforms.libs import conflicts_reporter
+from gcp_variant_transforms.libs import preprocess_reporter
 from gcp_variant_transforms.options import variant_transform_options
 from gcp_variant_transforms.transforms import merge_headers
 from gcp_variant_transforms.transforms import merge_header_definitions
@@ -103,7 +103,7 @@ def run(argv=None):
 
     _ = (merged_definitions
          | 'GenerateConflictsReport' >>
-         beam.ParDo(conflicts_reporter.generate_conflicts_report,
+         beam.ParDo(preprocess_reporter.generate_report,
                     known_args.report_path,
                     beam.pvalue.AsSingleton(merged_headers),
                     inferred_headers_side_input))

--- a/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
@@ -22,7 +22,7 @@ from gcp_variant_transforms.testing import temp_dir
 
 
 class PreprocessTest(unittest.TestCase):
-  _REPORT_NAME = 'header_conflicts_report.csv'
+  _REPORT_NAME = 'report.tsv'
   _RESOLVED_HEADERS_FILE_NAME = 'resolved_headers.vcf'
 
   def test_preprocess_run_locally(self):
@@ -44,3 +44,17 @@ class PreprocessTest(unittest.TestCase):
       vcf_to_bq_preprocess.run(argv)
       assert filesystems.FileSystems.exists(report_path)
       assert filesystems.FileSystems.exists(resolved_headers_path)
+
+  def test_preprocess_no_conflicts(self):
+    with temp_dir.TempDir() as tempdir:
+      report_path = filesystems.FileSystems.join(tempdir.get_path(),
+                                                 PreprocessTest._REPORT_NAME)
+      argv = [
+          '--input_pattern',
+          'gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf',
+          '--report_path',
+          report_path,
+          '--report_all'
+      ]
+      vcf_to_bq_preprocess.run(argv)
+      assert filesystems.FileSystems.exists(report_path)


### PR DESCRIPTION
The Report generated in the preprocessor is not easy to read. This pull request add some logic to format the report.

- Tested: Unit tests
- Issue: [178](https://github.com/googlegenomics/gcp-variant-transforms/issues/178)