### PR TITLE
Add integration tests for partitioning

### DIFF
--- a/gcp_variant_transforms/testing/data/partition_configs/integration_with_residual.yaml
+++ b/gcp_variant_transforms/testing/data/partition_configs/integration_with_residual.yaml
@@ -32,6 +32,14 @@
        - "chr9"
        - "9"
 -  partition:
+     partition_name: "chr19_10M"
+     regions:
+       - "chr19:0-10,000,000"
+-  partition:
+     partition_name: "chr19_20M"
+     regions:
+       - "chr19:10,000,000-20,000,000"
+-  partition:
      partition_name: "chrX"
      regions:
        - "chrX"

--- a/gcp_variant_transforms/testing/data/partition_configs/integration_without_residual.yaml
+++ b/gcp_variant_transforms/testing/data/partition_configs/integration_without_residual.yaml
@@ -11,6 +11,14 @@
      regions:
        - "chr7:0-1,000,000"
 -  partition:
-     partition_name: "chr01_1M"
+     partition_name: "chr01_100M"
      regions:
-       - "chr1:0-1,000,000"
+       - "chr1:0-100,000,000"
+-  partition:
+     partition_name: "chr01_200M"
+     regions:
+       - "chr1:100,000,000-200,000,000"
+-  partition:
+     partition_name: "chr01_remaining"
+     regions:
+       - "chr1:200,000,000-999,999,999"

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_partition_with_residual.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_partition_with_residual.json
@@ -1,0 +1,57 @@
+{
+  "test_name": "platinum-partition-with-residual",
+  "table_name": "platinum_partition_with_residual",
+  "input_pattern": "gs://genomics-public-data/platinum-genomes/vcf/*.vcf",
+  "partition_config": "gcp_variant_transforms/testing/data/partition_configs/integration_with_residual.yaml",
+  "runner": "DataflowRunner",
+  "variant_merge_strategy": "MOVE_TO_CALLS",
+  "worker_machine_type": "n1-highmem-4",
+  "max_num_workers": "60",
+  "num_workers": "60",
+  "assertion_configs": [
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr01"],
+      "expected_result": {"num_rows": 20206691}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr02"],
+      "expected_result": {"num_rows": 20712382}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr03"],
+      "expected_result": {"num_rows": 16194801}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr04_05"],
+      "expected_result": {"num_rows": 31051681}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr06_07_08_09"],
+      "expected_result": {"num_rows": 52523434}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr19_10M"],
+      "expected_result": {"num_rows": 1241683}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr19_20M"],
+      "expected_result": {"num_rows": 1077097}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chrX"],
+      "expected_result": {"num_rows": 19388563}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chrY_M"],
+      "expected_result": {"num_rows": 2188382}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_all_remaining"],
+      "expected_result": {"num_rows": 96701092}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM `{TABLE_NAME}*`"],
+      "expected_result": {"num_rows": 261285806}
+    }
+  ]
+}

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_partition_without_residual.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_partition_without_residual.json
@@ -1,0 +1,65 @@
+{
+  "test_name": "platinum-partition-without-residual",
+  "table_name": "platinum_partition_without_residual",
+  "input_pattern": "gs://genomics-public-data/platinum-genomes/vcf/*.vcf",
+  "partition_config": "gcp_variant_transforms/testing/data/partition_configs/integration_without_residual.yaml",
+  "runner": "DataflowRunner",
+  "variant_merge_strategy": "MOVE_TO_CALLS",
+  "worker_machine_type": "n1-highmem-4",
+  "max_num_workers": "20",
+  "num_workers": "20",
+  "assertion_configs": [
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr19_1M"],
+      "expected_result": {"num_rows": 158383}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr05_1M"],
+      "expected_result": {"num_rows": 153501}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr07_1M"],
+      "expected_result": {"num_rows": 140597}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr01_100M"],
+      "expected_result": {"num_rows": 8870895}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr01_200M"],
+      "expected_result": {"num_rows": 7017069}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM {TABLE_NAME}_chr01_remaining"],
+      "expected_result": {"num_rows": 4318727}
+    },
+    {
+      "query": ["SELECT COUNT(0) AS num_rows FROM `{TABLE_NAME}*`"],
+      "expected_result": {"num_rows": 20659172}
+    },
+    {
+      "query": ["SELECT SUM(start_position) AS sum_start FROM {TABLE_NAME}_chr19_1M"],
+      "expected_result": {"sum_start": 85839400831}
+    },
+    {
+      "query": ["SELECT SUM(start_position) AS sum_start FROM {TABLE_NAME}_chr05_1M"],
+      "expected_result": {"sum_start": 77369307142}
+    },
+    {
+      "query": ["SELECT SUM(start_position) AS sum_start FROM {TABLE_NAME}_chr07_1M"],
+      "expected_result": {"sum_start": 73321432863}
+    },
+    {
+      "query": ["SELECT SUM(start_position) AS sum_start FROM {TABLE_NAME}_chr01_100M"],
+      "expected_result": {"sum_start": 419294441736840}
+    },
+    {
+      "query": ["SELECT SUM(start_position) AS sum_start FROM {TABLE_NAME}_chr01_200M"],
+      "expected_result": {"sum_start": 1078363993898219}
+    },
+    {
+      "query": ["SELECT SUM(start_position) AS sum_start FROM {TABLE_NAME}_chr01_remaining"],
+      "expected_result": {"sum_start": 971922576966397}
+    }
+  ]
+}


### PR DESCRIPTION
Following PR #246 , here we add two integration tests to validate the correct
functionality of partitioning.

solves issue #247 
TESTED= time ./deploy_and_run_tests.sh --run_presubmit_tests took ~39 min