### PR TITLE
Update the schema #83

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -114,7 +114,7 @@ class BigQueryWriteOptions(VariantTransformsOptions):
               'overwritten. New records will be appended to those that '
               'already exist.'))
     parser.add_argument(
-        '--update_schema',
+        '--update_schema_on_append',
         type='bool', default=False, nargs='?', const=True,
         help=('If true, BigQuery schema will be updated by combining the '
               'existing schema and the new schema if they are compatible. '
@@ -162,8 +162,9 @@ class BigQueryWriteOptions(VariantTransformsOptions):
         raise
     # Ensuring given output table doesn't already exist to avoid overwriting it.
     if not parsed_args.append:
-      if parsed_args.update_schema:
-        raise ValueError('--update_schema requires --append to be true.')
+      if parsed_args.update_schema_on_append:
+        raise ValueError('--update_schema_on_append requires --append to be '
+                         'true.')
       try:
         client.tables.Get(bigquery.BigqueryTablesGetRequest(
             projectId=project_id,

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -114,6 +114,12 @@ class BigQueryWriteOptions(VariantTransformsOptions):
               'overwritten. New records will be appended to those that '
               'already exist.'))
     parser.add_argument(
+        '--update_schema',
+        type='bool', default=False, nargs='?', const=True,
+        help=('If true, BigQuery schema will be updated by combining the '
+              'existing schema and the new schema if they are compatible. '
+              'Requires append=True.'))
+    parser.add_argument(
         '--omit_empty_sample_calls',
         type='bool', default=False, nargs='?', const=True,
         help=("If true, samples that don't have a given call will be omitted."))
@@ -156,6 +162,8 @@ class BigQueryWriteOptions(VariantTransformsOptions):
         raise
     # Ensuring given output table doesn't already exist to avoid overwriting it.
     if not parsed_args.append:
+      if parsed_args.update_schema:
+        raise ValueError('--update_schema requires --append to be true.')
       try:
         client.tables.Get(bigquery.BigqueryTablesGetRequest(
             projectId=project_id,

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -16,12 +16,20 @@
 
 from __future__ import absolute_import
 
+import exceptions
 import random
+import re
+from typing import Dict, List  # pylint: disable=unused-import
+
 import apache_beam as beam
+from apache_beam.io.gcp.internal.clients import bigquery
+from apitools.base.py import exceptions
+from oauth2client.client import GoogleCredentials
 
 from gcp_variant_transforms.beam_io import vcf_header_io  # pylint: disable=unused-import
 from gcp_variant_transforms.libs import bigquery_row_generator
 from gcp_variant_transforms.libs import bigquery_schema_descriptor  # pylint: disable=unused-import
+from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs import bigquery_vcf_schema
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
@@ -65,6 +73,7 @@ class VariantToBigQuery(beam.PTransform):
       variant_merger=None,  # type: variant_merge_strategy.VariantMergeStrategy
       proc_var_factory=None,  # type: processed_variant.ProcessedVariantFactory
       append=False,  # type: bool
+      update_schema=False,  # type: bool
       allow_incompatible_records=False,  # type: bool
       omit_empty_sample_calls=False,  # type: bool
       num_bigquery_write_shards=1  # type: int
@@ -84,8 +93,10 @@ class VariantToBigQuery(beam.PTransform):
         The latter functionality is what is needed here.
       append: If true, existing records in output_table will not be
         overwritten. New records will be appended to those that already exist.
+      update_schema: If true, BigQuery schema will be updated by combining the
+        existing schema and the new schema if they are compatible.
       allow_incompatible_records: If true, field values are casted to Bigquery
-+        schema if there is a mismatch.
++       schema if there is a mismatch.
       omit_empty_sample_calls: If true, samples that don't have a given call
         will be omitted.
       num_bigquery_write_shards: If > 1, we will limit number of sources which
@@ -108,6 +119,7 @@ class VariantToBigQuery(beam.PTransform):
     self._allow_incompatible_records = allow_incompatible_records
     self._omit_empty_sample_calls = omit_empty_sample_calls
     self._num_bigquery_write_shards = num_bigquery_write_shards
+    self._update_bigquery_schema(update_schema)
 
   def expand(self, pcoll):
     bq_rows = pcoll | 'ConvertToBigQueryTableRow' >> beam.ParDo(
@@ -147,3 +159,79 @@ class VariantToBigQuery(beam.PTransform):
                       beam.io.BigQueryDisposition.WRITE_APPEND
                       if self._append
                       else beam.io.BigQueryDisposition.WRITE_TRUNCATE))))
+
+  def _update_bigquery_schema(self, update_schema):
+    # type: (bool) -> None
+    if not update_schema or not self._schema:
+      return
+    # if table does not exist, do not need to update the schema.
+    output_table_re_match = re.match(
+        r'^((?P<project>.+):)(?P<dataset>\w+)\.(?P<table>[\w\$]+)$',
+        self._output_table)
+    credentials = GoogleCredentials.get_application_default().create_scoped(
+        ['https://www.googleapis.com/auth/bigquery'])
+    client = bigquery.BigqueryV2(credentials=credentials)
+    try:
+      project_id = output_table_re_match.group('project')
+      dataset_id = output_table_re_match.group('dataset')
+      table_id = output_table_re_match.group('table')
+      found_table = client.tables.Get(bigquery.BigqueryTablesGetRequest(
+          projectId=project_id,
+          datasetId=dataset_id,
+          tableId=table_id))
+    except exceptions.HttpError:
+      return
+
+    new_schema = bigquery.TableSchema()
+    new_schema.fields = _merge_field_schemas(self._schema.fields,
+                                             found_table.schema.fields)
+    original_schema = found_table.schema
+    found_table.schema = new_schema
+    try:
+      client.tables.Update(bigquery.BigqueryTablesUpdateRequest(
+          projectId=project_id,
+          datasetId=dataset_id,
+          table=found_table,
+          tableId=table_id))
+    except exceptions.HttpError:
+      found_table.schema = original_schema
+
+
+def _merge_field_schemas(
+    field_schemas_1,  # type: List[bigquery.TableFieldSchema]
+    field_schemas_2  # type: List[bigquery.TableFieldSchema]
+    ):
+  # type: (...) -> List[bigquery.TableFieldSchema]
+  """Merges the `field_schemas_1` and `field_schemas_2`.
+
+  Raises an error if there are fields with the same name, but different modes or
+  different types.
+  """
+  existing_fields = {}  # type: Dict[str, bigquery.TableFieldSchema]
+  merged_field_schemas = []  # type: List[bigquery.TableFieldSchema]
+  for field_schema in field_schemas_1:
+    existing_fields.update({field_schema.name: field_schema})
+    merged_field_schemas.append(field_schema)
+
+  for field_schema in field_schemas_2:
+    if field_schema.name not in existing_fields.keys():
+      merged_field_schemas.append(field_schema)
+    else:
+      existing_field_schema = existing_fields.get(field_schema.name)
+      if field_schema.mode.lower() != existing_field_schema.mode.lower():
+        raise ValueError(
+            'The mode of field {} is not compatible. The original mode is {}, '
+            'and the new mode is {}.'.format(field_schema.name,
+                                             existing_field_schema.mode,
+                                             field_schema.mode))
+      if field_schema.type.lower() != existing_field_schema.type.lower():
+        raise ValueError(
+            'The type of field {} is not compatible. The original type is {}, '
+            'and the new type is {}.'.format(field_schema.name,
+                                             existing_field_schema.type,
+                                             field_schema.type))
+      if (field_schema.type.lower() ==
+          bigquery_util.TableFieldConstants.TYPE_RECORD):
+        existing_field_schema.fields = _merge_field_schemas(
+            existing_field_schema.fields, field_schema.fields)
+  return merged_field_schemas

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -294,7 +294,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
             mode=TableFieldConstants.MODE_NULLABLE,
             description='INFO foo desc')
     ]
-    merged_field_schemas = variant_to_bigquery._merge_field_schemas(
+    merged_field_schemas = variant_to_bigquery._get_merged_field_schemas(
         field_schemas_1, field_schemas_2)
     expected_merged_field_schemas = [
         bigquery.TableFieldSchema(
@@ -340,7 +340,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
             mode=TableFieldConstants.MODE_NULLABLE,
             description='INFO foo desc')
     ]
-    merged_field_schemas = variant_to_bigquery._merge_field_schemas(
+    merged_field_schemas = variant_to_bigquery._get_merged_field_schemas(
         field_schemas_1, field_schemas_2)
     expected_merged_field_schemas = [
         bigquery.TableFieldSchema(
@@ -376,9 +376,8 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
             mode=TableFieldConstants.MODE_REPEATED,
             description='INFO foo desc')
     ]
-    self.assertRaises(ValueError,
-                      variant_to_bigquery._merge_field_schemas, field_schemas_1,
-                      field_schemas_2)
+    self.assertRaises(ValueError, variant_to_bigquery._get_merged_field_schemas,
+                      field_schemas_1, field_schemas_2)
 
   def test_merge_field_schemas_conflict_type(self):
     field_schemas_1 = [
@@ -395,7 +394,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
             mode=TableFieldConstants.MODE_NULLABLE,
             description='INFO foo desc')
     ]
-    self.assertRaises(ValueError, variant_to_bigquery._merge_field_schemas,
+    self.assertRaises(ValueError, variant_to_bigquery._get_merged_field_schemas,
                       field_schemas_1, field_schemas_2)
 
   def test_merge_field_schemas_conflict_record_fields(self):
@@ -422,7 +421,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
         mode=TableFieldConstants.MODE_NULLABLE,
         description='FORMAT foo desc'))
     field_schemas_2 = [call_record_2]
-    self.assertRaises(ValueError, variant_to_bigquery._merge_field_schemas,
+    self.assertRaises(ValueError, variant_to_bigquery._get_merged_field_schemas,
                       field_schemas_1, field_schemas_2)
 
   def test_merge_field_schemas_same_record(self):
@@ -441,9 +440,10 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     field_schemas_2 = [call_record_1]
 
     expected_merged_field_schemas = [call_record_1]
-    self.assertEqual(variant_to_bigquery._merge_field_schemas(field_schemas_1,
-                                                              field_schemas_2),
-                     expected_merged_field_schemas)
+    self.assertEqual(
+        variant_to_bigquery._get_merged_field_schemas(field_schemas_1,
+                                                      field_schemas_2),
+        expected_merged_field_schemas)
 
   def test_merge_field_schemas_merge_record_fields(self):
     call_record_1 = bigquery.TableFieldSchema(
@@ -488,9 +488,10 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
         description='FORMAT foo desc'))
 
     expected_merged_field_schemas = [call_record_3]
-    self.assertEqual(variant_to_bigquery._merge_field_schemas(field_schemas_1,
-                                                              field_schemas_2),
-                     expected_merged_field_schemas)
+    self.assertEqual(
+        variant_to_bigquery._get_merged_field_schemas(field_schemas_1,
+                                                      field_schemas_2),
+        expected_merged_field_schemas)
 
   def test_merge_field_schemas_conflict_inner_record_fields(self):
     record_1 = bigquery.TableFieldSchema(
@@ -528,7 +529,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
         description='FORMAT foo desc'))
     record_2.fields.append(inner_record_2)
     field_schemas_2 = [record_2]
-    self.assertRaises(ValueError, variant_to_bigquery._merge_field_schemas,
+    self.assertRaises(ValueError, variant_to_bigquery._get_merged_field_schemas,
                       field_schemas_1, field_schemas_2)
 
   def test_merge_field_schemas_merge_inner_record_fields(self):
@@ -590,6 +591,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
         description='FORMAT foo desc'))
     merged_record.fields.append(merged_inner_record)
     expected_merged_field_schemas = [merged_record]
-    self.assertEqual(variant_to_bigquery._merge_field_schemas(field_schemas_1,
-                                                              field_schemas_2),
-                     expected_merged_field_schemas)
+    self.assertEqual(
+        variant_to_bigquery._get_merged_field_schemas(field_schemas_1,
+                                                      field_schemas_2),
+        expected_merged_field_schemas)

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -33,6 +33,7 @@ from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
 from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
 from gcp_variant_transforms.libs.bigquery_util import TableFieldConstants
+from gcp_variant_transforms.transforms import variant_to_bigquery
 from gcp_variant_transforms.transforms.variant_to_bigquery import _ConvertToBigQueryTableRow as ConvertToBigQueryTableRow
 
 
@@ -272,3 +273,323 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
             self._row_generator, allow_incompatible_records=True)))
     assert_that(bigquery_rows, equal_to([row]))
     pipeline.run()
+
+  def test_merge_field_schemas_no_same_id(self):
+    field_schemas_1 = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_INTEGER,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc'),
+        bigquery.TableFieldSchema(
+            name='IFR',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_REPEATED,
+            description='INFO foo desc')
+    ]
+    field_schemas_2 = [
+        bigquery.TableFieldSchema(
+            name='AB',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc')
+    ]
+    merged_field_schemas = variant_to_bigquery._merge_field_schemas(
+        field_schemas_1, field_schemas_2)
+    expected_merged_field_schemas = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_INTEGER,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc'),
+        bigquery.TableFieldSchema(
+            name='IFR',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_REPEATED,
+            description='INFO foo desc'),
+        bigquery.TableFieldSchema(
+            name='AB',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc')
+    ]
+    self.assertEqual(merged_field_schemas, expected_merged_field_schemas)
+
+  def test_merge_field_schemas_same_id_no_conflicts(self):
+    field_schemas_1 = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_INTEGER,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc'),
+        bigquery.TableFieldSchema(
+            name='IFR',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_REPEATED,
+            description='INFO foo desc')
+    ]
+    field_schemas_2 = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_INTEGER,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc'),
+        bigquery.TableFieldSchema(
+            name='AB',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc')
+    ]
+    merged_field_schemas = variant_to_bigquery._merge_field_schemas(
+        field_schemas_1, field_schemas_2)
+    expected_merged_field_schemas = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_INTEGER,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc'),
+        bigquery.TableFieldSchema(
+            name='IFR',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_REPEATED,
+            description='INFO foo desc'),
+        bigquery.TableFieldSchema(
+            name='AB',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc')
+    ]
+    self.assertEqual(merged_field_schemas, expected_merged_field_schemas)
+
+  def test_merge_field_schemas_conflict_mode(self):
+    field_schemas_1 = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_INTEGER,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc')
+    ]
+    field_schemas_2 = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_INTEGER,
+            mode=TableFieldConstants.MODE_REPEATED,
+            description='INFO foo desc')
+    ]
+    self.assertRaises(ValueError,
+                      variant_to_bigquery._merge_field_schemas, field_schemas_1,
+                      field_schemas_2)
+
+  def test_merge_field_schemas_conflict_type(self):
+    field_schemas_1 = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_INTEGER,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc')
+    ]
+    field_schemas_2 = [
+        bigquery.TableFieldSchema(
+            name='II',
+            type=TableFieldConstants.TYPE_FLOAT,
+            mode=TableFieldConstants.MODE_NULLABLE,
+            description='INFO foo desc')
+    ]
+    self.assertRaises(ValueError, variant_to_bigquery._merge_field_schemas,
+                      field_schemas_1, field_schemas_2)
+
+  def test_merge_field_schemas_conflict_record_fields(self):
+    call_record_1 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    call_record_1.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_BOOLEAN,
+        mode=TableFieldConstants.MODE_NULLABLE,
+        description='FORMAT foo desc'))
+    field_schemas_1 = [call_record_1]
+
+    call_record_2 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    call_record_2.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_INTEGER,
+        mode=TableFieldConstants.MODE_NULLABLE,
+        description='FORMAT foo desc'))
+    field_schemas_2 = [call_record_2]
+    self.assertRaises(ValueError, variant_to_bigquery._merge_field_schemas,
+                      field_schemas_1, field_schemas_2)
+
+  def test_merge_field_schemas_same_record(self):
+    call_record_1 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    call_record_1.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_BOOLEAN,
+        mode=TableFieldConstants.MODE_NULLABLE,
+        description='FORMAT foo desc'))
+
+    field_schemas_1 = [call_record_1]
+    field_schemas_2 = [call_record_1]
+
+    expected_merged_field_schemas = [call_record_1]
+    self.assertEqual(variant_to_bigquery._merge_field_schemas(field_schemas_1,
+                                                              field_schemas_2),
+                     expected_merged_field_schemas)
+
+  def test_merge_field_schemas_merge_record_fields(self):
+    call_record_1 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    call_record_1.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_BOOLEAN,
+        mode=TableFieldConstants.MODE_NULLABLE,
+        description='FORMAT foo desc'))
+
+    field_schemas_1 = [call_record_1]
+
+    call_record_2 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    call_record_2.fields.append(bigquery.TableFieldSchema(
+        name='GQ',
+        type=TableFieldConstants.TYPE_INTEGER,
+        mode=TableFieldConstants.MODE_NULLABLE,
+        description='FORMAT foo desc'))
+    field_schemas_2 = [call_record_2]
+
+    call_record_3 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    call_record_3.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_BOOLEAN,
+        mode=TableFieldConstants.MODE_NULLABLE,
+        description='FORMAT foo desc'))
+    call_record_3.fields.append(bigquery.TableFieldSchema(
+        name='GQ',
+        type=TableFieldConstants.TYPE_INTEGER,
+        mode=TableFieldConstants.MODE_NULLABLE,
+        description='FORMAT foo desc'))
+
+    expected_merged_field_schemas = [call_record_3]
+    self.assertEqual(variant_to_bigquery._merge_field_schemas(field_schemas_1,
+                                                              field_schemas_2),
+                     expected_merged_field_schemas)
+
+  def test_merge_field_schemas_conflict_inner_record_fields(self):
+    record_1 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    inner_record_1 = bigquery.TableFieldSchema(
+        name='inner record',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    inner_record_1.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='FORMAT foo desc'))
+    record_1.fields.append(inner_record_1)
+    field_schemas_1 = [record_1]
+
+    record_2 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    inner_record_2 = bigquery.TableFieldSchema(
+        name='inner record',
+        type=TableFieldConstants.TYPE_INTEGER,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    inner_record_2.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='FORMAT foo desc'))
+    record_2.fields.append(inner_record_2)
+    field_schemas_2 = [record_2]
+    self.assertRaises(ValueError, variant_to_bigquery._merge_field_schemas,
+                      field_schemas_1, field_schemas_2)
+
+  def test_merge_field_schemas_merge_inner_record_fields(self):
+    record_1 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    inner_record_1 = bigquery.TableFieldSchema(
+        name='inner record',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    inner_record_1.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='FORMAT foo desc'))
+    record_1.fields.append(inner_record_1)
+    field_schemas_1 = [record_1]
+
+    record_2 = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    inner_record_2 = bigquery.TableFieldSchema(
+        name='inner record',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    inner_record_2.fields.append(bigquery.TableFieldSchema(
+        name='AB',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='FORMAT foo desc'))
+    record_2.fields.append(inner_record_2)
+    field_schemas_2 = [record_2]
+
+    merged_record = bigquery.TableFieldSchema(
+        name=ColumnKeyConstants.CALLS,
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    merged_inner_record = bigquery.TableFieldSchema(
+        name='inner record',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='One record for each call.')
+    merged_inner_record.fields.append(bigquery.TableFieldSchema(
+        name='FB',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='FORMAT foo desc'))
+    merged_inner_record.fields.append(bigquery.TableFieldSchema(
+        name='AB',
+        type=TableFieldConstants.TYPE_RECORD,
+        mode=TableFieldConstants.MODE_REPEATED,
+        description='FORMAT foo desc'))
+    merged_record.fields.append(merged_inner_record)
+    expected_merged_field_schemas = [merged_record]
+    self.assertEqual(variant_to_bigquery._merge_field_schemas(field_schemas_1,
+                                                              field_schemas_2),
+                     expected_merged_field_schemas)

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -268,7 +268,7 @@ def run(argv=None):
              variant_merger,
              processed_variant_factory,
              append=known_args.append,
-             update_schema=known_args.update_schema,
+             update_schema_on_append=known_args.update_schema_on_append,
              allow_incompatible_records=known_args.allow_incompatible_records,
              omit_empty_sample_calls=known_args.omit_empty_sample_calls,
              num_bigquery_write_shards=known_args.num_bigquery_write_shards))

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -268,6 +268,7 @@ def run(argv=None):
              variant_merger,
              processed_variant_factory,
              append=known_args.append,
+             update_schema=known_args.update_schema,
              allow_incompatible_records=known_args.allow_incompatible_records,
              omit_empty_sample_calls=known_args.omit_empty_sample_calls,
              num_bigquery_write_shards=known_args.num_bigquery_write_shards))


### PR DESCRIPTION
- Add a new flag `update_schema` (requires `--append`). When it is set to true, BigQuery schema will be updated to be the merged version of the previous schema and the new schema.
- If the type or the mode is different for the same field id, throw an exception.
- Integration test will be added later.

Issue: [83](https://github.com/googlegenomics/gcp-variant-transforms/issues/83)
Tested: Manually run `vcf_to_bq` to an existing table with a different`input_file` (different schema).