### PR TITLE
Another hack to avoid BigQuery write failure

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options_test.py
+++ b/gcp_variant_transforms/options/variant_transform_options_test.py
@@ -28,6 +28,15 @@ from apitools.base.py import exceptions
 from gcp_variant_transforms.options import variant_transform_options
 
 
+def make_args(options, args):
+  parser = argparse.ArgumentParser()
+  parser.register('type', 'bool', lambda v: v.lower() == 'true')
+  options.add_arguments(parser)
+  namespace, remining_args = parser.parse_known_args(args)
+  assert not remining_args
+  return namespace
+
+
 class BigQueryWriteOptionsTest(unittest.TestCase):
   """Tests cases for the BigQueryWriteOptions class."""
 
@@ -36,12 +45,7 @@ class BigQueryWriteOptionsTest(unittest.TestCase):
 
   def _make_args(self, args):
     # type: (List[str]) -> argparse.Namespace
-    parser = argparse.ArgumentParser()
-    parser.register('type', 'bool', lambda v: v.lower() == 'true')
-    self._options.add_arguments(parser)
-    namespace, remining_args = parser.parse_known_args(args)
-    assert not remining_args
-    return namespace
+    return make_args(self._options, args)
 
   def test_valid_table_path(self):
     args = self._make_args(['--append',
@@ -92,12 +96,7 @@ class AnnotationOptionsTest(unittest.TestCase):
 
   def _make_args(self, args):
     # type: (List[str]) -> argparse.Namespace
-    parser = argparse.ArgumentParser()
-    parser.register('type', 'bool', lambda v: v.lower() == 'true')
-    self._options.add_arguments(parser)
-    namespace, remining_args = parser.parse_known_args(args)
-    assert not remining_args
-    return namespace
+    return make_args(self._options, args)
 
   def test_validate_okay(self):
     """Tests that no exceptions are raised for valid arguments."""

--- a/gcp_variant_transforms/options/variant_transform_options_test.py
+++ b/gcp_variant_transforms/options/variant_transform_options_test.py
@@ -17,7 +17,6 @@
 import unittest
 
 import argparse
-import collections
 
 from typing import List  # pylint: disable=unused-import
 
@@ -29,43 +28,61 @@ from apitools.base.py import exceptions
 from gcp_variant_transforms.options import variant_transform_options
 
 
-BigQueryArgs = collections.namedtuple('BigQueryArgs', ['output_table'])
-
-
 class BigQueryWriteOptionsTest(unittest.TestCase):
   """Tests cases for the BigQueryWriteOptions class."""
 
   def setUp(self):
-    self.options = variant_transform_options.BigQueryWriteOptions()
+    self._options = variant_transform_options.BigQueryWriteOptions()
+
+  def _make_args(self, args):
+    # type: (List[str]) -> argparse.Namespace
+    parser = argparse.ArgumentParser()
+    parser.register('type', 'bool', lambda v: v.lower() == 'true')
+    self._options.add_arguments(parser)
+    namespace, remining_args = parser.parse_known_args(args)
+    assert not remining_args
+    return namespace
 
   def test_valid_table_path(self):
-    args = BigQueryArgs('project:dataset.table')
+    args = self._make_args(['--append',
+                            '--output_table', 'project:dataset.table'])
     client = mock.Mock()
     client.datasets.Get.return_value = bigquery.Dataset(
         datasetReference=bigquery.DatasetReference(
             projectId='project', datasetId='dataset'))
-    self.options.validate(args, client)
+    self._options.validate(args, client)
+
+  def test_existing_table(self):
+    args = self._make_args(['--append', 'False',
+                            '--output_table', 'project:dataset.table'])
+    client = mock.Mock()
+    self.assertRaises(ValueError, self._options.validate, args, client)
 
   def test_no_project(self):
-    args = BigQueryArgs('dataset.table')
+    args = self._make_args(['--output_table', 'dataset.table'])
     client = mock.Mock()
-    self.assertRaises(ValueError, self.options.validate, args, client)
+    self.assertRaises(ValueError, self._options.validate, args, client)
 
   def test_invalid_table_path(self):
-    no_table = BigQueryArgs('project:dataset')
-    incorrect_sep1 = BigQueryArgs('project.dataset.table')
-    incorrect_sep2 = BigQueryArgs('project:dataset:table')
+    no_table = self._make_args(['--output_table', 'project:dataset'])
+    incorrect_sep1 = self._make_args(['--output_table',
+                                      'project.dataset.table'])
+    incorrect_sep2 = self._make_args(['--output_table',
+                                      'project:dataset:table'])
     client = mock.Mock()
-    self.assertRaises(ValueError, self.options.validate, no_table, client)
-    self.assertRaises(ValueError, self.options.validate, incorrect_sep1, client)
-    self.assertRaises(ValueError, self.options.validate, incorrect_sep2, client)
+    self.assertRaises(
+        ValueError, self._options.validate, no_table, client)
+    self.assertRaises(
+        ValueError, self._options.validate, incorrect_sep1, client)
+    self.assertRaises(
+        ValueError, self._options.validate, incorrect_sep2, client)
 
   def test_dataset_does_not_exists(self):
-    args = BigQueryArgs('project:dataset.table')
+    args = self._make_args(['--output_table', 'project:dataset.table'])
     client = mock.Mock()
     client.datasets.Get.side_effect = exceptions.HttpError(
         response={'status': '404'}, url='', content='')
-    self.assertRaises(ValueError, self.options.validate, args, client)
+    self.assertRaises(ValueError, self._options.validate, args, client)
 
 
 class AnnotationOptionsTest(unittest.TestCase):

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -29,15 +29,12 @@ from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy  # 
 from gcp_variant_transforms.transforms import limit_write
 
 
-# This has to be less than 10000.
 # TODO(samanvp): remove this hack when BQ custom sink is added to Python SDK,
 # see: https://issues.apache.org/jira/browse/BEAM-2801
+# This has to be less than 10000.
 _WRITE_SHARDS_LIMIT = 1000
-_NUM_RANDOM_PARTITIONS = 20
+_NUM_BQ_LIMITED_WRITE_PARTITIONS = 20
 
-
-def random_partition(unused_bq_row, num_partitions):
-  return random.randint(0, num_partitions - 1)
 
 @beam.typehints.with_input_types(processed_variant.ProcessedVariant)
 class _ConvertToBigQueryTableRow(beam.DoFn):
@@ -119,29 +116,34 @@ class VariantToBigQuery(beam.PTransform):
             self._allow_incompatible_records,
             self._omit_empty_sample_calls))
     if self._limited_write:
-      bq_row_partitions = bq_rows | beam.Partition(random_partition,
-                                                   _NUM_RANDOM_PARTITIONS)
+      # We split data into _NUM_BQ_LIMITED_WRITE_PARTITIONS random partitions
+      # and then write each part to final BQ by appending them together.
+      # Combined with LimitWrite transform, this will avoid the BQ failure.
+      bq_row_partitions = bq_rows | beam.Partition(
+          lambda _, n: random.randint(0, n - 1),
+          _NUM_BQ_LIMITED_WRITE_PARTITIONS)
       bq_writes = []
-      for i in range(_NUM_RANDOM_PARTITIONS):
+      for i in range(_NUM_BQ_LIMITED_WRITE_PARTITIONS):
         bq_rows = (bq_row_partitions[i] | 'LimitWrite' + str(i) >>
                    limit_write.LimitWrite(_WRITE_SHARDS_LIMIT))
-        bq_writes.append(bq_rows | 'WriteToBigQuery' + str(i) >>
-                         beam.io.Write(beam.io.BigQuerySink(
-                             self._output_table,
-                             schema=self._schema,
-                             create_disposition=(
-                                 beam.io.BigQueryDisposition.CREATE_IF_NEEDED),
-                             write_disposition=(
-                                 beam.io.BigQueryDisposition.WRITE_APPEND))))
-      return bq_writes
-    # If _limit_write == False we don't need any hack to avoid the BQ failure.
-    return (bq_rows
-            | 'WriteToBigQuery' >> beam.io.Write(beam.io.BigQuerySink(
+        bq_writes.append(
+            bq_rows | 'WriteToBigQuery' + str(i) >>
+            beam.io.Write(beam.io.BigQuerySink(
                 self._output_table,
                 schema=self._schema,
                 create_disposition=(
                     beam.io.BigQueryDisposition.CREATE_IF_NEEDED),
                 write_disposition=(
-                    beam.io.BigQueryDisposition.WRITE_APPEND
-                    if self._append
-                    else beam.io.BigQueryDisposition.WRITE_TRUNCATE))))
+                    beam.io.BigQueryDisposition.WRITE_APPEND))))
+      return bq_writes
+    else:
+      return (bq_rows
+              | 'WriteToBigQuery' >> beam.io.Write(beam.io.BigQuerySink(
+                  self._output_table,
+                  schema=self._schema,
+                  create_disposition=(
+                      beam.io.BigQueryDisposition.CREATE_IF_NEEDED),
+                  write_disposition=(
+                      beam.io.BigQueryDisposition.WRITE_APPEND
+                      if self._append
+                      else beam.io.BigQueryDisposition.WRITE_TRUNCATE))))

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -127,12 +127,12 @@ class VariantToBigQuery(beam.PTransform):
                    limit_write.LimitWrite(_WRITE_SHARDS_LIMIT))
         bq_writes.append(bq_rows | 'WriteToBigQuery' + str(i) >>
                          beam.io.Write(beam.io.BigQuerySink(
-                           self._output_table,
-                           schema=self._schema,
-                           create_disposition=(
-                             beam.io.BigQueryDisposition.CREATE_IF_NEEDED),
-                           write_disposition=(
-                             beam.io.BigQueryDisposition.WRITE_APPEND))))
+                             self._output_table,
+                             schema=self._schema,
+                             create_disposition=(
+                                 beam.io.BigQueryDisposition.CREATE_IF_NEEDED),
+                             write_disposition=(
+                                 beam.io.BigQueryDisposition.WRITE_APPEND))))
       return bq_writes
     # If _limit_write == False we don't need any hack to avoid the BQ failure.
     return (bq_rows

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -16,6 +16,7 @@
 
 from __future__ import absolute_import
 
+import random
 import apache_beam as beam
 
 from gcp_variant_transforms.beam_io import vcf_header_io  # pylint: disable=unused-import
@@ -31,7 +32,12 @@ from gcp_variant_transforms.transforms import limit_write
 # This has to be less than 10000.
 # TODO(samanvp): remove this hack when BQ custom sink is added to Python SDK,
 # see: https://issues.apache.org/jira/browse/BEAM-2801
-_WRITE_SHARDS_LIMIT = 4500
+_WRITE_SHARDS_LIMIT = 1000
+_NUM_RANDOM_PARTITIONS = 20
+
+
+def random_partition(unused_bq_row, num_partitions):
+  return random.randint(0, num_partitions - 1)
 
 @beam.typehints.with_input_types(processed_variant.ProcessedVariant)
 class _ConvertToBigQueryTableRow(beam.DoFn):
@@ -113,7 +119,22 @@ class VariantToBigQuery(beam.PTransform):
             self._allow_incompatible_records,
             self._omit_empty_sample_calls))
     if self._limited_write:
-      bq_rows |= 'LimitWrite' >> limit_write.LimitWrite(_WRITE_SHARDS_LIMIT)
+      bq_row_partitions = bq_rows | beam.Partition(random_partition,
+                                                   _NUM_RANDOM_PARTITIONS)
+      bq_writes = []
+      for i in range(_NUM_RANDOM_PARTITIONS):
+        bq_rows = (bq_row_partitions[i] | 'LimitWrite' + str(i) >>
+                   limit_write.LimitWrite(_WRITE_SHARDS_LIMIT))
+        bq_writes.append(bq_rows | 'WriteToBigQuery' + str(i) >>
+                         beam.io.Write(beam.io.BigQuerySink(
+                           self._output_table,
+                           schema=self._schema,
+                           create_disposition=(
+                             beam.io.BigQueryDisposition.CREATE_IF_NEEDED),
+                           write_disposition=(
+                             beam.io.BigQueryDisposition.WRITE_APPEND))))
+      return bq_writes
+    # If _limit_write == False we don't need any hack to avoid the BQ failure.
     return (bq_rows
             | 'WriteToBigQuery' >> beam.io.Write(beam.io.BigQuerySink(
                 self._output_table,


### PR DESCRIPTION
Following hack proposed in #197 (to fix #199) we still observed BQ write failures.
This is a second attempt to deal with this problem until a principled
solution by DataFlow team will be ready:
https://issues.apache.org/jira/browse/BEAM-2801