### PR TITLE
Partitioning Part 2 (input config file)

### DIFF
--- a/gcp_variant_transforms/data/partition_configs/homo_sapiens_default.yaml
+++ b/gcp_variant_transforms/data/partition_configs/homo_sapiens_default.yaml
@@ -1,0 +1,130 @@
+-  partition:
+     partition_name: "chr01"
+     regions:
+       - "chr1"
+       - "1"
+-  partition:
+     partition_name: "chr02"
+     regions:
+       - "chr2"
+       - "2"
+-  partition:
+     partition_name: "chr03"
+     regions:
+       - "chr3"
+       - "3"
+-  partition:
+     partition_name: "chr04"
+     regions:
+       - "chr4"
+       - "4"
+-  partition:
+     partition_name: "chr05"
+     regions:
+       - "chr5"
+       - "5"
+-  partition:
+     partition_name: "chr06"
+     regions:
+       - "chr6"
+       - "6"
+-  partition:
+     partition_name: "chr07"
+     regions:
+       - "chr7"
+       - "7"
+-  partition:
+     partition_name: "chr08"
+     regions:
+       - "chr8"
+       - "8"
+-  partition:
+     partition_name: "chr09"
+     regions:
+       - "chr9"
+       - "9"
+
+-  partition:
+     partition_name: "chr10"
+     regions:
+       - "chr10"
+       - "10"
+-  partition:
+     partition_name: "chr11"
+     regions:
+       - "chr11"
+       - "11"
+-  partition:
+     partition_name: "chr12"
+     regions:
+       - "chr12"
+       - "12"
+-  partition:
+     partition_name: "chr13"
+     regions:
+       - "chr13"
+       - "13"
+-  partition:
+     partition_name: "chr14"
+     regions:
+       - "chr14"
+       - "14"
+-  partition:
+     partition_name: "chr15"
+     regions:
+       - "chr15"
+       - "15"
+-  partition:
+     partition_name: "chr16"
+     regions:
+       - "chr16"
+       - "16"
+-  partition:
+     partition_name: "chr17"
+     regions:
+       - "chr17"
+       - "17"
+-  partition:
+     partition_name: "chr18"
+     regions:
+       - "chr18"
+       - "18"
+-  partition:
+     partition_name: "chr19"
+     regions:
+       - "chr19"
+       - "19"
+-  partition:
+     partition_name: "chr20"
+     regions:
+       - "chr20"
+       - "20"
+-  partition:
+     partition_name: "chr21"
+     regions:
+       - "chr21"
+       - "21"
+-  partition:
+     partition_name: "chr22"
+     regions:
+       - "chr22"
+       - "22"
+-  partition:
+     partition_name: "chrx"
+     regions:
+       - "chrX"
+       - "x"
+-  partition:
+     partition_name: "chry"
+     regions:
+       - "chrY"
+       - "y"
+-  partition:
+     partition_name: "chrm"
+     regions:
+       - "chrM"
+       - "M"
+-  partition:
+     partition_name: "all_remaining"
+     regions:
+       - "residual"

--- a/gcp_variant_transforms/libs/variant_partition.py
+++ b/gcp_variant_transforms/libs/variant_partition.py
@@ -14,16 +14,26 @@
 
 """Encapsulates all partitioning logic used by VCF to BigQuery pipeline.
 
-VariantPartition class basically returns an index for a given (
-reference_name, pos) pair. The main utilization of this class is in
+VariantPartition class basically returns an index for a given
+(reference_name, pos) pair. The main utilization of this class is in
 partition_for() function used by DataFlow pipeline.
+This class has 2 main operating modes:
+  1) Automatic: it will partition variants based on their reference_name
+  2) Based on user provided config file: Users can parition output tables as
+     they wish by providing a partition config file, example config files are
+     available at gcp_variant_transforms/testing/data/misc/*.yaml
 """
 
 from __future__ import absolute_import
 
+from collections import defaultdict
 import re
+import sys
+import intervaltree
 from mmh3 import hash  # pylint: disable=no-name-in-module,redefined-builtin
+import yaml
 
+from apache_beam.io.filesystems import FileSystems
 
 # A reg exp that will match to standard reference_names such as "chr01" or "13".
 _CHROMOSOME_NAME_REGEXP = re.compile(r'^(chr)?([0-9][0-9]?)$')
@@ -34,27 +44,199 @@ _RESERVED_AUTO_PARTITIONS = 22
 # will be matched to next available partitions [22, 27).
 _DEFAULT_NUM_PARTITIONS = _RESERVED_AUTO_PARTITIONS + 5
 
+# At most 1000 partitions can be set as output of VariantTransform.
+_MAX_NUM_PARTITIONS = 1000
+# Each partition can contain at most 64 regions.
+_MAX_NUM_REGIONS = 64
+# Matches to regions formatted as 'chr12:10,000-20,000' used in par_config.yaml
+_REGION_LITERAL_REGEXP = re.compile(r'^(\S+):([0-9,]+)-([0-9,]+)$')
+# A special literal for identifying residual partition's region name.
+_RESIDUAL_REGION_LITERAL = 'residual'
+_UNDEFINED_PARTITION_INDEX = -1
 
-class VariantPartition(object):
-  """Automatically partition variants based on their reference_name."""
+
+class _ChromosomePartitioner(object):
+  """Assigns partition indices to multiple regions inside a chromosome.
+
+  This class logic is implemented using an interval tree, each region is
+  considered as an interval and will be added to the interval tree. Note all
+  regions must be pairwise disjoint, i.e. no overlapping interval is accepted.
+  """
 
   def __init__(self):
+    # Each instance contains multiple regions of one chromosome.
+    self._interval_tree = intervaltree.IntervalTree()
+
+  def add_region(self, start, end, partition_index):
+    if start < 0:
+      raise ValueError(
+          'Start position on a region cannot be negative: {}'.format(start))
+    if end <= start:
+      raise ValueError('End position must be larger than start position: {} '
+                       'vs {}'.format(end, start))
+    if partition_index < 0:
+      raise ValueError(
+          'Index of a region cannot be negative {}'.format(partition_index))
+    if self._interval_tree.overlaps_range(start, end):
+      raise ValueError(
+          'Cannot add overlapping region {}-{}'.format(start, end))
+    # If everything goes well we add the new region to the interval tree.
+    self._interval_tree.addi(start, end, partition_index)
+
+  def get_partition_index(self, pos=0):
+    """Finds a region that includes pos, if none _UNDEFINED_PARTITION_INDEX."""
+    matched_regions = self._interval_tree.search(pos)
+    # Ensure at most one region is matching to the give position.
+    assert len(matched_regions) <= 1
+    if len(matched_regions) == 1:
+      return next(iter(matched_regions)).data
+    else:
+      return _UNDEFINED_PARTITION_INDEX
+
+class VariantPartition(object):
+  """Partition variants based on their reference_name and position.
+
+  This class has 2 operating modes:
+    1) No config file is given (config_file_path == None):
+       Automatically partition variants based on their reference_name.
+    2) A config file is given:
+       partitions variants based on input config file.
+  """
+
+  def __init__(self, config_file_path=None):
     if _DEFAULT_NUM_PARTITIONS <= _RESERVED_AUTO_PARTITIONS:
       raise ValueError(
           '_DEFAULT_NUM_PARTITIONS must be > _RESERVED_AUTO_PARTITIONS')
-    self._reference_name_to_partition_map = {}
+    self._num_partitions = _DEFAULT_NUM_PARTITIONS
+    # This variable determines the operation mode auto (default mode) vs config.
+    self._config_file_path_given = False
+    # Residual partition will contain all remaining variants that do not match
+    # to any other partition.
+    self._residual_partition_index = _UNDEFINED_PARTITION_INDEX
+    self._should_keep_residual_partition = False
+    self._ref_name_to_partitions_map = defaultdict(_ChromosomePartitioner)
+    self._partition_names = {}
+
+    if config_file_path:
+      self._config_file_path_given = True
+      self._parse_config(config_file_path)
+
+  def _validate_config(self, config_file_path):
+    # type: (str) -> None
+    with FileSystems.open(config_file_path, 'r') as f:
+      try:
+        partition_configs = yaml.load(f)
+      except yaml.YAMLError as e:
+        raise ValueError('Invalid yaml file: %s' % str(e))
+    if len(partition_configs) > _MAX_NUM_PARTITIONS:
+      raise ValueError(
+          'There can be at most {} partitions but given config file '
+          'contains {}'.format(_MAX_NUM_PARTITIONS, len(partition_configs)))
+    if not partition_configs:
+      raise ValueError('There must be at least one partition in config file.')
+
+    existing_partition_names = set()
+    for partition_config in partition_configs:
+      partition = partition_config.get('partition', None)
+      if partition is None:
+        raise ValueError('Wrong yaml file format, partition field missing.')
+      regions = partition.get('regions', None)
+      if regions is None:
+        raise ValueError('Each partition must have at least one region.')
+      if len(regions) > _MAX_NUM_REGIONS:
+        raise ValueError('At most {} regions per partition, thie partition '
+                         'contains {}'.format(_MAX_NUM_REGIONS, len(regions)))
+      if not partition.get('partition_name', None):
+        raise ValueError('Each partition must have partition_name field.')
+      partition_name = partition.get('partition_name').strip()
+      if not partition_name:
+        raise ValueError('Partition name can not be empty string.')
+      if partition_name in existing_partition_names:
+        raise ValueError('Partition names must be unique, '
+                         '{} is duplicated'.format(partition_name))
+      existing_partition_names.add(partition_name)
+    return partition_configs
+
+  def _parse_config(self, config_file_path):
+    # type: (str) -> None
+    """Parses the given partition config file.
+
+    Args:
+      config_file_path: name of the input partition_config file.
+    Raises:
+      A ValueError if any of the expected config formats are violated.
+    """
+    def _parse_position(pos_str):
+      # type: (str) -> int
+      return int(pos_str.replace(',', ''))
+
+    def _is_residual_partition(regions):
+      # type: (List[str]) -> bool
+      return (len(regions) == 1 and
+              regions[0].strip().lower() == _RESIDUAL_REGION_LITERAL)
+
+    partition_configs = self._validate_config(config_file_path)
+
+    self._num_partitions = len(partition_configs)
+    for partition_index in range(self._num_partitions):
+      partition = partition_configs[partition_index].get('partition')
+      self._partition_names[partition_index] = (
+          partition.get('partition_name').strip())
+      regions = partition.get('regions', None)
+
+      if _is_residual_partition(regions):
+        if self._residual_partition_index != _UNDEFINED_PARTITION_INDEX:
+          raise ValueError('There must be only one residual partition.')
+        self._residual_partition_index = partition_index
+        self._should_keep_residual_partition = True
+        continue
+
+      for r in regions:
+        matched = _REGION_LITERAL_REGEXP.match(r)
+        if matched:
+          ref_name, start, end = matched.groups()
+          ref_name = ref_name.strip().lower()
+          start = _parse_position(start)
+          end = _parse_position(end)
+        else:
+          # This region includes a full chromosome
+          ref_name = r.strip().lower()
+          start = 0
+          end = sys.maxint
+        self._ref_name_to_partitions_map[ref_name].add_region(
+            start, end, partition_index)
+
+    if self._residual_partition_index == _UNDEFINED_PARTITION_INDEX:
+      # We add an extra dummy partition for residuals.
+      # Note, here self._should_keep_residual_partition is False.
+      self._residual_partition_index = self._num_partitions
+      self._num_partitions += 1
 
   def get_num_partitions(self):
-    """Returns the number of partitions."""
-    return _DEFAULT_NUM_PARTITIONS
+    # type: (None) -> int
+    return self._num_partitions
 
   def get_partition(self, reference_name, pos=0):
-    # type: (str, int) -> int
+    # type: (str, Optional[int]) -> int
+    """Returns partition index on ref_name chromosome which pos falls into ."""
     reference_name = reference_name.strip().lower()
     if not reference_name or pos < 0:
-      raise ValueError('Cannot partition given input {}:{}'
-                       .format(reference_name, pos))
-    return self._get_auto_partition(reference_name)
+      raise ValueError(
+          'Cannot partition given input {}:{}'.format(reference_name, pos))
+    if self._config_file_path_given:
+      return self._get_config_partition(reference_name, pos)
+    else:
+      return self._get_auto_partition(reference_name)
+
+  def _get_config_partition(self, reference_name, pos):
+    # type: (str, int) -> int
+    partitioner = self._ref_name_to_partitions_map.get(reference_name, None)
+    if partitioner:
+      partition_index = partitioner.get_partition_index(pos)
+      if partition_index != _UNDEFINED_PARTITION_INDEX:
+        return partition_index
+    # No match was found, returns residual partition index.
+    return self._residual_partition_index
 
   def _get_auto_partition(self, reference_name):
     # type: (str) -> int
@@ -62,33 +244,61 @@ class VariantPartition(object):
 
     Given a reference_name returns an index in [0, _DEFAULT_NUM_PARTITIONS)
     range. In order to make this lookup less computationally intensive we first:
-      1) Lookup the reference_name in _reference_name_to_partition_map dict
+      1) Lookup the reference_name in _ref_name_to_partitions_map dict
 
     If the result of lookup is None, we will try the following steps:
-      2) Match the reference_name to a reg exp of common names (eg 'chr12')
+      2) Match the reference_name to a reg exp of common names (e.g. 'chr12') or
       3) Hash the reference_name and calculate its mod to remaining buckets
-    result will be added to _reference_name_to_partition_map for future lookup.
+    result of 2-3 is added to _ref_name_to_partitions_map for future lookups.
 
     Args:
       reference_name: reference name of the variant which is being partitioned
     Returns:
       An integer in the range of [0, _DEFAULT_NUM_PARTITIONS)
     """
-    partition = self._reference_name_to_partition_map.get(reference_name, None)
-    if partition is None:
+    partitioner = self._ref_name_to_partitions_map.get(reference_name, None)
+    if partitioner:
+      return partitioner.get_partition_index()
+    else:
       matched = _CHROMOSOME_NAME_REGEXP.match(reference_name)
       if matched:
         # First match the reference_name to the common formats.
         _, chr_no = matched.groups()
         chr_no = int(chr_no)
         if chr_no > 0 and chr_no <= _RESERVED_AUTO_PARTITIONS:
-          partition = chr_no - 1
-          self._reference_name_to_partition_map[reference_name] = partition
-          return partition
+          partition_index = chr_no - 1
+          self._ref_name_to_partitions_map[reference_name].add_region(
+              0, sys.maxint, partition_index)
+          return partition_index
       # If RegExp didn't match, we will find the hash of reference_name
       remaining_partitions = _DEFAULT_NUM_PARTITIONS - _RESERVED_AUTO_PARTITIONS
-      partition = (hash(reference_name) % remaining_partitions +
-                   _RESERVED_AUTO_PARTITIONS)
+      partition_index = (hash(reference_name) % remaining_partitions +
+                         _RESERVED_AUTO_PARTITIONS)
       # Save partition in _reference_name_to_partition dict for future lookups
-      self._reference_name_to_partition_map[reference_name] = partition
-    return partition
+      self._ref_name_to_partitions_map[reference_name].add_region(
+          0, sys.maxint, partition_index)
+      return partition_index
+
+  def should_flatten(self):
+    # type: (None) -> bool
+    """In auto mode (no config) flattens partitions, produces 1 output table."""
+    return not self._config_file_path_given
+
+  def should_keep_partition(self, partition_index):
+    # type: (int) -> bool
+    """Returns False only for dummy extra residual partition (if was added)."""
+    if partition_index != self._residual_partition_index:
+      return True
+    else:
+      return self._should_keep_residual_partition
+
+  def get_partition_name(self, partition_index):
+    # type: (int) -> Optional[str]
+    if self._config_file_path_given:
+      if partition_index >= self._num_partitions or partition_index < 0:
+        raise ValueError(
+            'Given partition index {} is outside of expected range: '
+            '[0, {}]'.format(partition_index, self._num_partitions))
+      return self._partition_names[partition_index]
+    else:
+      return None

--- a/gcp_variant_transforms/libs/variant_partition_test.py
+++ b/gcp_variant_transforms/libs/variant_partition_test.py
@@ -12,19 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for metrics_util module."""
+"""Unit tests for variant_partition module."""
 
 from __future__ import absolute_import
 
 import unittest
 
 from gcp_variant_transforms.libs import variant_partition
-
+from gcp_variant_transforms.testing import temp_dir
 
 class VariantPartitionTest(unittest.TestCase):
 
   def test_auto_partitioning(self):
     partitioner = variant_partition.VariantPartition()
+    self.assertTrue(partitioner.should_flatten())
     self.assertEqual(partitioner.get_num_partitions(),
                      variant_partition._DEFAULT_NUM_PARTITIONS)
 
@@ -48,9 +49,14 @@ class VariantPartitionTest(unittest.TestCase):
                             variant_partition._RESERVED_AUTO_PARTITIONS)
     self.assertGreaterEqual(partitioner.get_partition('Unknown'),
                             variant_partition._RESERVED_AUTO_PARTITIONS)
+    # Expected empty string as partition_name as we are in auto mode.
+    self.assertEqual(partitioner.get_partition_name(0), None)
+    self.assertEqual(partitioner.get_partition_name(100), None)
+
 
   def test_auto_partitioning_invalid_partitions(self):
     partitioner = variant_partition.VariantPartition()
+    self.assertTrue(partitioner.should_flatten())
     self.assertEqual(partitioner.get_num_partitions(),
                      variant_partition._DEFAULT_NUM_PARTITIONS)
 
@@ -62,3 +68,345 @@ class VariantPartitionTest(unittest.TestCase):
 
     with self.assertRaisesRegexp(ValueError, 'Cannot partition given input*'):
       partitioner.get_partition('  ', 1)
+
+  def test_config_boundaries(self):
+    partitioner = variant_partition.VariantPartition(
+        'gcp_variant_transforms/testing/data/partition_configs/'
+        'residual_at_end.yaml')
+    self.assertFalse(partitioner.should_flatten())
+    self.assertEqual(partitioner.get_num_partitions(), 8)
+    for i in range(partitioner.get_num_partitions()):
+      self.assertTrue(partitioner.should_keep_partition(i))
+
+    # 'chr1:0-1,000,000'
+    self.assertEqual(partitioner.get_partition('chr1', 0), 0)
+    self.assertEqual(partitioner.get_partition('chr1', 999999), 0)
+    # 'chr1:1,000,000-2,000,000'
+    self.assertEqual(partitioner.get_partition('chr1', 1000000), 1)
+    self.assertEqual(partitioner.get_partition('chr1', 1999999), 1)
+    # 'chr1:2,000,000-999,999,999'
+    self.assertEqual(partitioner.get_partition('chr1', 2000000), 2)
+    self.assertEqual(partitioner.get_partition('chr1', 999999998), 2)
+    self.assertEqual(partitioner.get_partition('chr1', 999999999), 7)
+
+    # 'chr2' OR 'chr2_alternate_name1' OR 'chr2_alternate_name2' OR '2'.
+    self.assertEqual(partitioner.get_partition('chr2', 0), 3)
+    self.assertEqual(partitioner.get_partition('chr2', 999999999000), 3)
+    self.assertEqual(
+        partitioner.get_partition('chr2_alternate_name1', 0), 3)
+    self.assertEqual(
+        partitioner.get_partition('chr2_alternate_name1', 999999999000), 3)
+    self.assertEqual(partitioner.get_partition('chr2_alternate_name2', 0), 3)
+    self.assertEqual(
+        partitioner.get_partition('CHR2_ALTERNATE_NAME2', 999999999000), 3)
+    self.assertEqual(partitioner.get_partition('2', 0), 3)
+    self.assertEqual(partitioner.get_partition('2', 999999999000), 3)
+
+    # 'chr4' OR 'chr5' OR 'chr6:1,000,000-2,000,000'
+    self.assertEqual(partitioner.get_partition('chr4', 0), 4)
+    self.assertEqual(partitioner.get_partition('chr4', 999999999000), 4)
+    self.assertEqual(partitioner.get_partition('chr5', 0), 4)
+    self.assertEqual(partitioner.get_partition('chr5', 999999999000), 4)
+    self.assertEqual(partitioner.get_partition('chr6', 1000000), 4)
+    self.assertEqual(partitioner.get_partition('chr6', 2000000 - 1), 4)
+    self.assertEqual(partitioner.get_partition('chr6', 0), 7)
+    self.assertEqual(partitioner.get_partition('chr6', 999999), 7)
+    self.assertEqual(partitioner.get_partition('chr6', 2000000), 7)
+
+    # '3:0-500,000'
+    self.assertEqual(partitioner.get_partition('3', 0), 5)
+    self.assertEqual(partitioner.get_partition('3', 499999), 5)
+    # '3:500,000-1,000,000'
+    self.assertEqual(partitioner.get_partition('3', 500000), 6)
+    self.assertEqual(partitioner.get_partition('3', 999999), 6)
+    self.assertEqual(partitioner.get_partition('3', 1000000), 7)
+
+  def test_config_case_insensitive(self):
+    partitioner = variant_partition.VariantPartition(
+        'gcp_variant_transforms/testing/data/partition_configs/'
+        'residual_at_end.yaml')
+    self.assertFalse(partitioner.should_flatten())
+    self.assertEqual(partitioner.get_num_partitions(), 8)
+    for i in range(partitioner.get_num_partitions()):
+      self.assertTrue(partitioner.should_keep_partition(i))
+
+    # 'chr1:0-1,000,000'
+    self.assertEqual(partitioner.get_partition('chr1', 0), 0)
+    self.assertEqual(partitioner.get_partition('Chr1', 0), 0)
+    self.assertEqual(partitioner.get_partition('CHr1', 0), 0)
+    self.assertEqual(partitioner.get_partition('CHR1', 0), 0)
+
+  def test_config_get_partition_name(self):
+    partitioner = variant_partition.VariantPartition(
+        'gcp_variant_transforms/testing/data/partition_configs/'
+        'residual_at_end.yaml')
+    self.assertFalse(partitioner.should_flatten())
+    self.assertEqual(partitioner.get_num_partitions(), 8)
+    for i in range(partitioner.get_num_partitions()):
+      self.assertTrue(partitioner.should_keep_partition(i))
+
+    self.assertEqual(partitioner.get_partition_name(0), 'chr01_part1')
+    self.assertEqual(partitioner.get_partition_name(1), 'chr01_part2')
+    self.assertEqual(partitioner.get_partition_name(2), 'chr01_part3')
+    self.assertEqual(partitioner.get_partition_name(3), 'chrom02')
+    self.assertEqual(partitioner.get_partition_name(4), 'chrom04_05_part_06')
+    self.assertEqual(partitioner.get_partition_name(5), 'chr3_01')
+    self.assertEqual(partitioner.get_partition_name(6), 'chr3_02')
+    self.assertEqual(partitioner.get_partition_name(7), 'all_remaining')
+
+
+  def test_config_non_existent_partition_name(self):
+    partitioner = variant_partition.VariantPartition(
+        'gcp_variant_transforms/testing/data/partition_configs/'
+        'residual_at_end.yaml')
+    self.assertFalse(partitioner.should_flatten())
+    self.assertEqual(partitioner.get_num_partitions(), 8)
+
+    with self.assertRaisesRegexp(
+        ValueError, 'Given partition index -1 is outside of expected range*'):
+      partitioner.get_partition_name(-1)
+    with self.assertRaisesRegexp(
+        ValueError, 'Given partition index 8 is outside of expected range*'):
+      partitioner.get_partition_name(8)
+
+  def test_config_residual_partition_in_middle(self):
+    partitioner = variant_partition.VariantPartition(
+        'gcp_variant_transforms/testing/data/partition_configs/'
+        'residual_in_middle.yaml')
+    self.assertFalse(partitioner.should_flatten())
+    self.assertEqual(partitioner.get_num_partitions(), 5)
+    for i in range(partitioner.get_num_partitions()):
+      self.assertTrue(partitioner.should_keep_partition(i))
+
+    # 'chr1:0-1,000,000'
+    self.assertEqual(partitioner.get_partition('chr1', 0), 0)
+    self.assertEqual(partitioner.get_partition('chr1', 999999), 0)
+    # 'chr1:1,000,000-2,000,000'
+    self.assertEqual(partitioner.get_partition('chr1', 1000000), 2)
+    self.assertEqual(partitioner.get_partition('chr1', 1999999), 2)
+    # 'chr2' OR 'ch2' OR 'c2' OR '2'
+    self.assertEqual(partitioner.get_partition('chr2', 0), 3)
+    self.assertEqual(partitioner.get_partition('chr2', 999999999000), 3)
+    # '3:500,000-1,000,000'
+    self.assertEqual(partitioner.get_partition('3', 500000), 4)
+    self.assertEqual(partitioner.get_partition('3', 999999), 4)
+
+    # All the followings are assigned to residual partition.
+    self.assertEqual(partitioner.get_partition('chr1', 2000000), 1)
+    self.assertEqual(partitioner.get_partition('chr1', 999999999), 1)
+
+    self.assertEqual(partitioner.get_partition('3', 0), 1)
+    self.assertEqual(partitioner.get_partition('3', 499999), 1)
+    self.assertEqual(partitioner.get_partition('3', 1000000), 1)
+
+    self.assertEqual(partitioner.get_partition('ch2', 0), 1)
+    self.assertEqual(partitioner.get_partition('c2', 0), 1)
+    self.assertEqual(partitioner.get_partition('2', 0), 1)
+
+    self.assertEqual(partitioner.get_partition('c4', 0), 1)
+    self.assertEqual(partitioner.get_partition('cr5', 0), 1)
+    self.assertEqual(partitioner.get_partition('chr6', 0), 1)
+
+  def test_config_residual_partition_absent(self):
+    partitioner = variant_partition.VariantPartition(
+        'gcp_variant_transforms/testing/data/partition_configs/'
+        'residual_missing.yaml')
+    self.assertFalse(partitioner.should_flatten())
+    self.assertEqual(partitioner.get_num_partitions(), 5)
+    # All partitions excpet the last one (dummy residual) should be kept.
+    for i in range(partitioner.get_num_partitions() - 1):
+      self.assertTrue(partitioner.should_keep_partition(i))
+    self.assertFalse(partitioner.should_keep_partition(5 - 1))
+
+    # 'chr1:0-1,000,000'
+    self.assertEqual(partitioner.get_partition('chr1', 0), 0)
+    self.assertEqual(partitioner.get_partition('chr1', 999999), 0)
+    # 'chr1:1,000,000-2,000,000'
+    self.assertEqual(partitioner.get_partition('chr1', 1000000), 1)
+    self.assertEqual(partitioner.get_partition('chr1', 1999999), 1)
+    # 'chr2' OR 'ch2' OR 'c2' OR '2'
+    self.assertEqual(partitioner.get_partition('chr2', 0), 2)
+    self.assertEqual(partitioner.get_partition('chr2', 999999999000), 2)
+    # '3:500,000-1,000,000'
+    self.assertEqual(partitioner.get_partition('3', 500000), 3)
+    self.assertEqual(partitioner.get_partition('3', 999999), 3)
+
+    # All the followings are assigned to residual partition.
+    self.assertEqual(partitioner.get_partition('chr1', 2000000), 4)
+    self.assertEqual(partitioner.get_partition('chr1', 999999999), 4)
+
+    self.assertEqual(partitioner.get_partition('3', 0), 4)
+    self.assertEqual(partitioner.get_partition('3', 499999), 4)
+    self.assertEqual(partitioner.get_partition('3', 1000000), 4)
+
+    self.assertEqual(partitioner.get_partition('ch2', 0), 4)
+    self.assertEqual(partitioner.get_partition('c2', 0), 4)
+    self.assertEqual(partitioner.get_partition('2', 0), 4)
+
+    self.assertEqual(partitioner.get_partition('c4', 0), 4)
+    self.assertEqual(partitioner.get_partition('cr5', 0), 4)
+    self.assertEqual(partitioner.get_partition('chr6', 0), 4)
+
+  def test_config_failed_missing_region(self):
+    tempdir = temp_dir.TempDir()
+    missing_region = [
+        '-  partition:',
+        '     partition_name: "chr01_part1"',
+        '     regions:',
+        '       - "chr1:0-1,000,000"',
+        '-  partition:',
+        '     partition_name: "all_remaining"',
+        '     regions:',
+        '       - "residual"',
+        '-  partition:',
+        '     partition_name: "missing_region"',
+        '     regions:',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError,
+        'Each partition must have at least one region.'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(missing_region)))
+
+  def test_config_failed_missing_partition_name(self):
+    tempdir = temp_dir.TempDir()
+    missing_par_name = [
+        '-  partition:',
+        '     regions:',
+        '       - "chr1:0-1,000,000"',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError,
+        'Each partition must have partition_name field.'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(missing_par_name)))
+    empty_par_name = [
+        '-  partition:',
+        '     partition_name: "          "',
+        '     regions:',
+        '       - "chr1:0-1,000,000"',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError,
+        'Partition name can not be empty string.'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(empty_par_name)))
+
+  def test_config_failed_duplicate_residual_partition(self):
+    tempdir = temp_dir.TempDir()
+    duplicate_residual = [
+        '-  partition:',
+        '     partition_name: "all_remaining"',
+        '     regions:',
+        '       - "residual"',
+        '-  partition:',
+        '     partition_name: "chr01"',
+        '     regions:',
+        '       - "chr1"',
+        '-  partition:',
+        '     partition_name: "all_remaining_2"',
+        '     regions:',
+        '       - "residual"',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError,
+        'There must be only one residual partition.'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(duplicate_residual)))
+
+  def test_config_failed_overlapping_regions(self):
+    tempdir = temp_dir.TempDir()
+    overlapping_regions = [
+        '-  partition:',
+        '     partition_name: "chr01_part1"',
+        '     regions:',
+        '       - "chr1:0-1,000,000"',
+        '-  partition:',
+        '     partition_name: "chr01_part2_overlapping"',
+        '     regions:',
+        '       - "chr1:999,999-2,000,000"',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError, 'Cannot add overlapping region *'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(overlapping_regions)))
+
+    full_and_partial = [
+        '-  partition:',
+        '     partition_name: "chr01_full"',
+        '     regions:',
+        '       - "chr1"',
+        '-  partition:',
+        '     partition_name: "chr01_part_overlapping"',
+        '     regions:',
+        '       - "chr1:1,000,000-2,000,000"',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError, 'Cannot add overlapping region *'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(full_and_partial)))
+
+    partial_and_full = [
+        '-  partition:',
+        '     partition_name: "chr01_part"',
+        '     regions:',
+        '       - "chr1:1,000,000-2,000,000"',
+        '-  partition:',
+        '     partition_name: "chr01_full_overlapping"',
+        '     regions:',
+        '       - "chr1"',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError, 'Cannot add overlapping region *'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(partial_and_full)))
+
+    full_and_full = [
+        '-  partition:',
+        '     partition_name: "chr01_full"',
+        '     regions:',
+        '       - "chr1"',
+        '-  partition:',
+        '     partition_name: "chr02_part"',
+        '     regions:',
+        '       - "chr2:1,000,000-2,000,000"',
+        '-  partition:',
+        '     partition_name: "chr01_full_redundant"',
+        '     regions:',
+        '       - "chr1"',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError, 'Cannot add overlapping region *'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(full_and_full)))
+
+  def test_config_failed_duplicate_table_name(self):
+    tempdir = temp_dir.TempDir()
+    dup_table_name = [
+        '-  partition:',
+        '     partition_name: "duplicate_name"',
+        '     regions:',
+        '       - "chr1:0-1,000,000"',
+        '-  partition:',
+        '     partition_name: "all_remaining"',
+        '     regions:',
+        '       - "residual"',
+        '-  partition:',
+        '     partition_name: "duplicate_name"',
+        '     regions:',
+        '       - "chr1:1,000,000-2,000,000"',
+    ]
+    with self.assertRaisesRegexp(
+        ValueError,
+        'Partition names must be unique *'):
+      _ = variant_partition.VariantPartition(
+          tempdir.create_temp_file(suffix='.yaml',
+                                   lines='\n'.join(dup_table_name)))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -385,3 +385,16 @@ class PreprocessOptions(VariantTransformsOptions):
         help=('The full path of the resolved headers. The file will not be'
               'generated if unspecified. Otherwise, please provide a local '
               'path if run locally, or a cloud path if run on Dataflow.'))
+
+class PartitionOptions(VariantTransformsOptions):
+  """Options for partitioning Variant records."""
+
+  def add_arguments(self, parser):
+    parser.add_argument(
+        '--partition_config_path',
+        default='',
+        help=('File containing list of partitions and output table names. You '
+              'can use provided default partition_config file to split output '
+              'by chromosome (one table per chromosome) which is located at: '
+              'gcp_variant_transforms/data/partition_configs/'
+              'homo_sapiens_default.yaml'))

--- a/gcp_variant_transforms/testing/data/partition_configs/README.md
+++ b/gcp_variant_transforms/testing/data/partition_configs/README.md
@@ -1,0 +1,22 @@
+This file summarizes the contents and the purpose for each files/folder within
+current folder.
+
+All files in this folder are used as inputs for --partition_config_path flag.
+
+`residual_at_end.yaml`, `residual_in_middle.yaml`, and `residual_missing.yaml`
+are used by unit tests in gcp_variant_transforms/libs/variant_partition_test.py
+which are testing the functionality of VariantPartition class. This class
+contains the core logic of partitioning functionality of VariantTransform.
+
+The main difference between these 3 yaml files is related to their residual
+partition (the default partition which all variants will be assigned to if they
+did not get mapped to any partition defined in the config file). As their name
+suggests, `residual_at_end.yaml` has its residual partition at the end,
+`residual_in_middle.yaml` has its residual partition in the middle, and
+`residual_missing.yaml` does not have a residual partition (which means all
+unmapped variants will be dropped from the final output).
+
+Similarly, `integration_with_residual.yaml` and
+`integration_without_residual.yaml` are used for integration testing of
+partitioning functionality and as their name suggests their main difference is
+presence or absense of residual partition.

--- a/gcp_variant_transforms/testing/data/partition_configs/integration_with_residual.yaml
+++ b/gcp_variant_transforms/testing/data/partition_configs/integration_with_residual.yaml
@@ -1,0 +1,49 @@
+-  partition:
+     partition_name: "chr01"
+     regions:
+       - "chr1"
+       - "1"
+-  partition:
+     partition_name: "chr02"
+     regions:
+       - "chr2"
+       - "2"
+-  partition:
+     partition_name: "chr03"
+     regions:
+       - "chr3"
+       - "3"
+-  partition:
+     partition_name: "chr04_05"
+     regions:
+       - "chr4"
+       - "4"
+       - "chr5"
+       - "5"
+-  partition:
+     partition_name: "chr06_07_08_09"
+     regions:
+       - "chr6"
+       - "6"
+       - "chr7"
+       - "7"
+       - "chr8"
+       - "8"
+       - "chr9"
+       - "9"
+-  partition:
+     partition_name: "chrX"
+     regions:
+       - "chrX"
+       - "x"
+-  partition:
+     partition_name: "chrY_M"
+     regions:
+       - "chrY"
+       - "y"
+       - "chrM"
+       - "m"
+-  partition:
+     partition_name: "all_remaining"
+     regions:
+       - "residual"

--- a/gcp_variant_transforms/testing/data/partition_configs/integration_without_residual.yaml
+++ b/gcp_variant_transforms/testing/data/partition_configs/integration_without_residual.yaml
@@ -1,0 +1,16 @@
+-  partition:
+     partition_name: "chr19_1M"
+     regions:
+       - "chr19:0-1,000,000"
+-  partition:
+     partition_name: "chr05_1M"
+     regions:
+       - "chr5:0-1,000,000"
+-  partition:
+     partition_name: "chr07_1M"
+     regions:
+       - "chr7:0-1,000,000"
+-  partition:
+     partition_name: "chr01_1M"
+     regions:
+       - "chr1:0-1,000,000"

--- a/gcp_variant_transforms/testing/data/partition_configs/residual_at_end.yaml
+++ b/gcp_variant_transforms/testing/data/partition_configs/residual_at_end.yaml
@@ -1,0 +1,37 @@
+-  partition:
+     partition_name: "chr01_part1"
+     regions:
+       - "chr1:0-1,000,000"
+-  partition:
+     partition_name: "chr01_part2"
+     regions:
+       - "chr1:1,000,000-2,000,000"
+-  partition:
+     partition_name: "chr01_part3"
+     regions:
+       - "chr1:2,000,000-999,999,999"
+-  partition:
+     partition_name: "chrom02"
+     regions:
+       - "chr2"
+       - "chr2_alternate_name1"
+       - "chr2_ALteRNate_NAME2"
+       - "2"
+-  partition:
+     partition_name: "chrom04_05_part_06"
+     regions:
+       - "CHR4"
+       - "cHr5"
+       - "chr6:1,000,000-2,000,000"
+-  partition:
+     partition_name: "chr3_01"
+     regions:
+       - "3:0-500,000"
+-  partition:
+     partition_name: "chr3_02"
+     regions:
+       - "3:500,000-1,000,000"
+-  partition:
+     partition_name: "all_remaining"
+     regions:
+       - "residual"

--- a/gcp_variant_transforms/testing/data/partition_configs/residual_in_middle.yaml
+++ b/gcp_variant_transforms/testing/data/partition_configs/residual_in_middle.yaml
@@ -1,0 +1,20 @@
+-  partition:
+     partition_name: "chr01_part1"
+     regions:
+       - "chr1:0-1,000,000"
+-  partition:
+     partition_name: "all_remaining"
+     regions:
+       - "residual"
+-  partition:
+     partition_name: "chr01_part2"
+     regions:
+       - "chr1:1,000,000-2,000,000"
+-  partition:
+     partition_name: "chrom02"
+     regions:
+       - "chr2"
+-  partition:
+     partition_name: "chr3_02"
+     regions:
+       - "3:500,000-1,000,000"

--- a/gcp_variant_transforms/testing/data/partition_configs/residual_missing.yaml
+++ b/gcp_variant_transforms/testing/data/partition_configs/residual_missing.yaml
@@ -1,0 +1,16 @@
+-  partition:
+     partition_name: "chr01_part1"
+     regions:
+       - "chr1:0-1,000,000"
+-  partition:
+     partition_name: "chr01_part2"
+     regions:
+       - "chr1:1,000,000-2,000,000"
+-  partition:
+     partition_name: "chrom02"
+     regions:
+       - "chr2"
+-  partition:
+     partition_name: "chr3_02"
+     regions:
+       - "3:500,000-1,000,000"


### PR DESCRIPTION
Following the PR #195, here we add the functionality that user can input
a config file to partition output tables to optimise their future BQ
query costs.

Issue #86.