### PR TITLE
Remove `optimize_for_large_inputs` for preprocessor tool (Issue 178)

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -377,8 +377,3 @@ class PreprocessOptions(VariantTransformsOptions):
         help=('The full path of the resolved headers. The file will not be'
               'generated if unspecified. Otherwise, please provide a local '
               'path if run locally, or a cloud path if run on Dataflow.'))
-    parser.add_argument(
-        '--optimize_for_large_inputs',
-        type='bool', default=False, nargs='?', const=True,
-        help=('If true, the pipeline runs in optimized way for handling large '
-              'inputs.'))

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -197,7 +197,8 @@ def run(argv=None):
     logging.info('Using VEP processed files: %s', known_args.input_pattern)
 
   variant_merger = _get_variant_merge_strategy(known_args)
-  pipeline_mode = vcf_to_bq_common.get_pipeline_mode(known_args)
+  pipeline_mode = vcf_to_bq_common.get_pipeline_mode(
+      known_args.input_pattern, known_args.optimize_for_large_inputs)
 
   # Starts a pipeline to merge VCF headers in beam if the total files that
   # match the input pattern exceeds _SMALL_DATA_THRESHOLD

--- a/gcp_variant_transforms/vcf_to_bq_common.py
+++ b/gcp_variant_transforms/vcf_to_bq_common.py
@@ -62,16 +62,15 @@ def parse_args(argv, command_line_options):
   return known_args, pipeline_args
 
 
-def get_pipeline_mode(known_args):
-  # type: (argparse.Namespace) -> int
+def get_pipeline_mode(input_pattern, optimize_for_large_inputs=False):
+  # type: (str, bool) -> int
   """Returns the mode the pipeline should operate in based on input size."""
-  if known_args.optimize_for_large_inputs:
+  if optimize_for_large_inputs:
     return PipelineModes.LARGE
 
-  match_results = filesystems.FileSystems.match([known_args.input_pattern])
+  match_results = filesystems.FileSystems.match([input_pattern])
   if not match_results:
-    raise ValueError('No files matched input_pattern: {}'.format(
-        known_args.input_pattern))
+    raise ValueError('No files matched input_pattern: {}'.format(input_pattern))
 
   total_files = len(match_results[0].metadata_list)
   if total_files > _LARGE_DATA_THRESHOLD:

--- a/gcp_variant_transforms/vcf_to_bq_common_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_common_test.py
@@ -20,7 +20,7 @@ import unittest
 from apache_beam.io.filesystems import FileSystems
 import mock
 
-from gcp_variant_transforms.vcf_to_bq_common import get_pipeline_mode
+from gcp_variant_transforms import vcf_to_bq_common
 from gcp_variant_transforms.vcf_to_bq_common import PipelineModes
 
 
@@ -30,19 +30,23 @@ class DataProcessorTest(unittest.TestCase):
   def _create_mock_args(self, **args):
     return collections.namedtuple('MockArgs', args.keys())(*args.values())
 
+  def _get_pipeline_mode(self, args):
+    return vcf_to_bq_common.get_pipeline_mode(args.input_pattern,
+                                              args.optimize_for_large_inputs)
+
   def test_get_mode_raises_error_for_no_match(self):
     args = self._create_mock_args(
         input_pattern='', optimize_for_large_inputs=False)
 
     with mock.patch.object(FileSystems, 'match', return_value=None), \
          self.assertRaises(ValueError):
-      get_pipeline_mode(args)
+      self._get_pipeline_mode(args)
 
   def test_get_mode_optimize_set(self):
     args = self._create_mock_args(
         input_pattern='', optimize_for_large_inputs=True)
 
-    self.assertEqual(get_pipeline_mode(args), PipelineModes.LARGE)
+    self.assertEqual(self._get_pipeline_mode(args), PipelineModes.LARGE)
 
   def test_get_mode_small(self):
     args = self._create_mock_args(
@@ -51,7 +55,7 @@ class DataProcessorTest(unittest.TestCase):
     match = match_result([None for _ in range(100)])
 
     with mock.patch.object(FileSystems, 'match', return_value=[match]):
-      self.assertEqual(get_pipeline_mode(args), PipelineModes.SMALL)
+      self.assertEqual(self._get_pipeline_mode(args), PipelineModes.SMALL)
 
   def test_get_mode_medium(self):
     args = self._create_mock_args(
@@ -60,11 +64,11 @@ class DataProcessorTest(unittest.TestCase):
 
     match = match_result(range(101))
     with mock.patch.object(FileSystems, 'match', return_value=[match]):
-      self.assertEqual(get_pipeline_mode(args), PipelineModes.MEDIUM)
+      self.assertEqual(self._get_pipeline_mode(args), PipelineModes.MEDIUM)
 
     match = match_result(range(50000))
     with mock.patch.object(FileSystems, 'match', return_value=[match]):
-      self.assertEqual(get_pipeline_mode(args), PipelineModes.MEDIUM)
+      self.assertEqual(self._get_pipeline_mode(args), PipelineModes.MEDIUM)
 
   def test_get_mode_large(self):
     args = self._create_mock_args(
@@ -73,4 +77,13 @@ class DataProcessorTest(unittest.TestCase):
 
     match = match_result(range(50001))
     with mock.patch.object(FileSystems, 'match', return_value=[match]):
-      self.assertEqual(get_pipeline_mode(args), PipelineModes.LARGE)
+      self.assertEqual(self._get_pipeline_mode(args), PipelineModes.LARGE)
+
+  def test_default_optimize_for_large_inputs(self):
+    args = self._create_mock_args(input_pattern='')
+    match_result = collections.namedtuple('MatchResult', ['metadata_list'])
+
+    match = match_result(range(101))
+    with mock.patch.object(FileSystems, 'match', return_value=[match]):
+      self.assertEqual(vcf_to_bq_common.get_pipeline_mode(args.input_pattern),
+                       PipelineModes.MEDIUM)

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -91,7 +91,7 @@ def run(argv=None):
   known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
                                                           _COMMAND_LINE_OPTIONS)
   options = pipeline_options.PipelineOptions(pipeline_args)
-  pipeline_mode = vcf_to_bq_common.get_pipeline_mode(known_args)
+  pipeline_mode = vcf_to_bq_common.get_pipeline_mode(known_args.input_pattern)
 
   with beam.Pipeline(options=options) as p:
     headers = vcf_to_bq_common.read_headers(p, pipeline_mode, known_args)


### PR DESCRIPTION
Refactor the get pipeline mode, so that `optimize_for_large_inputs` is not necessary for preprocessor pipeline.

Issue: [178](https://github.com/googlegenomics/gcp-variant-transforms/issues/178)