### PR TITLE
Add malformed records to the report

### DIFF
--- a/docs/vcf_files_preprocessor.md
+++ b/docs/vcf_files_preprocessor.md
@@ -52,7 +52,7 @@ are:
   Google Cloud Storage that your project has write access to. These are used to
   store temporary files needed for running the pipeline.
 
-`report_all` is optional. By default, the preprocessor reports the inconsistent
+`report_all_conflicts` is optional. By default, the preprocessor reports the inconsistent
 header definitions across multiple VCF files. By setting this parameter to true,
 it also checks the undefined headers and the malformed records.
 
@@ -66,7 +66,7 @@ docker:
       --input_pattern gs://my_bucket/vcffiles/*.vcf \
       --report_path gs://my_bucket/preprocess/report.tsv \
       --resolved_headers_path gs://my_bucket/preprocess/headers.vcf \
-      --report_all true \
+      --report_all_conflicts true \
       --staging_location gs://my_bucket/staging \
       --temp_location gs://my_bucket/temp \
       --job_name vcf-to-bigquery-preprocess \
@@ -97,7 +97,7 @@ python -m gcp_variant_transforms.vcf_to_bq_preprocess \
   --input_pattern gcp_variant_transforms/testing/data/vcf/valid-4.0.vcf \
   --report_path gs://my_bucket/preprocess/report.tsv
   --resolved_headers_path gs://my_bucket/preprocess/headers.vcf \
-  --report_all true
+  --report_all_conflicts true
 ```
 
 Example command for DataflowRunner:
@@ -107,7 +107,7 @@ python -m gcp_variant_transforms.vcf_to_bq_preprocess \
   --input_pattern gs://my_bucket/vcffiles/*.vcf \
   --report_path gs://my_bucket/preprocess/report.tsv \
   --resolved_headers_path gs://my_bucket/preprocess/headers.vcf \
-  --report_all true \
+  --report_all_conflicts true \
   --project my_project \
   --staging_location gs://my_bucket/staging \
   --temp_location gs://my_bucket/temp \

--- a/gcp_variant_transforms/libs/preprocess_reporter.py
+++ b/gcp_variant_transforms/libs/preprocess_reporter.py
@@ -27,6 +27,7 @@ resource estimation.
 from typing import Dict, List, Union  # pylint: disable=unused-import
 
 from apache_beam.io.filesystems import FileSystems
+from apache_beam import pvalue
 
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.beam_io.vcf_header_io import VcfHeader  # pylint: disable=unused-import
@@ -68,10 +69,18 @@ def generate_report(header_definitions,
   content_lines.extend(_generate_conflicting_headers_lines(
       _extract_conflicts(header_definitions.formats), resolved_headers.formats,
       vcf_header_io.HeaderTypeConstants.FORMAT))
+<<<<<<< HEAD:gcp_variant_transforms/libs/preprocess_reporter.py
   content_lines.extend(_generate_inferred_headers_lines(
       inferred_headers.infos, vcf_header_io.HeaderTypeConstants.INFO))
   content_lines.extend(_generate_inferred_headers_lines(
       inferred_headers.formats, vcf_header_io.HeaderTypeConstants.FORMAT))
+=======
+  if not isinstance(inferred_headers, pvalue.EmptySideInput):
+    content_lines.extend(_generate_inferred_headers_lines(
+        inferred_headers.infos, vcf_header_io.HeaderTypeConstants.INFO))
+    content_lines.extend(_generate_inferred_headers_lines(
+        inferred_headers.formats, vcf_header_io.HeaderTypeConstants.FORMAT))
+>>>>>>> Format the report:gcp_variant_transforms/libs/preprocess_reporter.py
   _write_to_report(content_lines, file_path)
 
 
@@ -97,6 +106,7 @@ def _generate_conflicting_headers_lines(
   # type: (...) -> List[str]
   """Returns the conflicting headers lines for the report.
 
+<<<<<<< HEAD:gcp_variant_transforms/libs/preprocess_reporter.py
   Each conflicting header record is structured into columns(TAB separated
   values): the ID, the category('FOMRAT' or 'INFO'), conflicting definitions,
   file names and the resolution. To make the contents more readable (especially
@@ -105,6 +115,20 @@ def _generate_conflicting_headers_lines(
   such that each row/cell only contains one definition/file name. While
   splitting, the empty cells are filled by ``_PADDING_CHARACTER`` as a
   placeholder so it can be easily viewed in both text editor and spreadsheets.
+=======
+  To better align contents in the report so that it can be viewed easily, for
+  every unique ID, generate several rows with the following steps.
+  - Step 1: The first row starts with The ID, the category('FOMRAT' or 'INFO'),
+    one conflicting definition, one file name and the resolution, separated by
+    the ``_DELIMITER ``.
+  - Step 2: If there there are more files having the same definition as the
+    previous step, list each file path in one separate row by filling all other
+    columns using ``_PADDING_CHARACTER``, separated by the ``_DELIMITER ``.
+  - Step 3: If there are more conflicting definitions, generate a new row with
+    one conflicting definition, one file path, and fill the ID, the category and
+    the resolution with `_PADDING_CHARACTER``, separated by the ``_DELIMITER ``.
+  - Repeat step 2 and step 3 until there are no more conflicts.
+>>>>>>> Format the report:gcp_variant_transforms/libs/preprocess_reporter.py
   Output example:
   DP\tFORMAT\tnum=1 type=Float\tfile1\tnum=1 type=Float
    \t \t \tfile2\t

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -368,3 +368,9 @@ class PreprocessOptions(VariantTransformsOptions):
         help=('The full path of the resolved headers. The file will not be'
               'generated if unspecified. Otherwise, please provide a local '
               'path if run locally, or a cloud path if run on Dataflow.'))
+    parser.add_argument(
+        '--optimize_for_large_inputs',
+        type='bool', default=False, nargs='?', const=True,
+        help=('If true, the pipeline runs in optimized way for handling large '
+              'inputs. Set this to true if you are loading more than 50,000 '
+              'files.'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -372,5 +372,4 @@ class PreprocessOptions(VariantTransformsOptions):
         '--optimize_for_large_inputs',
         type='bool', default=False, nargs='?', const=True,
         help=('If true, the pipeline runs in optimized way for handling large '
-              'inputs. Set this to true if you are loading more than 50,000 '
-              'files.'))
+              'inputs.'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -345,8 +345,11 @@ class PreprocessOptions(VariantTransformsOptions):
   """Options for preprocess."""
 
   def add_arguments(self, parser):
+    parser.add_argument('--input_pattern',
+                        required=True,
+                        help='Input pattern for VCF files to process.')
     parser.add_argument(
-        '--report_all',
+        '--report_all_conflicts',
         type='bool', default=False, nargs='?', const=True,
         help=('By default, only the incompatible VCF headers will be reported. '
               'If true, it also reports the undefined headers and malformed '
@@ -356,7 +359,9 @@ class PreprocessOptions(VariantTransformsOptions):
         required=True,
         help=('The full path of the preprocessor report. If run locally, a '
               'local path must be provided. Otherwise, a cloud path is '
-              'required.'))
+              'required. For best readability, please save the report as a tab '
+              'delimited file (by appending the extension .tsv to the file '
+              'name) and open with the spreadsheets.'))
     parser.add_argument(
         '--resolved_headers_path',
         default='',

--- a/gcp_variant_transforms/transforms/filter_variants.py
+++ b/gcp_variant_transforms/transforms/filter_variants.py
@@ -16,13 +16,12 @@
 
 from __future__ import absolute_import
 
+from typing import Iterable  # pylint: disable=unused-import
 import logging
 
 import apache_beam as beam
 
 from gcp_variant_transforms.beam_io import vcfio
-
-__all__ = ['FilterVariants']
 
 
 class FilterVariants(beam.PTransform):
@@ -61,3 +60,15 @@ class FilterVariants(beam.PTransform):
 
   def expand(self, pcoll):
     return pcoll | 'ApplyFilters' >> beam.ParDo(self._apply_filters)
+
+
+class ExtractMalformedVariants(beam.PTransform):
+  """Extracts malformed variants from all variants."""
+
+  def _apply_filters(self, variant):
+    # type: (vcfio.Variant) -> Iterable[vcfio.Variant]
+    if isinstance(variant, vcfio.MalformedVcfRecord):
+      yield variant
+
+  def expand(self, pcoll):
+    return pcoll | 'ExtractMalformedVariants' >> beam.ParDo(self._apply_filters)

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -46,6 +46,7 @@ from apache_beam.io import filesystems
 from apache_beam.options import pipeline_options
 
 from gcp_variant_transforms import vcf_to_bq_common
+from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import metrics_util
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_header_parser
@@ -56,6 +57,7 @@ from gcp_variant_transforms.libs.variant_merge import move_to_calls_strategy
 from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy  # pylint: disable=unused-import
 from gcp_variant_transforms.options import variant_transform_options
 from gcp_variant_transforms.transforms import filter_variants
+from gcp_variant_transforms.transforms import infer_undefined_headers
 from gcp_variant_transforms.transforms import merge_headers
 from gcp_variant_transforms.transforms import merge_variants
 from gcp_variant_transforms.transforms import partition_variants
@@ -71,6 +73,29 @@ _COMMAND_LINE_OPTIONS = [
 
 _MERGE_HEADERS_FILE_NAME = 'merged_headers.vcf'
 _MERGE_HEADERS_JOB_NAME = 'merge-vcf-headers'
+
+
+def _read_variants(pipeline, known_args):
+  # type: (beam.Pipeline, argparse.Namespace) -> pvalue.PCollection
+  """Helper method for returning a PCollection of Variants from VCFs."""
+  representative_header_lines = None
+  if known_args.representative_header_file:
+    representative_header_lines = vcf_header_parser.get_metadata_header_lines(
+        known_args.representative_header_file)
+
+  if known_args.optimize_for_large_inputs:
+    variants = (pipeline
+                | 'InputFilePattern' >> beam.Create([known_args.input_pattern])
+                | 'ReadAllFromVcf' >> vcfio.ReadAllFromVcf(
+                    representative_header_lines=representative_header_lines,
+                    allow_malformed_records=(
+                        known_args.allow_malformed_records)))
+  else:
+    variants = pipeline | 'ReadFromVcf' >> vcfio.ReadFromVcf(
+        known_args.input_pattern,
+        representative_header_lines=representative_header_lines,
+        allow_malformed_records=known_args.allow_malformed_records)
+  return variants
 
 
 def _get_variant_merge_strategy(known_args  # type: argparse.Namespace
@@ -100,8 +125,13 @@ def _add_inferred_headers(pipeline,  # type: beam.Pipeline
                           merged_header  # type: pvalue.PCollection
                          ):
   # type: (...) -> pvalue.PCollection
-  inferred_headers = vcf_to_bq_common.get_inferred_headers(pipeline, known_args,
-                                                           merged_header)
+  inferred_headers = (
+      _read_variants(pipeline, known_args)
+      | 'FilterVariants' >> filter_variants.FilterVariants(
+          reference_names=known_args.reference_names)
+      | ' InferUndefinedHeaderFields' >>
+      infer_undefined_headers.InferUndefinedHeaderFields(
+          pvalue.AsSingleton(merged_header)))
   merged_header = (
       (inferred_headers, merged_header)
       | beam.Flatten()
@@ -151,6 +181,7 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
     vcf_to_bq_common.write_headers(merged_header, temp_merged_headers_file_path)
     known_args.representative_header_file = temp_merged_headers_file_path
 
+
 def run(argv=None):
   # type: (List[str]) -> None
   """Runs VCF to BigQuery pipeline."""
@@ -189,7 +220,7 @@ def run(argv=None):
   partitioner = variant_partition.VariantPartition()
   beam_pipeline_options = pipeline_options.PipelineOptions(pipeline_args)
   pipeline = beam.Pipeline(options=beam_pipeline_options)
-  variants = vcf_to_bq_common.read_variants(pipeline, known_args)
+  variants = _read_variants(pipeline, known_args)
   variants |= 'FilterVariants' >> filter_variants.FilterVariants(
       reference_names=known_args.reference_names)
   if variant_merger:

--- a/gcp_variant_transforms/vcf_to_bq_common.py
+++ b/gcp_variant_transforms/vcf_to_bq_common.py
@@ -23,14 +23,10 @@ import argparse
 import enum
 
 import apache_beam as beam
-from apache_beam import pvalue
+from apache_beam import pvalue  # pylint: disable=unused-import
 from apache_beam.io import filesystems
 
-from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.beam_io import vcf_header_io
-from gcp_variant_transforms.libs import vcf_header_parser
-from gcp_variant_transforms.transforms import filter_variants
-from gcp_variant_transforms.transforms import infer_undefined_headers
 from gcp_variant_transforms.transforms import merge_headers
 
 # If the # of files matching the input file_pattern exceeds this value, then
@@ -83,42 +79,6 @@ def get_pipeline_mode(known_args):
   elif total_files > _SMALL_DATA_THRESHOLD:
     return PipelineModes.MEDIUM
   return PipelineModes.SMALL
-
-def read_variants(pipeline, known_args):
-  # type: (beam.Pipeline, argparse.Namespace) -> pvalue.PCollection
-  """Helper method for returning a PCollection of Variants from VCFs."""
-  representative_header_lines = None
-  if known_args.representative_header_file:
-    representative_header_lines = vcf_header_parser.get_metadata_header_lines(
-        known_args.representative_header_file)
-
-  if known_args.optimize_for_large_inputs:
-    variants = (pipeline
-                | 'InputFilePattern' >> beam.Create([known_args.input_pattern])
-                | 'ReadAllFromVcf' >> vcfio.ReadAllFromVcf(
-                    representative_header_lines=representative_header_lines,
-                    allow_malformed_records=(
-                        known_args.allow_malformed_records)))
-  else:
-    variants = pipeline | 'ReadFromVcf' >> vcfio.ReadFromVcf(
-        known_args.input_pattern,
-        representative_header_lines=representative_header_lines,
-        allow_malformed_records=known_args.allow_malformed_records)
-  return variants
-
-
-def get_inferred_headers(pipeline,  # type: beam.Pipeline
-                         known_args,  # type: argparse.Namespace
-                         merged_header  # type: pvalue.PCollection
-                        ):
-  # type: (...) -> pvalue.PCollection
-  """Infers the missing headers."""
-  return (read_variants(pipeline, known_args)
-          | 'FilterVariants' >> filter_variants.FilterVariants(
-              reference_names=known_args.reference_names)
-          | ' InferUndefinedHeaderFields' >>
-          infer_undefined_headers.InferUndefinedHeaderFields(
-              pvalue.AsSingleton(merged_header)))
 
 
 def read_headers(pipeline, pipeline_mode, known_args):

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -91,7 +91,7 @@ def run(argv=None):
   known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
                                                           _COMMAND_LINE_OPTIONS)
   options = pipeline_options.PipelineOptions(pipeline_args)
-  pipeline_mode = vcf_to_bq_common.PipelineModes.MEDIUM
+  pipeline_mode = vcf_to_bq_common.get_pipeline_mode(known_args)
 
   with beam.Pipeline(options=options) as p:
     headers = vcf_to_bq_common.read_headers(p, pipeline_mode, known_args)

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -17,8 +17,8 @@ r"""Pipeline for preprocessing the VCF files.
 This pipeline is aimed to help the user to easily identify and further import
 the malformed/incompatible VCF files to BigQuery. It generates two files as the
 output:
-- Conflicts report: A file that lists the incompatible headers, undefined header
-  fields, the suggested resolutions and eventually malformed records.
+- Report: A file that lists the conflicting headers, undefined header fields,
+  the suggested resolutions and malformed records.
 - Resolved headers file: A VCF file that contains the resolved fields
   definitions.
 
@@ -30,14 +30,14 @@ python -m gcp_variant_transforms.vcf_to_bq_preprocess \
   --input_pattern <path to VCF file(s)> \
   --report_path <local path to the report file> \
   --resolved_headers_path <local path to the resolved headers file> \
-  --report_all True
+  --report_all_conflicts True
 
 Run on Dataflow:
 python -m gcp_variant_transforms.vcf_to_bq_preprocess \
   --input_pattern <path to VCF file(s)>
   --report_path <cloud path to the report file> \
   --resolved_headers_path <cloud path to the resolved headers file> \
-  --report_all True \
+  --report_all_conflicts True \
   --project gcp-variant-transforms-test \
   --job_name preprocess \
   --staging_location "gs://integration_test_runs/staging" \
@@ -46,32 +46,36 @@ python -m gcp_variant_transforms.vcf_to_bq_preprocess \
   --setup_file ./setup.py
 """
 
+from __future__ import absolute_import
+
 import logging
 import sys
 
 import apache_beam as beam
+from apache_beam import pvalue
 from apache_beam.options import pipeline_options
 
 from gcp_variant_transforms import vcf_to_bq_common
+from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import preprocess_reporter
 from gcp_variant_transforms.options import variant_transform_options
+from gcp_variant_transforms.transforms import filter_variants
+from gcp_variant_transforms.transforms import infer_undefined_headers
 from gcp_variant_transforms.transforms import merge_headers
 from gcp_variant_transforms.transforms import merge_header_definitions
 
-_COMMAND_LINE_OPTIONS = [
-    variant_transform_options.FilterOptions,
-    variant_transform_options.PreprocessOptions,
-    variant_transform_options.VcfReadOptions
-]
+_COMMAND_LINE_OPTIONS = [variant_transform_options.PreprocessOptions]
 
 
-def _get_inferred_headers(pipeline,  # type: beam.Pipeline
-                          known_args,  # type: argparse.Namespace
+def _get_inferred_headers(variants,  # type: pvalue.PCollection
                           merged_header  # type: pvalue.PCollection
                          ):
   # type: (...) -> (pvalue.PCollection, pvalue.PCollection)
-  inferred_headers = vcf_to_bq_common.get_inferred_headers(pipeline, known_args,
-                                                           merged_header)
+  inferred_headers = (variants
+                      | 'FilterVariants' >> filter_variants.FilterVariants()
+                      | ' InferUndefinedHeaderFields' >>
+                      infer_undefined_headers.InferUndefinedHeaderFields(
+                          pvalue.AsSingleton(merged_header)))
   merged_header = (
       (inferred_headers, merged_header)
       | beam.Flatten()
@@ -87,7 +91,7 @@ def run(argv=None):
   known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
                                                           _COMMAND_LINE_OPTIONS)
   options = pipeline_options.PipelineOptions(pipeline_args)
-  pipeline_mode = vcf_to_bq_common.get_pipeline_mode(known_args)
+  pipeline_mode = vcf_to_bq_common.PipelineModes.MEDIUM
 
   with beam.Pipeline(options=options) as p:
     headers = vcf_to_bq_common.read_headers(p, pipeline_mode, known_args)
@@ -95,18 +99,26 @@ def run(argv=None):
     merged_definitions = (headers
                           | 'MergeDefinitions' >>
                           merge_header_definitions.MergeDefinitions())
-    inferred_headers_side_input = None
-    if known_args.report_all:
-      inferred_headers, merged_headers = _get_inferred_headers(
-          p, known_args, merged_headers)
-      inferred_headers_side_input = beam.pvalue.AsSingleton(inferred_headers)
+    if known_args.report_all_conflicts:
+      variants = p | 'ReadFromVcf' >> vcfio.ReadFromVcf(
+          known_args.input_pattern, allow_malformed_records=True)
+      malformed_records = variants | filter_variants.ExtractMalformedVariants()
+      inferred_headers, merged_headers = (_get_inferred_headers(variants,
+                                                                merged_headers))
+      _ = (merged_definitions
+           | 'GenerateConflictsReport' >>
+           beam.ParDo(preprocess_reporter.generate_report,
+                      known_args.report_path,
+                      beam.pvalue.AsSingleton(merged_headers),
+                      beam.pvalue.AsSingleton(inferred_headers),
+                      beam.pvalue.AsIter(malformed_records)))
+    else:
+      _ = (merged_definitions
+           | 'GenerateConflictsReport' >>
+           beam.ParDo(preprocess_reporter.generate_report,
+                      known_args.report_path,
+                      beam.pvalue.AsSingleton(merged_headers)))
 
-    _ = (merged_definitions
-         | 'GenerateConflictsReport' >>
-         beam.ParDo(preprocess_reporter.generate_report,
-                    known_args.report_path,
-                    beam.pvalue.AsSingleton(merged_headers),
-                    inferred_headers_side_input))
     if known_args.resolved_headers_path:
       vcf_to_bq_common.write_headers(merged_headers,
                                      known_args.resolved_headers_path)

--- a/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess_test.py
@@ -35,7 +35,7 @@ class PreprocessTest(unittest.TestCase):
           '--input_pattern',
           'gs://gcp-variant-transforms-testfiles/small_tests/infer-undefined'
           '-header-fields.vcf',
-          '--report_all',
+          '--report_all_conflicts',
           '--report_path',
           report_path,
           '--resolved_headers_path',
@@ -54,7 +54,22 @@ class PreprocessTest(unittest.TestCase):
           'gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf',
           '--report_path',
           report_path,
-          '--report_all'
+          '--report_all_conflicts'
+      ]
+      vcf_to_bq_preprocess.run(argv)
+      assert filesystems.FileSystems.exists(report_path)
+
+  def test_preprocess_malformed_records(self):
+    with temp_dir.TempDir() as tempdir:
+      report_path = filesystems.FileSystems.join(tempdir.get_path(),
+                                                 PreprocessTest._REPORT_NAME)
+      argv = [
+          '--input_pattern',
+          'gs://gcp-variant-transforms-testfiles/small_tests/invalid-4.0-POS'
+          '-empty.vcf',
+          '--report_path',
+          report_path,
+          '--report_all_conflicts'
       ]
       vcf_to_bq_preprocess.run(argv)
       assert filesystems.FileSystems.exists(report_path)


### PR DESCRIPTION
Add the malformed records when parsing the VCF files to the report.

Tested: Unit tests.
Issue: [178](https://github.com/googlegenomics/gcp-variant-transforms/issues/178)