### PR TITLE
update the job name to be unique #271

### DIFF
--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -156,18 +156,19 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
     options.view_as(pipeline_options.StandardOptions).runner = 'DirectRunner'
 
   google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)
+  merge_headers_job_name = '-'.join([
+      _MERGE_HEADERS_JOB_NAME,
+      datetime.datetime.now().strftime('%Y%m%d-%H%M%S')])
   if google_cloud_options.job_name:
-    google_cloud_options.job_name += '-' + _MERGE_HEADERS_JOB_NAME
+    google_cloud_options.job_name += '-' + merge_headers_job_name
   else:
-    google_cloud_options.job_name = _MERGE_HEADERS_JOB_NAME
+    google_cloud_options.job_name = merge_headers_job_name
 
   temp_directory = google_cloud_options.temp_location or tempfile.mkdtemp()
   # Add a time prefix to ensure files are unique in case multiple
   # pipelines are run at the same time.
-  temp_merged_headers_file_name = '-'.join([
-      datetime.datetime.now().strftime('%Y%m%d-%H%M%S'),
-      google_cloud_options.job_name,
-      _MERGE_HEADERS_FILE_NAME])
+  temp_merged_headers_file_name = '-'.join([google_cloud_options.job_name,
+                                            _MERGE_HEADERS_FILE_NAME])
   temp_merged_headers_file_path = filesystems.FileSystems.join(
       temp_directory, temp_merged_headers_file_name)
 

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -156,6 +156,8 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
     options.view_as(pipeline_options.StandardOptions).runner = 'DirectRunner'
 
   google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)
+  # Add a time suffix to ensure the job names and the merged headers files are
+  # unique in case multiple pipelines are run at the same time.
   merge_headers_job_name = '-'.join([
       _MERGE_HEADERS_JOB_NAME,
       datetime.datetime.now().strftime('%Y%m%d-%H%M%S')])
@@ -165,8 +167,6 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
     google_cloud_options.job_name = merge_headers_job_name
 
   temp_directory = google_cloud_options.temp_location or tempfile.mkdtemp()
-  # Add a time prefix to ensure files are unique in case multiple
-  # pipelines are run at the same time.
   temp_merged_headers_file_name = '-'.join([google_cloud_options.job_name,
                                             _MERGE_HEADERS_FILE_NAME])
   temp_merged_headers_file_path = filesystems.FileSystems.join(


### PR DESCRIPTION
Append current time on `merge-vcf-headers` job name such that multiple jobs can run together without running into a conflicting job name issue.

Issue: [271](https://github.com/googlegenomics/gcp-variant-transforms/issues/271)
Tested: Manually submited two jobs and checked the job names.