### PR TITLE
Integration tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - "2.7"
 install:
   - pip install --upgrade .
-  - pip install --upgrade google-cloud-storage
   - pip install pylint
   - pip install python-coveralls
 script:

--- a/cloudbuild_CI.yaml
+++ b/cloudbuild_CI.yaml
@@ -55,4 +55,4 @@ steps:
       # - '--gs_dir bashir-variant_integration_test_runs'
 images:
   - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-timeout: 45m
+timeout: 60m

--- a/deploy_and_run_tests.sh
+++ b/deploy_and_run_tests.sh
@@ -213,11 +213,11 @@ export VIRTUAL_ENV_DISABLE_PROMPT="something"
 virtualenv "${temp_dir}"
 source ${temp_dir}/bin/activate;
 trap clean_up EXIT
-pip install --upgrade .[int_test]
 if [[ -n "${run_unit_tests}" ]]; then
   pip install --upgrade .
   python setup.py test
 fi
+pip install --upgrade .[int_test]
 
 color_print "Running integration tests against ${full_image_name}" "${GREEN}"
 python gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py \
@@ -233,7 +233,6 @@ if [[ -n "${run_preprocessor_tests}" ]]; then
       --staging_location "gs://${gs_dir}/staging" \
       --temp_location "gs://${gs_dir}/temp" \
       --logging_location "gs://${gs_dir}/temp/logs" \
-      --image "${full_image_name}" ${TEST_ARGUMENTS}
+      --image "${full_image_name}"
 fi
 color_print "$0 succeeded!" "${GREEN}"
-

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,12 @@ REQUIRED_PACKAGES = [
     'intervaltree>=2.1.0,<2.2.0',
     'pyvcf<0.7.0',
     'mmh3<2.6',
+    'google-cloud-storage<=1.2.0'
 ]
 
 INTEGRATION_TEST_REQUIREMENTS = [
     # Need to explicitly install v>0.25 as the BigQuery python API has changed.
-    'google-cloud-bigquery>0.25',
-    'google-cloud-storage'
+    'google-cloud-bigquery>0.25'
 ]
 
 REQUIRED_SETUP_PACKAGES = [
@@ -65,8 +65,7 @@ setuptools.setup(
         'int_test': INTEGRATION_TEST_REQUIREMENTS,
     },
     test_suite='nose.collector',
-    packages=setuptools.find_packages(
-        exclude=('gcp_variant_transforms/testing')),
+    packages=setuptools.find_packages(),
     package_data={
         'gcp_variant_transforms': ['gcp_variant_transforms/testing/testdata/*']
     },

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,10 @@ REQUIRED_PACKAGES = [
     'intervaltree>=2.1.0,<2.2.0',
     'pyvcf<0.7.0',
     'mmh3<2.6',
+    # Need to explicitly install v<=1.2.0. apache-beam requires
+    # google-cloud-pubsub 0.26.0, which relies on google-cloud-core<0.26dev,
+    # >=0.25.0. google-cloud-storage also has requirements on google-cloud-core,
+    # and version 1.2.0 resolves the dependency conflicts.
     'google-cloud-storage<=1.2.0'
 ]
 


### PR DESCRIPTION
Related with [Pull 243](https://github.com/googlegenomics/gcp-variant-transforms/pull/243) and [Pull 237](https://github.com/googlegenomics/gcp-variant-transforms/pull/237). Add the `google-cloud-storage` as a dependency. 

Tested: Manually created a trigger in container registry.