### PR TITLE
Fixing Build Breakage

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,9 @@ FROM google/cloud-sdk
 RUN mkdir -p /opt/gcp_variant_transforms/bin && mkdir -p /opt/gcp_variant_transforms/src
 ADD / /opt/gcp_variant_transforms/src/
 
+# Needed for installing mmh3 (one of the required packages in setup.py).
+RUN apt install -y g++
+
 # Install dependencies.
 RUN pip install --upgrade pip && pip install --upgrade virtualenv && \
     virtualenv /opt/gcp_variant_transforms/venv && \


### PR DESCRIPTION
Failure was caused by the mmh3 install in the docker image which was originally added in the
following commit:
https://github.com/googlegenomics/gcp-variant-transforms/commit/d79f0b798b56a456adc78b33aef604c1ee04aa8b

Search for the error message "x86_64-linux-gnu-gcc: error trying to exec 'cc1plus': execvp: No such file or directory" I found this solution, not 100% clear why it works.