### PR TITLE
Add type annotation for beam.io #189

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_header_io.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io.py
@@ -18,11 +18,12 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 from functools import partial
-from typing import Dict  # pylint: disable=unused-import
+from typing import Dict, Iterable  # pylint: disable=unused-import
 import vcf
 
 import apache_beam as beam
 from apache_beam.io import filebasedsource
+from apache_beam.io import range_trackers  # pylint: disable=unused-import
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.io.iobase import Read
@@ -38,7 +39,6 @@ class VcfHeaderFieldTypeConstants(object):
   STRING = 'String'
   FLAG = 'Flag'
   CHARACTER = 'Character'
-  STRING = 'String'
 
 
 class VcfParserHeaderKeyConstants(object):
@@ -63,6 +63,7 @@ class VcfHeader(object):
                contigs=None,  # type: Dict[str, OrderedDict[vcf.parser._Contig]]
                file_name=None  # type: str
               ):
+    # type: (...) -> None
     """Initializes a VcfHeader object.
 
     It keeps the order of values in the input dictionaries. Order is important
@@ -119,13 +120,19 @@ class VcfHeaderSource(filebasedsource.FileBasedSource):
                file_pattern,
                compression_type=CompressionTypes.AUTO,
                validate=True):
+    # type: (str, str, bool) -> None
     super(VcfHeaderSource, self).__init__(file_pattern,
                                           compression_type=compression_type,
                                           validate=validate,
                                           splittable=False)
     self._compression_type = compression_type
 
-  def read_records(self, file_name, unused_range_tracker):
+  def read_records(
+      self,
+      file_name,  # type: str
+      unused_range_tracker  # type: range_trackers.UnsplittableRangeTracker
+      ):
+    # type: (...) -> Iterable[VcfHeader]
     try:
       vcf_reader = vcf.Reader(fsock=self._read_headers(file_name))
     except StopIteration:
@@ -161,17 +168,18 @@ class ReadVcfHeaders(PTransform):
       compression_type=CompressionTypes.AUTO,
       validate=True,
       **kwargs):
+    # type: (str, str, bool, **str) -> None
     """Initialize the :class:`ReadVcfHeaders` transform.
 
     Args:
-      file_pattern (str): The file path to read from either as a single file or
-        a glob pattern.
-      compression_type (str): Used to handle compressed input files.
+      file_pattern: The file path to read from either as a single file or a glob
+        pattern.
+      compression_type: Used to handle compressed input files.
         Typical value is :attr:`CompressionTypes.AUTO
         <apache_beam.io.filesystem.CompressionTypes.AUTO>`, in which case the
         underlying file_path's extension will be used to detect the compression.
-      validate (bool): flag to verify that the files exist during the pipeline
-        creation time.
+      validate: Flag to verify that the files exist during the pipeline creation
+        time.
     """
     super(ReadVcfHeaders, self).__init__(**kwargs)
     self._source = VcfHeaderSource(
@@ -204,14 +212,15 @@ class ReadAllVcfHeaders(PTransform):
       desired_bundle_size=DEFAULT_DESIRED_BUNDLE_SIZE,
       compression_type=CompressionTypes.AUTO,
       **kwargs):
+    # type: (int, str, **str) -> None
     """Initialize the :class:`ReadAllVcfHeaders` transform.
 
     Args:
-      desired_bundle_size (int): Desired size of bundles that should be
-        generated when splitting this source into bundles. See
+      desired_bundle_size: Desired size of bundles that should be generated when
+        splitting this source into bundles. See
         :class:`~apache_beam.io.filebasedsource.FileBasedSource` for more
         details.
-      compression_type (str): Used to handle compressed input files.
+      compression_type: Used to handle compressed input files.
         Typical value is :attr:`CompressionTypes.AUTO
         <apache_beam.io.filesystem.CompressionTypes.AUTO>`, in which case the
         underlying file_path's extension will be used to detect the compression.
@@ -254,10 +263,12 @@ class _WriteVcfHeaderFn(beam.DoFn):
   FINAL_HEADER_LINE = '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT\n'
 
   def __init__(self, file_path):
+    # type: (str) -> None
     self._file_path = file_path
     self._file_to_write = None
 
   def process(self, header):
+    # type: (VcfHeader) -> None
     with FileSystems.create(self._file_path) as self._file_to_write:
       self._write_headers_by_type(HeaderTypeConstants.INFO, header.infos)
       self._write_headers_by_type(HeaderTypeConstants.FILTER, header.filters)
@@ -267,24 +278,26 @@ class _WriteVcfHeaderFn(beam.DoFn):
       self._file_to_write.write(self.FINAL_HEADER_LINE)
 
   def _write_headers_by_type(self, header_type, headers):
+    # type: (str, Dict[str, Dict[str, Union[str, int]]]) -> None
     """Writes all VCF headers of a specific type.
 
     Args:
-      header_type (str): The type of `headers` (e.g. INFO, FORMAT, etc.).
-      headers (dict): Each value of headers is a dictionary that describes a
-        single VCF header line.
+      header_type: The type of `headers` (e.g. INFO, FORMAT, etc.).
+      headers: Each value of headers is a dictionary that describes a single VCF
+        header line.
     """
     for header in headers.values():
       self._file_to_write.write(
           self._to_vcf_header_line(header_type, header))
 
   def _to_vcf_header_line(self, header_type, header):
+    # type: (str, Dict[str, Union[str, int]]) -> str
     """Formats a single VCF header line.
 
     Args:
-      header_type (str): The VCF type of `header` (e.g. INFO, FORMAT, etc.).
-      header (dict): A dictionary mapping header field keys (e.g. id, desc,
-        etc.) to their corresponding values for the header line.
+      header_type: The VCF type of `header` (e.g. INFO, FORMAT, etc.).
+      header: A dictionary mapping header field keys (e.g. id, desc, etc.) to
+        their corresponding values for the header line.
 
     Returns:
       A formatted VCF header line.
@@ -293,11 +306,12 @@ class _WriteVcfHeaderFn(beam.DoFn):
     return self.HEADER_TEMPLATE.format(header_type, formatted_header_values)
 
   def _format_header(self, header):
+    # type: (Dict[str, Union[str, int]]) -> str
     """Formats all key, value pairs that describe the header line.
 
     Args:
-      header (dict): A dictionary mapping header field keys (e.g. id, desc,
-        etc.) to their corresponding values for the header line.
+      header: A dictionary mapping header field keys (e.g. id, desc, etc.) to
+        their corresponding values for the header line.
 
     Returns:
       A formatted string composed of header keys and values.
@@ -312,10 +326,11 @@ class _WriteVcfHeaderFn(beam.DoFn):
     return value is not None or (key != 'source' and key != 'version')
 
   def _format_header_key_value(self, key, value):
+    # type: (str, Union[str, int]) -> str
     """Formats a single key, value pair in a header line.
 
     Args:
-      key (str): The key of the header field (e.g. num, desc, etc.).
+      key: The key of the header field (e.g. num, desc, etc.).
       value: The header value corresponding to the key in a specific
         header line.
 
@@ -352,6 +367,7 @@ class _WriteVcfHeaderFn(beam.DoFn):
       raise ValueError('Invalid VCF header key {}.'.format(key))
 
   def _format_number(self, number):
+    # type: (int) -> Optional[str]
     """Returns the string representation of field_count from PyVCF.
 
     PyVCF converts field counts to an integer with some predefined constants
@@ -360,8 +376,8 @@ class _WriteVcfHeaderFn(beam.DoFn):
     direct dependency on the arbitrary PyVCF constants.
 
     Args:
-      number (int): An integer representing the number of fields in INFO
-        as specified by PyVCF.
+      number: An integer representing the number of fields in INFO as specified
+        by PyVCF.
 
     Returns:
       A string representation of field_count (e.g. '-1' becomes 'A').
@@ -387,6 +403,7 @@ class WriteVcfHeaders(PTransform):
   """A PTransform for writing VCF header lines."""
 
   def __init__(self, file_path):
+    # type: (str) -> None
     self._file_path = file_path
 
   def expand(self, pcoll):

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -18,7 +18,8 @@ The 4.2 spec is available at https://samtools.github.io/hts-specs/VCFv4.2.pdf.
 """
 
 from __future__ import absolute_import
-
+# pylint: disable=unused-import
+from typing import Dict, Iterable, List, Optional
 import logging
 from collections import namedtuple
 from functools import partial
@@ -27,6 +28,7 @@ import vcf
 
 from apache_beam.coders import coders
 from apache_beam.io import filebasedsource
+from apache_beam.io import range_trackers  # pylint: disable=unused-import
 from apache_beam.io import textio
 from apache_beam.io.filesystem import CompressionTypes
 from apache_beam.io.iobase import Read
@@ -71,39 +73,38 @@ class Variant(object):
   """
 
   def __init__(self,
-               reference_name=None,
-               start=None,
-               end=None,
-               reference_bases=None,
-               alternate_bases=None,
-               names=None,
-               quality=None,
-               filters=None,
-               info=None,
-               calls=None):
-    """Initialize the :class:`Variant` object.
+               reference_name=None,  # type: str
+               start=None,  # type: int
+               end=None,  # type: int
+               reference_bases=None,  # type: str
+               alternate_bases=None,  # type: List[str]
+               names=None,  # type: List[str]
+               quality=None,  # type: float
+               filters=None,  # type: List[str]
+               info=None,  # type: Dict[str, VariantInfo]
+               calls=None  # type: List[VariantCall]
+              ):
+    # type: (...) -> None
+    """Initialize the ``Variant`` object.
 
     Args:
-      reference_name (str): The reference on which this variant occurs
-        (such as `chr20` or `X`). .
-      start (int): The position at which this variant occurs (0-based).
-        Corresponds to the first base of the string of reference bases.
-      end (int): The end position (0-based) of this variant. Corresponds to the
-        first base after the last base in the reference allele.
-      reference_bases (str): The reference bases for this variant.
-      alternate_bases (List[str]): The bases that appear instead of the
-        reference bases.
-      names (List[str]): Names for the variant, for example a RefSNP ID.
-      quality (float): Phred-scaled quality score (-10log10 prob(call is wrong))
+      reference_name: The reference on which this variant occurs (such as
+        `chr20` or `X`).
+      start: The position at which this variant occurs (0-based). Corresponds to
+        the first base of the string of reference bases.
+      end: The end position (0-based) of this variant. Corresponds to the first
+        base after the last base in the reference allele.
+      reference_bases: The reference bases for this variant.
+      alternate_bases: The bases that appear instead of the reference bases.
+      names: Names for the variant, for example a RefSNP ID.
+      quality: Phred-scaled quality score (-10log10 prob(call is wrong)).
         Higher values imply better quality.
-      filters (List[str]): A list of filters (normally quality filters) this
-        variant has failed. `PASS` indicates this variant has passed all
-        filters.
-      info (dict): A map of additional variant information. The key is specified
+      filters: A list of filters (normally quality filters) this variant has
+        failed. `PASS` indicates this variant has passed all filters.
+      info: A map of additional variant information. The key is specified
         in the VCF record and the value is of type ``VariantInfo``.
-      calls (list of :class:`VariantCall`): The variant calls for this variant.
-        Each one represents the determination of genotype with respect to this
-        variant.
+      calls: The variant calls for this variant. Each one represents the
+        determination of genotype with respect to this variant.
     """
     self.reference_name = reference_name
     self.start = start
@@ -185,23 +186,24 @@ class VariantCall(object):
   """
 
   def __init__(self, name=None, genotype=None, phaseset=None, info=None):
+    # type: (str, List[int], str, Dict[str, VariantInfo]) -> None
     """Initialize the :class:`VariantCall` object.
 
     Args:
-      name (str): The name of the call.
-      genotype (List[int]): The genotype of this variant call as specified by
-        the VCF schema. The values are either `0` representing the reference,
-        or a 1-based index into alternate bases. Ordering is only important if
+      name: The name of the call.
+      genotype: The genotype of this variant call as specified by the VCF
+        schema. The values are either `0` representing the reference, or a
+        1-based index into alternate bases. Ordering is only important if
         `phaseset` is present. If a genotype is not called (that is, a `.` is
-        present in the GT string), -1 is used
-      phaseset (str): If this field is present, this variant call's genotype
-        ordering implies the phase of the bases and is consistent with any other
-        variant calls in the same reference sequence which have the same
-        phaseset value. If the genotype data was phased but no phase set was
-        specified, this field will be set to `*`.
-      info (dict): A map of additional variant call information. The key is
-        specified in the VCF record and the type of the value is specified by
-        the VCF header FORMAT.
+        present in the GT string), -1 is used.
+      phaseset: If this field is present, this variant call's genotype ordering
+        implies the phase of the bases and is consistent with any other variant
+        calls in the same reference sequence which have the same phaseset value.
+        If the genotype data was phased but no phase set was specified, this
+        field will be set to `*`.
+      info: A map of additional variant call information. The key is specified
+        in the VCF record and the type of the value is specified by the VCF
+        header FORMAT.
     """
     self.name = name
     self.genotype = genotype or []
@@ -243,6 +245,7 @@ class _ToVcfRecordCoder(coders.Coder):
   """Coder for encoding :class:`Variant` objects as VCF text lines."""
 
   def encode(self, variant):
+    # type: (Variant) -> str
     """Converts a :class:`Variant` object back to a VCF line."""
     encoded_info = self._encode_variant_info(variant)
     format_keys = self._get_variant_format_keys(variant)
@@ -375,6 +378,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
                buffer_size=DEFAULT_VCF_READ_BUFFER_SIZE,
                validate=True,
                allow_malformed_records=False):
+    # type: (str, List[str], str, int, bool, bool) -> None
     super(_VcfSource, self).__init__(file_pattern,
                                      compression_type=compression_type,
                                      validate=validate)
@@ -383,7 +387,11 @@ class _VcfSource(filebasedsource.FileBasedSource):
     self._buffer_size = buffer_size
     self._allow_malformed_records = allow_malformed_records
 
-  def read_records(self, file_name, range_tracker):
+  def read_records(self,
+                   file_name,  # type: str
+                   range_tracker  # type: range_trackers.OffsetRangeTracker
+                  ):
+    # type: (...) -> Iterable[MalformedVcfRecord]
     record_iterator = _VcfSource._VcfRecordIterator(
         file_name,
         range_tracker,
@@ -402,13 +410,15 @@ class _VcfSource(filebasedsource.FileBasedSource):
     """An Iterator for processing a single VCF file."""
 
     def __init__(self,
-                 file_name,
-                 range_tracker,
-                 file_pattern,
-                 compression_type,
-                 allow_malformed_records,
-                 representative_header_lines=None,
-                 **kwargs):
+                 file_name,  # type: str
+                 range_tracker,  # type: range_trackers.OffsetRangeTracker
+                 file_pattern,  # type: str
+                 compression_type,  # type: str
+                 allow_malformed_records,  # type: bool
+                 representative_header_lines=None,  # type:  List[str]
+                 **kwargs  # type: **str
+                ):
+      # type: (...) -> None
       # If `representative_header_lines` is given, header lines in `file_name`
       # are ignored.
       self._header_lines = []
@@ -475,16 +485,21 @@ class _VcfSource(filebasedsource.FileBasedSource):
 
         raise ValueError('Invalid record in VCF file. Error: %s' % str(e))
 
-    def _convert_to_variant_record(self, record, infos, formats):
+    def _convert_to_variant_record(
+        self,
+        record,  # type: vcf.model._Record
+        infos,  # type: Dict[str, vcf.parser._Info]
+        formats  # type: Dict[str, vcf.parser._Format]
+        ):
+      # type: (...) -> Variant
       """Converts the PyVCF record to a :class:`Variant` object.
 
       Args:
-        record (:class:`~vcf.model._Record`): An object containing info about a
-          variant.
-        infos (dict): The PyVCF dict storing INFO extracted from the VCF header.
+        record: An object containing info about a variant.
+        info: The PyVCF dict storing INFO extracted from the VCF header.
           The key is the info key and the value is :class:`~vcf.parser._Info`.
-        formats (dict): The PyVCF dict storing FORMAT extracted from the VCF
-          header. The key is the FORMAT key and the value is
+        formats: The PyVCF dict storing FORMAT extracted from the VCF header.
+          The key is the FORMAT key and the value is
           :class:`~vcf.parser._Format`.
 
       Returns:
@@ -536,6 +551,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
       return info
 
     def _get_field_count_as_string(self, field_count):
+      # type: (Optional[int]) -> Optional[str]
       """Returns the string representation of field_count from PyVCF.
 
       PyVCF converts field counts to an integer with some predefined constants
@@ -544,8 +560,8 @@ class _VcfSource(filebasedsource.FileBasedSource):
       direct dependency on the arbitrary PyVCF constants.
 
       Args:
-        field_count (int): An integer representing the number of fields in INFO
-          as specified by PyVCF.
+        field_count: An integer representing the number of fields in INFO as
+          specified by PyVCF.
 
       Returns:
         A string representation of field_count (e.g. '-1' becomes 'A').
@@ -616,20 +632,20 @@ class ReadFromVcf(PTransform):
       validate=True,
       allow_malformed_records=False,
       **kwargs):
+    # type: (str, List[str], str, bool, bool, **str) -> None
     """Initialize the :class:`ReadFromVcf` transform.
 
     Args:
-      file_pattern (str): The file path to read from either as a single file or
-        a glob pattern.
-      representative_header_lines(list of str): Header definitions to be used
-        for parsing VCF files. If supplied, header definitions in VCF files are
-        ignored.
-      compression_type (str): Used to handle compressed input files.
-        Typical value is :attr:`CompressionTypes.AUTO
+      file_pattern: The file path to read from either as a single file or a
+        glob pattern.
+      representative_header_lines: Header definitions to be used for parsing
+        VCF files. If supplied, header definitions in VCF files are ignored.
+      compression_type: Used to handle compressed input files. Typical value is
+        :attr:`CompressionTypes.AUTO
         <apache_beam.io.filesystem.CompressionTypes.AUTO>`, in which case the
         underlying file_path's extension will be used to detect the compression.
-      validate (bool): flag to verify that the files exist during the pipeline
-        creation time.
+      validate: flag to verify that the files exist during the pipeline creation
+        time.
     """
     super(ReadFromVcf, self).__init__(**kwargs)
     self._source = _VcfSource(
@@ -673,23 +689,22 @@ class ReadAllFromVcf(PTransform):
       compression_type=CompressionTypes.AUTO,
       allow_malformed_records=False,
       **kwargs):
+    # type: (List[str], int, str, bool, **str) -> None
     """Initialize the :class:`ReadAllFromVcf` transform.
 
     Args:
-      representative_header_lines(list of str): Header definitions to be used
-        for parsing VCF files. If supplied, header definitions in VCF files are
-        ignored.
-      desired_bundle_size (int): Desired size of bundles that should be
-        generated when splitting this source into bundles. See
+      representative_header_lines: Header definitions to be used for parsing VCF
+        files. If supplied, header definitions in VCF files are ignored.
+      desired_bundle_size: Desired size of bundles that should be generated when
+        splitting this source into bundles. See
         :class:`~apache_beam.io.filebasedsource.FileBasedSource` for more
         details.
-      compression_type (str): Used to handle compressed input files.
+      compression_type: Used to handle compressed input files.
         Typical value is :attr:`CompressionTypes.AUTO
         <apache_beam.io.filesystem.CompressionTypes.AUTO>`, in which case the
         underlying file_path's extension will be used to detect the compression.
-      allow_malformed_records (bool): If true, malformed records from VCF files
-        will be returned as :class:`MalformedVcfRecord` instead of failing
-        the pipeline.
+      allow_malformed_records: If true, malformed records from VCF files will be
+        returned as :class:`MalformedVcfRecord` instead of failing the pipeline.
     """
     super(ReadAllFromVcf, self).__init__(**kwargs)
     source_from_file = partial(
@@ -715,6 +730,7 @@ class WriteToVcf(PTransform):
                num_shards=1,
                compression_type=CompressionTypes.AUTO,
                headers=None):
+    # type: (str, int, str, List[str]) -> None
     """Initialize a WriteToVcf PTransform.
 
     Args:


### PR DESCRIPTION
Add type annotation for `vcf_header_io.py` and `vcfio.py`.

Tested: unit tests
Issue: [189](https://github.com/googlegenomics/gcp-variant-transforms/issues/189)