### PR TITLE
Making num of output splits an input flag

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -116,13 +116,14 @@ class BigQueryWriteOptions(VariantTransformsOptions):
         type='bool', default=False, nargs='?', const=True,
         help=("If true, samples that don't have a given call will be omitted."))
     parser.add_argument(
-        '--num_output_splits',
+        '--num_bigquery_write_shards',
         type=int, default=1,
-        help=('Before writing the final result to output BigQuery we split '
-              'data to avoid a known failure caused by a BigQuery sink. If set '
-              'to 1, the output will be written without splitting. We '
-              'recommend 20 for large outputs. if --optimize_for_large_inputs '
-              'is set then use 5 for this flag.'))
+        help=('Before writing the final result to output BigQuery, the data is '
+              'sharded to avoid a known failure for very large inputs (issue '
+              '#199). Setting this flag to 1 will avoid this extra sharding.'
+              'It is recommended to use 20 for loading large inputs without '
+              'merging. Use a smaller value (2 or 3) if both merging and '
+              'optimize_for_large_inputs are enabled.'))
 
   def validate(self, parsed_args, client=None):
     output_table_re_match = re.match(

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -115,6 +115,14 @@ class BigQueryWriteOptions(VariantTransformsOptions):
         '--omit_empty_sample_calls',
         type='bool', default=False, nargs='?', const=True,
         help=("If true, samples that don't have a given call will be omitted."))
+    parser.add_argument(
+        '--num_output_splits',
+        type=int, default=1,
+        help=('Before writing the final result to output BigQuery we split '
+              'data to avoid a known failure caused by a BigQuery sink. If set '
+              'to 1, the output will be written without splitting. We '
+              'recommend 20 for large outputs. if --optimize_for_large_inputs '
+              'is set then use 5 for this flag.'))
 
   def validate(self, parsed_args, client=None):
     output_table_re_match = re.match(

--- a/gcp_variant_transforms/testing/integration/huge_tests/test_1000_genomes.json
+++ b/gcp_variant_transforms/testing/integration/huge_tests/test_1000_genomes.json
@@ -8,6 +8,7 @@
   "worker_machine_type": "n1-standard-64",
   "max_num_workers": "64",
   "num_workers": "20",
+  "num_output_splits": "20",
   "assertion_configs": [
     {
       "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/huge_tests/test_1000_genomes.json
+++ b/gcp_variant_transforms/testing/integration/huge_tests/test_1000_genomes.json
@@ -8,7 +8,7 @@
   "worker_machine_type": "n1-standard-64",
   "max_num_workers": "64",
   "num_workers": "20",
-  "num_output_splits": "20",
+  "num_bigquery_write_shards": "20",
   "assertion_configs": [
     {
       "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
+++ b/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
@@ -8,6 +8,7 @@
   "worker_machine_type": "n1-standard-16",
   "max_num_workers": "20",
   "num_workers": "20",
+  "num_output_splits": "5",
   "assertion_configs": [
     {
       "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
+++ b/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
@@ -8,7 +8,7 @@
   "worker_machine_type": "n1-standard-16",
   "max_num_workers": "20",
   "num_workers": "20",
-  "num_output_splits": "5",
+  "num_bigquery_write_shards": "2",
   "assertion_configs": [
     {
       "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/platinum_no_merge.json
+++ b/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/platinum_no_merge.json
@@ -6,7 +6,7 @@
   "worker_machine_type": "n1-standard-16",
   "max_num_workers": "20",
   "num_workers": "20",
-  "num_output_splits": "20",
+  "num_bigquery_write_shards": "20",
   "assertion_configs": [
     {
       "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/platinum_no_merge.json
+++ b/gcp_variant_transforms/testing/integration/presubmit_tests/large_tests/platinum_no_merge.json
@@ -6,6 +6,7 @@
   "worker_machine_type": "n1-standard-16",
   "max_num_workers": "20",
   "num_workers": "20",
+  "num_output_splits": "20",
   "assertion_configs": [
     {
       "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -217,7 +217,7 @@ def run(argv=None):
            append=known_args.append,
            allow_incompatible_records=known_args.allow_incompatible_records,
            omit_empty_sample_calls=known_args.omit_empty_sample_calls,
-           limited_write=known_args.optimize_for_large_inputs))
+           num_output_splits=known_args.num_output_splits))
   result = pipeline.run()
   result.wait_until_finish()
 

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -217,7 +217,7 @@ def run(argv=None):
            append=known_args.append,
            allow_incompatible_records=known_args.allow_incompatible_records,
            omit_empty_sample_calls=known_args.omit_empty_sample_calls,
-           num_output_splits=known_args.num_output_splits))
+           num_bigquery_write_shards=known_args.num_bigquery_write_shards))
   result = pipeline.run()
   result.wait_until_finish()
 


### PR DESCRIPTION
Following the last PR attemping to fix the BQ sink bug  (to fix #199) :
https://github.com/googlegenomics/gcp-variant-transforms/pull/226

We realized when we have both partitioning before merge and partitioning
before write_to_bq, one of our integration test fails due to larger time
that DataFlow needs to bring up the pipeline.

In order to fix thie problem we added a new flag to make it possible:
1) To set the num of output splits dynamically (as opposed to default 20)
2) Make that option independent from optimize_for_large_inputs flag.

With this change it will be possible to partition before merge independently from partition before write.
