### PR TITLE
Remove all occurrences of VariantInfo.field_count 

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -89,7 +89,7 @@ class Variant(object):
       filters: A list of filters (normally quality filters) this variant has
         failed. `PASS` indicates this variant has passed all filters.
       info: A map of additional variant information. The key is specified
-        in the VCF record and the value can be Any type .
+        in the VCF record and the value can be any type .
       calls: The variant calls for this variant. Each one represents the
         determination of genotype with respect to this variant.
     """
@@ -530,35 +530,6 @@ class _VcfSource(filebasedsource.FileBasedSource):
           info[k] = v
 
       return info
-
-    def _get_field_count_as_string(self, field_count):
-      # type: (Optional[int]) -> Optional[str]
-      """Returns the string representation of field_count from PyVCF.
-
-      PyVCF converts field counts to an integer with some predefined constants
-      as specified in the vcf.parser.field_counts dict (e.g. 'A' is -1). This
-      method converts them back to their string representation to avoid having
-      direct dependency on the arbitrary PyVCF constants.
-
-      Args:
-        field_count: An integer representing the number of fields in INFO as
-          specified by PyVCF.
-
-      Returns:
-        A string representation of field_count (e.g. '-1' becomes 'A').
-
-      Raises:
-        ValueError: if the field_count is not valid.
-      """
-      if field_count is None:
-        return None
-      elif field_count >= 0:
-        return str(field_count)
-      field_count_to_string = {v: k for k, v in vcf.parser.field_counts.items()}
-      if field_count in field_count_to_string:
-        return field_count_to_string[field_count]
-      else:
-        raise ValueError('Invalid value for field_count: %d' % field_count)
 
     def _get_variant_calls(self, record, formats):
       calls = []

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -76,9 +76,7 @@ def _get_sample_variant_1():
   variant = vcfio.Variant(
       reference_name='20', start=1233, end=1234, reference_bases='C',
       alternate_bases=['A', 'T'], names=['rs123', 'rs2'], quality=50,
-      filters=['PASS'],
-      info={'AF': [0.5, 0.1],
-            'NS': 1})
+      filters=['PASS'], info={'AF': [0.5, 0.1], 'NS': 1})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[0, 0], info={'GQ': 48}))
   variant.calls.append(
@@ -101,12 +99,10 @@ def _get_sample_variant_2():
   variant = vcfio.Variant(
       reference_name='19', start=122, end=125, reference_bases='GTC',
       alternate_bases=[], names=['rs1234'], quality=40,
-      filters=['q10', 's50'],
-      info={'NS': 2})
+      filters=['q10', 's50'], info={'NS': 2})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[1, 0],
-                        phaseset=vcfio.DEFAULT_PHASESET_VALUE,
-                        info={'GQ': 48}))
+                        phaseset=vcfio.DEFAULT_PHASESET_VALUE, info={'GQ': 48}))
   variant.calls.append(
       vcfio.VariantCall(name='Sample2', genotype=[0, 1], info={'GQ': None}))
   return variant, vcf_line
@@ -129,8 +125,7 @@ def _get_sample_variant_3():
       info={'AF': [0.5]})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[0, 1],
-                        phaseset='1',
-                        info={'GQ': 45}))
+                        phaseset='1', info={'GQ': 45}))
   variant.calls.append(
       vcfio.VariantCall(name='Sample2',
                         genotype=[vcfio.MISSING_GENOTYPE_VALUE],
@@ -310,8 +305,7 @@ class VcfSourceTest(unittest.TestCase):
   def _default_variant_call(self):
     return vcfio.VariantCall(
         name='Sample1', genotype=[1, 0],
-        phaseset=vcfio.DEFAULT_PHASESET_VALUE,
-        info={'GQ': 48})
+        phaseset=vcfio.DEFAULT_PHASESET_VALUE, info={'GQ': 48})
 
   def test_variant_call_order(self):
     variant_call_1 = self._default_variant_call()
@@ -397,8 +391,7 @@ class VcfSourceTest(unittest.TestCase):
     record_line = '19	123	.	G	A	.	PASS	AF=0.2'
     expected_variant = Variant(
         reference_name='19', start=122, end=123, reference_bases='G',
-        alternate_bases=['A'], filters=['PASS'],
-        info={'AF': [0.2]})
+        alternate_bases=['A'], filters=['PASS'], info={'AF': [0.2]})
     read_data = self._create_temp_file_and_read_records(
         _SAMPLE_HEADER_LINES[:-1] + [header_line, record_line])
     self.assertEqual(1, len(read_data))
@@ -429,19 +422,14 @@ class VcfSourceTest(unittest.TestCase):
     variant_1 = Variant(
         reference_name='19', start=1, end=2, reference_bases='A',
         alternate_bases=['T', 'C'],
-        info={'HA': ['a1', 'a2'],
-              'HG': [1, 2, 3],
-              'HR': ['a', 'b', 'c'],
-              'HF': True,
-              'HU': [0.1]})
+        info={'HA': ['a1', 'a2'], 'HG': [1, 2, 3], 'HR': ['a', 'b', 'c'],
+              'HF': True, 'HU': [0.1]})
     variant_1.calls.append(VariantCall(name='Sample1', genotype=[1, 0]))
     variant_1.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
     variant_2 = Variant(
         reference_name='19', start=123, end=124, reference_bases='A',
         alternate_bases=['T'],
-        info={'HG': [3, 4, 5],
-              'HR': ['d', 'e'],
-              'HU': [1.1, 1.2]})
+        info={'HG': [3, 4, 5], 'HR': ['d', 'e'], 'HU': [1.1, 1.2]})
     variant_2.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
     variant_2.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
     read_data = self._create_temp_file_and_read_records(
@@ -464,8 +452,7 @@ class VcfSourceTest(unittest.TestCase):
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\r\n',]
     variant = Variant(
         reference_name='19', start=1, end=2, reference_bases='A',
-        alternate_bases=['T'],
-        info={'HU': ['a', 'b']})
+        alternate_bases=['T'], info={'HU': ['a', 'b']})
     variant.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
     variant.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
 
@@ -500,14 +487,12 @@ class VcfSourceTest(unittest.TestCase):
 
     variant_1 = Variant(
         reference_name='9', start=1, end=2, reference_bases='A',
-        alternate_bases=['T'],
-        info={'HU': ['a', 'b']})
+        alternate_bases=['T'], info={'HU': ['a', 'b']})
     variant_1.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
 
     variant_2 = Variant(
         reference_name='19', start=1, end=2, reference_bases='A',
-        alternate_bases=['T'],
-        info={'HU': ['a', 'b']})
+        alternate_bases=['T'], info={'HU': ['a', 'b']})
     variant_2.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
 
     read_data_1 = self._create_temp_file_and_read_records(

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -38,7 +38,6 @@ from gcp_variant_transforms.beam_io.vcfio import ReadAllFromVcf
 from gcp_variant_transforms.beam_io.vcfio import ReadFromVcf
 from gcp_variant_transforms.beam_io.vcfio import Variant
 from gcp_variant_transforms.beam_io.vcfio import VariantCall
-from gcp_variant_transforms.beam_io.vcfio import VariantInfo
 from gcp_variant_transforms.testing import testdata_util
 from gcp_variant_transforms.testing.temp_dir import TempDir
 
@@ -78,8 +77,8 @@ def _get_sample_variant_1():
       reference_name='20', start=1233, end=1234, reference_bases='C',
       alternate_bases=['A', 'T'], names=['rs123', 'rs2'], quality=50,
       filters=['PASS'],
-      info={'AF': vcfio.VariantInfo(data=[0.5, 0.1], field_count='A'),
-            'NS': vcfio.VariantInfo(data=1, field_count='1')})
+      info={'AF': [0.5, 0.1],
+            'NS': 1})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[0, 0], info={'GQ': 48}))
   variant.calls.append(
@@ -103,7 +102,7 @@ def _get_sample_variant_2():
       reference_name='19', start=122, end=125, reference_bases='GTC',
       alternate_bases=[], names=['rs1234'], quality=40,
       filters=['q10', 's50'],
-      info={'NS': vcfio.VariantInfo(data=2, field_count='1')})
+      info={'NS': 2})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[1, 0],
                         phaseset=vcfio.DEFAULT_PHASESET_VALUE,
@@ -127,7 +126,7 @@ def _get_sample_variant_3():
   variant = vcfio.Variant(
       reference_name='19', start=11, end=12, reference_bases='C',
       alternate_bases=['<SYMBOLIC>'], quality=49, filters=['q10'],
-      info={'AF': vcfio.VariantInfo(data=[0.5], field_count='A')})
+      info={'AF': [0.5]})
   variant.calls.append(
       vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                         phaseset='1',
@@ -399,7 +398,7 @@ class VcfSourceTest(unittest.TestCase):
     expected_variant = Variant(
         reference_name='19', start=122, end=123, reference_bases='G',
         alternate_bases=['A'], filters=['PASS'],
-        info={'AF': VariantInfo(data=[0.2], field_count='A')})
+        info={'AF': [0.2]})
     read_data = self._create_temp_file_and_read_records(
         _SAMPLE_HEADER_LINES[:-1] + [header_line, record_line])
     self.assertEqual(1, len(read_data))
@@ -430,19 +429,19 @@ class VcfSourceTest(unittest.TestCase):
     variant_1 = Variant(
         reference_name='19', start=1, end=2, reference_bases='A',
         alternate_bases=['T', 'C'],
-        info={'HA': VariantInfo(data=['a1', 'a2'], field_count='A'),
-              'HG': VariantInfo(data=[1, 2, 3], field_count='G'),
-              'HR': VariantInfo(data=['a', 'b', 'c'], field_count='R'),
-              'HF': VariantInfo(data=True, field_count='0'),
-              'HU': VariantInfo(data=[0.1], field_count=None)})
+        info={'HA': ['a1', 'a2'],
+              'HG': [1, 2, 3],
+              'HR': ['a', 'b', 'c'],
+              'HF': True,
+              'HU': [0.1]})
     variant_1.calls.append(VariantCall(name='Sample1', genotype=[1, 0]))
     variant_1.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
     variant_2 = Variant(
         reference_name='19', start=123, end=124, reference_bases='A',
         alternate_bases=['T'],
-        info={'HG': VariantInfo(data=[3, 4, 5], field_count='G'),
-              'HR': VariantInfo(data=['d', 'e'], field_count='R'),
-              'HU': VariantInfo(data=[1.1, 1.2], field_count=None)})
+        info={'HG': [3, 4, 5],
+              'HR': ['d', 'e'],
+              'HU': [1.1, 1.2]})
     variant_2.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
     variant_2.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
     read_data = self._create_temp_file_and_read_records(
@@ -466,7 +465,7 @@ class VcfSourceTest(unittest.TestCase):
     variant = Variant(
         reference_name='19', start=1, end=2, reference_bases='A',
         alternate_bases=['T'],
-        info={'HU': VariantInfo(data=['a', 'b'], field_count=None)})
+        info={'HU': ['a', 'b']})
     variant.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
     variant.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
 
@@ -502,13 +501,13 @@ class VcfSourceTest(unittest.TestCase):
     variant_1 = Variant(
         reference_name='9', start=1, end=2, reference_bases='A',
         alternate_bases=['T'],
-        info={'HU': VariantInfo(data=['a', 'b'], field_count=None)})
+        info={'HU': ['a', 'b']})
     variant_1.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
 
     variant_2 = Variant(
         reference_name='19', start=1, end=2, reference_bases='A',
         alternate_bases=['T'],
-        info={'HU': VariantInfo(data=['a', 'b'], field_count=None)})
+        info={'HU': ['a', 'b']})
     variant_2.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
 
     read_data_1 = self._create_temp_file_and_read_records(
@@ -840,9 +839,9 @@ class VcfSinkTest(unittest.TestCase):
   def test_info_field_count(self):
     coder = self._get_coder()
     variant = Variant()
-    variant.info['NS'] = VariantInfo(data=3, field_count='1')
-    variant.info['AF'] = VariantInfo(data=[0.333, 0.667], field_count='A')
-    variant.info['DB'] = VariantInfo(data=True, field_count='0')
+    variant.info['NS'] = 3
+    variant.info['AF'] = [0.333, 0.667]
+    variant.info['DB'] = True
     expected = '.	.	.	.	.	.	.	NS=3;AF=0.333,0.667;DB	.\n'
 
     self._assert_variant_lines_equal(coder.encode(variant), expected)

--- a/gcp_variant_transforms/libs/bigquery_row_generator_test.py
+++ b/gcp_variant_transforms/libs/bigquery_row_generator_test.py
@@ -156,48 +156,18 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     return schema
 
   def _make_header(self, key_num_dict):
-    info_list = [
-        parser._Info(
-            id=None,
-            num='A',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None),
-        parser._Info(
-            id=None,
-            num='1',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None),
-        parser._Info(
-            id=None,
-            num='2',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None),
-        parser._Info(
-            id=None,
-            num='3',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None),
-        parser._Info(
-            id=None,
-            num='4',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None)]
     infos_dict = {}
     for k, v in key_num_dict.iteritems():
-      if v == 'A':
-        infos_dict[k] = info_list[0]
+      if v == '.':
+        infos_dict[k] = parser._Info(None, None, None, '', None, None)
+      elif v == 'A':
+        infos_dict[k] = parser._Info(None, -1, None, '', None, None)
+      elif v == 'G':
+        infos_dict[k] = parser._Info(None, -2, None, '', None, None)
+      elif v == 'R':
+        infos_dict[k] = parser._Info(None, -3, None, '', None, None)
       elif int(v) <= 4 and int(v) >= 1:
-        infos_dict[k] = info_list[int(v)]
+        infos_dict[k] = parser._Info(None, int(v), None, '', None, None)
       else:
         self.fail("given NUM value is not valid: " + v)
     return vcf_header_io.VcfHeader(infos=infos_dict)

--- a/gcp_variant_transforms/libs/bigquery_row_generator_test.py
+++ b/gcp_variant_transforms/libs/bigquery_row_generator_test.py
@@ -222,10 +222,10 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'IFR': vcfio.VariantInfo([0.1, 0.2], ''),
-              'IFR2': vcfio.VariantInfo([0.2, 0.3], ''),
-              'IS': vcfio.VariantInfo('some data', ''),
-              'ISR': vcfio.VariantInfo(['data1', 'data2'], '')},
+        info={'IFR': [0.1, 0.2],
+              'IFR2': [0.2, 0.3],
+              'IS': 'some data',
+              'ISR': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -270,8 +270,8 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='CT',
         alternate_bases=[], filters=['q10'],
-        info={'IS': vcfio.VariantInfo('some data', ''),
-              'ISR': vcfio.VariantInfo(['data1', 'data2'], '')})
+        info={'IS': 'some data',
+              'ISR': ['data1', 'data2']})
     header_num_dict = {'IS': '1', 'ISR': '2'}
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
@@ -319,10 +319,10 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='CT',
         alternate_bases=[], filters=['q10'],
-        info={'IIR': vcfio.VariantInfo([0, 1, None], ''),
-              'IBR': vcfio.VariantInfo([True, None, False], ''),
-              'IFR': vcfio.VariantInfo([0.1, 0.2, None, 0.4], ''),
-              'ISR': vcfio.VariantInfo([None, 'data1', 'data2'], '')})
+        info={'IIR': [0, 1, None],
+              'IBR': [True, None, False],
+              'IFR': [0.1, 0.2, None, 0.4],
+              'ISR': [None, 'data1', 'data2']})
     header_num_dict = {'IIR': '3', 'IBR': '3', 'IFR': '4', 'ISR': '3'}
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
@@ -345,9 +345,8 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='CT',
         alternate_bases=[], filters=[sample_unicode_str, sample_utf8_str],
-        info={'IS': vcfio.VariantInfo(sample_utf8_str, ''),
-              'ISR': vcfio.VariantInfo(
-                  [sample_unicode_str, sample_utf8_str], '')})
+        info={'IS': sample_utf8_str,
+              'ISR': [sample_unicode_str, sample_utf8_str]})
     header_num_dict = {'IS': '1', 'ISR': '2'}
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
@@ -366,9 +365,9 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='CT',
         alternate_bases=[], filters=[],
-        info={'IF': vcfio.VariantInfo(float('inf'), ''),
-              'IFR': vcfio.VariantInfo([float('-inf'), float('nan'), 1.2], ''),
-              'IF2': vcfio.VariantInfo(float('nan'), ''),})
+        info={'IF': float('inf'),
+              'IFR': [float('-inf'), float('nan'), 1.2],
+              'IF2': float('nan')})
     header_num_dict = {'IF': '1', 'IFR': '3', 'IF2': '1'}
     null_replacement_value = -sys.maxint
     expected_row = {
@@ -388,8 +387,8 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='CT',
         alternate_bases=[],
-        info={'IS': vcfio.VariantInfo('data1', ''),
-              '_IS': vcfio.VariantInfo('data2', '')})
+        info={'IS': 'data1',
+              '_IS': 'data2'})
     header_num_dict = {'IS': '1', '_IS': '2'}
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
@@ -408,9 +407,9 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'IFR': vcfio.VariantInfo([0.1, 0.2], ''),
-              'IFR2': vcfio.VariantInfo([0.2, 0.3], ''),
-              'IS': vcfio.VariantInfo('some data', ''),},
+        info={'IFR': [0.1, 0.2],
+              'IFR2': [0.2, 0.3],
+              'IS': 'some data'},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -516,10 +515,10 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='CT',
         alternate_bases=[], filters=[],
-        info={'IB': vcfio.VariantInfo(data=1, field_count=''),
-              'II': vcfio.VariantInfo(data=1.1, field_count=''),
-              'IFR': vcfio.VariantInfo(data=[1, 2], field_count=''),
-              'ISR': vcfio.VariantInfo(data=[1.0, 2.0], field_count='')})
+        info={'IB': 1,
+              'II': 1.1,
+              'IFR': [1, 2],
+              'ISR': [1.0, 2.0]})
     header_num_dict = {'IB': '1', 'II': '1', 'IFR': '2', 'ISR': '2'}
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
@@ -540,7 +539,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
           reference_name='chr19', start=11, end=12, reference_bases='CT',
           alternate_bases=[], filters=[],
           # String cannot be casted to integer.
-          info={'II': vcfio.VariantInfo(data='1.1', field_count=''),})
+          info={'II': '1.1'})
       header_num_dict = {'II': '1'}
       self._get_row_list_from_variant(
           variant, header_num_dict, allow_incompatible_records=True)
@@ -550,11 +549,11 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='CT',
         alternate_bases=[], filters=[],
-        info={'IB': vcfio.VariantInfo(data=[1, 2], field_count=''),
-              'IBR': vcfio.VariantInfo(data=1, field_count=''),
-              'II': vcfio.VariantInfo(data=[10, 20], field_count=''),
-              'IFR': vcfio.VariantInfo(data=1.1, field_count=''),
-              'ISR': vcfio.VariantInfo(data='foo', field_count='')},)
+        info={'IB': [1, 2],
+              'IBR': 1,
+              'II': [10, 20],
+              'IFR': 1.1,
+              'ISR': 'foo'},)
     header_num_dict = {'IB': '2', 'IBR': '1', 'II': '2', 'IFR': '1', 'ISR': '1'}
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',

--- a/gcp_variant_transforms/libs/processed_variant.py
+++ b/gcp_variant_transforms/libs/processed_variant.py
@@ -242,7 +242,7 @@ class ProcessedVariantFactory(object):
     self._variant_counter.inc()
     for key, variant_info_data in variant.info.iteritems():
       if (self._header_fields.infos[key][_HeaderKeyConstants.NUM] ==
-          _FIELD_COUNT_ALTERNATE_ALLELE):
+          vcf.parser.field_counts[_FIELD_COUNT_ALTERNATE_ALLELE]):
         self._add_per_alt_info(proc_var, key, variant_info_data)
       elif key in self._annotation_field_set:
         self._annotation_processor.add_annotation_data(

--- a/gcp_variant_transforms/libs/processed_variant.py
+++ b/gcp_variant_transforms/libs/processed_variant.py
@@ -240,15 +240,15 @@ class ProcessedVariantFactory(object):
     """
     proc_var = ProcessedVariant(variant)
     self._variant_counter.inc()
-    for key, variant_info in variant.info.iteritems():
+    for key, variant_info_data in variant.info.iteritems():
       if (self._header_fields.infos[key][_HeaderKeyConstants.NUM] ==
           _FIELD_COUNT_ALTERNATE_ALLELE):
-        self._add_per_alt_info(proc_var, key, variant_info.data)
+        self._add_per_alt_info(proc_var, key, variant_info_data)
       elif key in self._annotation_field_set:
         self._annotation_processor.add_annotation_data(
-            proc_var, key, variant_info.data)
+            proc_var, key, variant_info_data)
       else:
-        proc_var._non_alt_info[key] = variant_info.data
+        proc_var._non_alt_info[key] = variant_info_data
     return proc_var
 
   def _add_per_alt_info(self, proc_var, field_name, variant_info_data):

--- a/gcp_variant_transforms/libs/processed_variant.py
+++ b/gcp_variant_transforms/libs/processed_variant.py
@@ -241,7 +241,8 @@ class ProcessedVariantFactory(object):
     proc_var = ProcessedVariant(variant)
     self._variant_counter.inc()
     for key, variant_info_data in variant.info.iteritems():
-      if (self._header_fields.infos[key][_HeaderKeyConstants.NUM] ==
+      if (self._split_alternate_allele_info_fields and
+          self._header_fields.infos[key][_HeaderKeyConstants.NUM] ==
           vcf.parser.field_counts[_FIELD_COUNT_ALTERNATE_ALLELE]):
         self._add_per_alt_info(proc_var, key, variant_info_data)
       elif key in self._annotation_field_set:

--- a/gcp_variant_transforms/libs/processed_variant.py
+++ b/gcp_variant_transforms/libs/processed_variant.py
@@ -241,10 +241,8 @@ class ProcessedVariantFactory(object):
     proc_var = ProcessedVariant(variant)
     self._variant_counter.inc()
     for key, variant_info in variant.info.iteritems():
-      # TODO(bashir2): field_count should be removed from VariantInfo and
-      # instead looked up from header_fields.
-      if (self._split_alternate_allele_info_fields and
-          variant_info.field_count == _FIELD_COUNT_ALTERNATE_ALLELE):
+      if (self._header_fields.infos[key][_HeaderKeyConstants.NUM] ==
+          _FIELD_COUNT_ALTERNATE_ALLELE):
         self._add_per_alt_info(proc_var, key, variant_info.data)
       elif key in self._annotation_field_set:
         self._annotation_processor.add_annotation_data(

--- a/gcp_variant_transforms/libs/processed_variant_test.py
+++ b/gcp_variant_transforms/libs/processed_variant_test.py
@@ -59,8 +59,8 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', ''),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '')},
+        info={'A1': 'some data',
+              'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                               info={'GQ': 20, 'HQ': [10, 20]}),
@@ -129,9 +129,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
 
   def _get_sample_variant_and_header_with_csq(self):
     variant = self._get_sample_variant()
-    variant.info['CSQ'] = vcfio.VariantInfo(
-        data=['A|C1|I1|S1|G1', 'TT|C2|I2|S2|G2', 'A|C3|I3|S3|G3'],
-        field_count='')
+    variant.info['CSQ'] = ['A|C1|I1|S1|G1', 'TT|C2|I2|S2|G2', 'A|C3|I3|S3|G3']
     csq_info = parser._Info(
         id=None,
         num='.',
@@ -199,10 +197,8 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     # with the difference that it has an extra alt annotation which does not
     # match any alts.
     variant, header_fields = self._get_sample_variant_and_header_with_csq()
-    variant.info['CSQ'] = vcfio.VariantInfo(
-        data=['A|C1|I1|S1|G1', 'TT|C2|I2|S2|G2', 'A|C3|I3|S3|G3',
-              'ATAT|C3|I3|S3|G3'],
-        field_count='')
+    variant.info['CSQ'] = data=['A|C1|I1|S1|G1', 'TT|C2|I2|S2|G2',
+                                'A|C3|I3|S3|G3', 'ATAT|C3|I3|S3|G3']
     counter_factory = _CounterSpyFactory()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,
@@ -245,11 +241,9 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         alternate_bases=['<SYMBOLIC>', '[13:123457[.', 'C[10:10357[.'],
         names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'CSQ': vcfio.VariantInfo(
-            data=[
-                'SYMBOLIC|C1|I1|S1|G1', '[13|C2|I2|S2|G2', 'C[10|C3|I3|S3|G3',
-                'C[1|C3|I3|S3|G3'],  # The last one does not match any alts.
-            field_count='')})
+        info={'CSQ': [
+          'SYMBOLIC|C1|I1|S1|G1', '[13|C2|I2|S2|G2', 'C[10|C3|I3|S3|G3',
+          'C[1|C3|I3|S3|G3']}) # The last one does not match any alts.
     counter_factory = _CounterSpyFactory()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,
@@ -293,10 +287,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         alternate_bases=['CT', 'CC', 'CCC'],
         names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'CSQ': vcfio.VariantInfo(
-            data=[
-                'T|C1|I1|S1|G1', 'C|C2|I2|S2|G2', 'CC|C3|I3|S3|G3'],
-            field_count='')})
+        info={'CSQ': ['T|C1|I1|S1|G1', 'C|C2|I2|S2|G2', 'CC|C3|I3|S3|G3']})
     counter_factory = _CounterSpyFactory()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,
@@ -340,10 +331,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         alternate_bases=['CCT', 'CCC', 'CCCC'],
         names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'CSQ': vcfio.VariantInfo(
-            data=[
-                'CT|C1|I1|S1|G1', 'CC|C2|I2|S2|G2', 'CCC|C3|I3|S3|G3'],
-            field_count='')})
+        info={'CSQ': ['CT|C1|I1|S1|G1', 'CC|C2|I2|S2|G2', 'CCC|C3|I3|S3|G3']})
     counter_factory = _CounterSpyFactory()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,
@@ -387,10 +375,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         alternate_bases=['AA', 'AAA'],
         names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'CSQ': vcfio.VariantInfo(
-            data=[
-                'AA|C1|I1|S1|G1', 'AAA|C2|I2|S2|G2'],
-            field_count='')})
+        info={'CSQ': ['AA|C1|I1|S1|G1', 'AAA|C2|I2|S2|G2']})
     counter_factory = _CounterSpyFactory()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,
@@ -435,10 +420,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         # Note that in the minimal mode, 'T' is an ambiguous annotation ALT
         # because it can map to either the 'CT' SNV or the 'CCT' insertion.
         # It is not ambiguous in the non-minimal mode (it only maps to `CT`).
-        info={'CSQ': vcfio.VariantInfo(
-            data=[
-                'T|C1|I1|S1|G1', '-|C2|I2|S2|G2'],
-            field_count='')})
+        info={'CSQ': ['T|C1|I1|S1|G1', '-|C2|I2|S2|G2']})
     counter_factory = _CounterSpyFactory()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,
@@ -495,10 +477,8 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         # ALT because it can map to either the 'T' SNV or the 'CT' insertion.
         # But because there is ALLELE_NUM there should be no ambiguity.
         # The last four annotations have incorrect ALLELE_NUMs.
-        info={'CSQ': vcfio.VariantInfo(
-            data=[
-                'T|C1|I1|1', 'T|C2|I2|2', 'T|C3|I3|0', 'T|C4|I4|3',
-                'T|C5|I5|TEST', 'T|C6|I6|'], field_count='')})
+        info={'CSQ': ['T|C1|I1|1', 'T|C2|I2|2', 'T|C3|I3|0', 'T|C4|I4|3',
+                      'T|C5|I5|TEST', 'T|C6|I6|']})
     counter_factory = _CounterSpyFactory()
     factory = processed_variant.ProcessedVariantFactory(
         header_fields,

--- a/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
@@ -32,8 +32,8 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'A1': 'some data',
+              'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                               info={'GQ': 20, 'HQ': [10, 20]}),
@@ -43,8 +43,8 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs3'], quality=20,
         filters=['q10'],
-        info={'A1': vcfio.VariantInfo('some data2', '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A1': 'some data2',
+              'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(name='Sample4', genotype=[1, 0],
@@ -86,11 +86,9 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
         merged_variant.calls)
     self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
     self.assertTrue(
-        merged_variant.info['A1'].data in ('some data', 'some data2'))
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
-                     merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
-                     merged_variant.info['A3'])
+        merged_variant.info['A1'] in ('some data', 'some data2'))
+    self.assertEqual(['data1', 'data2'], merged_variant.info['A2'])
+    self.assertEqual(['data3', 'data4'], merged_variant.info['A3'])
 
   def test_get_merged_variants_move_quality_and_filter_to_calls(self):
     strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
@@ -134,11 +132,9 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
         merged_variant.calls)
     self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
     self.assertTrue(
-        merged_variant.info['A1'].data in ('some data', 'some data2'))
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
-                     merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
-                     merged_variant.info['A3'])
+        merged_variant.info['A1'] in ('some data', 'some data2'))
+    self.assertEqual(['data1', 'data2'], merged_variant.info['A2'])
+    self.assertEqual(['data3', 'data4'], merged_variant.info['A3'])
 
   def test_get_merged_variants_move_info_to_calls(self):
     strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(
@@ -170,10 +166,8 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
                            info={'GQ': 20, 'A1': 'some data2'})],
         merged_variant.calls)
     self.assertItemsEqual(['A2', 'A3'], merged_variant.info.keys())
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
-                     merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
-                     merged_variant.info['A3'])
+    self.assertEqual(['data1', 'data2'], merged_variant.info['A2'])
+    self.assertEqual(['data3', 'data4'], merged_variant.info['A3'])
 
   def test_get_merged_variants_move_everything_to_calls(self):
     strategy = merge_with_non_variants_strategy.MergeWithNonVariantsStrategy(

--- a/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/merge_with_non_variants_strategy_test.py
@@ -32,8 +32,7 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'A1': 'some data',
-              'A2': ['data1', 'data2']},
+        info={'A1': 'some data', 'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                               info={'GQ': 20, 'HQ': [10, 20]}),
@@ -43,8 +42,7 @@ class MergeWithNonVariantsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs3'], quality=20,
         filters=['q10'],
-        info={'A1': 'some data2',
-              'A3': ['data3', 'data4']},
+        info={'A1': 'some data2', 'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(name='Sample4', genotype=[1, 0],

--- a/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy.py
+++ b/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy.py
@@ -83,7 +83,7 @@ class MoveToCallsStrategy(variant_merge_strategy.VariantMergeStrategy):
           bigquery_util.ColumnKeyConstants.QUALITY] = variant.quality
     for info_key, info_value in variant.info.iteritems():
       if self._should_move_info_key_to_calls(info_key):
-        additional_call_info[info_key] = info_value.data
+        additional_call_info[info_key] = info_value
     for call in variant.calls:
       call.info.update(additional_call_info)
 

--- a/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy_test.py
@@ -35,8 +35,7 @@ class MoveToCallsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'A1': 'some data',
-              'A2': ['data1', 'data2']},
+        info={'A1': 'some data', 'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                               info={'GQ': 20, 'HQ': [10, 20]}),
@@ -46,8 +45,7 @@ class MoveToCallsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs3'], quality=20,
         filters=['q10'],
-        info={'A1': 'some data2',
-              'A3': ['data3', 'data4']},
+        info={'A1': 'some data2', 'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(name='Sample4', genotype=[1, 0],

--- a/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy_test.py
+++ b/gcp_variant_transforms/libs/variant_merge/move_to_calls_strategy_test.py
@@ -35,8 +35,8 @@ class MoveToCallsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'A1': 'some data',
+              'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(name='Sample1', genotype=[0, 1],
                               info={'GQ': 20, 'HQ': [10, 20]}),
@@ -46,8 +46,8 @@ class MoveToCallsStrategyTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs3'], quality=20,
         filters=['q10'],
-        info={'A1': vcfio.VariantInfo('some data2', '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A1': 'some data2',
+              'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(name='Sample4', genotype=[1, 0],
@@ -88,10 +88,10 @@ class MoveToCallsStrategyTest(unittest.TestCase):
         merged_variant.calls)
     self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
     self.assertTrue(
-        merged_variant.info['A1'].data in ('some data', 'some data2'))
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+        merged_variant.info['A1'] in ('some data', 'some data2'))
+    self.assertEqual(['data1', 'data2'],
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(['data3', 'data4'],
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_quality_and_filter_to_calls(self):
@@ -136,10 +136,10 @@ class MoveToCallsStrategyTest(unittest.TestCase):
         merged_variant.calls)
     self.assertItemsEqual(['A1', 'A2', 'A3'], merged_variant.info.keys())
     self.assertTrue(
-        merged_variant.info['A1'].data in ('some data', 'some data2'))
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+        merged_variant.info['A1'] in ('some data', 'some data2'))
+    self.assertEqual(['data1', 'data2'],
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(['data3', 'data4'],
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_info_to_calls(self):
@@ -172,9 +172,9 @@ class MoveToCallsStrategyTest(unittest.TestCase):
                            info={'GQ': 20, 'A1': 'some data2'})],
         merged_variant.calls)
     self.assertItemsEqual(['A2', 'A3'], merged_variant.info.keys())
-    self.assertEqual(vcfio.VariantInfo(['data1', 'data2'], '2'),
+    self.assertEqual(['data1', 'data2'],
                      merged_variant.info['A2'])
-    self.assertEqual(vcfio.VariantInfo(['data3', 'data4'], '2'),
+    self.assertEqual(['data3', 'data4'],
                      merged_variant.info['A3'])
 
   def test_get_merged_variants_move_everything_to_calls(self):

--- a/gcp_variant_transforms/testing/vcf_header_util.py
+++ b/gcp_variant_transforms/testing/vcf_header_util.py
@@ -1,0 +1,43 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for creating VcfHeader objects used by unit tests."""
+
+from __future__ import absolute_import
+
+from vcf import parser
+
+from gcp_variant_transforms.beam_io import vcf_header_io
+
+
+def make_header(header_num_dict):
+  # type: (Dict[str, str]) -> VcfHeader
+  """Builds a VcfHeader based on the header_num_dict.
+
+  All fields of parser._Info are set to their default values except for the
+  'id' which is set to the keys in header_num_dict and 'num' which is set based
+  on header_num_dict values mapped according to parser.field_counts.
+
+  Args:
+    header_num_dict: a dictionary mapping info keys to string num values.
+  """
+  infos = {}
+  for k, v in header_num_dict.iteritems():
+    if v in parser.field_counts:
+      pyvcf_num_field_value = parser.field_counts[v]
+    else:
+      pyvcf_num_field_value = int(v)
+    infos[k] = parser._Info(id=k, num=pyvcf_num_field_value,
+                            type=None, desc='', source=None, version=None)
+  return vcf_header_io.VcfHeader(infos=infos)

--- a/gcp_variant_transforms/transforms/filter_variants_test.py
+++ b/gcp_variant_transforms/transforms/filter_variants_test.py
@@ -43,8 +43,8 @@ class FilterVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'A1': 'some data',
+              'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -58,8 +58,8 @@ class FilterVariantsTest(unittest.TestCase):
         reference_name='20', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=20,
         filters=['q10'],
-        info={'A1': vcfio.VariantInfo('some data2', '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A1': 'some data2',
+              'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(

--- a/gcp_variant_transforms/transforms/filter_variants_test.py
+++ b/gcp_variant_transforms/transforms/filter_variants_test.py
@@ -43,8 +43,7 @@ class FilterVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'A1': 'some data',
-              'A2': ['data1', 'data2']},
+        info={'A1': 'some data', 'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -58,8 +57,7 @@ class FilterVariantsTest(unittest.TestCase):
         reference_name='20', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=20,
         filters=['q10'],
-        info={'A1': 'some data2',
-              'A3': ['data3', 'data4']},
+        info={'A1': 'some data2', 'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(

--- a/gcp_variant_transforms/transforms/infer_undefined_headers.py
+++ b/gcp_variant_transforms/transforms/infer_undefined_headers.py
@@ -90,8 +90,7 @@ class _InferUndefinedHeaderFields(beam.DoFn):
       that is not defined in the header.
     """
     infos = {}
-    for info_field_key, variant_info in variant.info.iteritems():
-      info_field_value = variant_info.data
+    for info_field_key, info_field_value in variant.info.iteritems():
       if not defined_headers or info_field_key not in defined_headers.infos:
         if info_field_key in infos:
           raise ValueError(

--- a/gcp_variant_transforms/transforms/infer_undefined_headers_test.py
+++ b/gcp_variant_transforms/transforms/infer_undefined_headers_test.py
@@ -58,12 +58,12 @@ class InferUndefinedHeaderFieldsTest(unittest.TestCase):
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'IS': vcfio.VariantInfo('some data', '1'),
-              'ISI': vcfio.VariantInfo('1', '1'),
-              'ISF': vcfio.VariantInfo('1.0', '1'),
-              'IF': vcfio.VariantInfo(1.0, '1'),
-              'IB': vcfio.VariantInfo(True, '0'),
-              'IA': vcfio.VariantInfo([0.1, 0.2], '2')},
+        info={'IS': 'some data',
+              'ISI': '1',
+              'ISF': '1.0',
+              'IF': 1.0,
+              'IB': True,
+              'IA': [0.1, 0.2]},
         calls=[vcfio.VariantCall(
             name='Sample1', genotype=[0, 1], phaseset='*',
             info={'FI': 20, 'FU': [10.0, 20.0]})]
@@ -74,7 +74,7 @@ class InferUndefinedHeaderFieldsTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='20', start=123, end=125, reference_bases='CT',
         alternate_bases=[], filters=['q10', 's10'],
-        info={'IS_2': vcfio.VariantInfo('some data', '1')},
+        info={'IS_2': 'some data'},
         calls=[vcfio.VariantCall(
             name='Sample1', genotype=[0, 1], phaseset='*', info={'FI_2': 20})]
     )

--- a/gcp_variant_transforms/transforms/infer_undefined_headers_test.py
+++ b/gcp_variant_transforms/transforms/infer_undefined_headers_test.py
@@ -58,12 +58,8 @@ class InferUndefinedHeaderFieldsTest(unittest.TestCase):
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'IS': 'some data',
-              'ISI': '1',
-              'ISF': '1.0',
-              'IF': 1.0,
-              'IB': True,
-              'IA': [0.1, 0.2]},
+        info={'IS': 'some data', 'ISI': '1', 'ISF': '1.0',
+              'IF': 1.0, 'IB': True, 'IA': [0.1, 0.2]},
         calls=[vcfio.VariantCall(
             name='Sample1', genotype=[0, 1], phaseset='*',
             info={'FI': 20, 'FU': [10.0, 20.0]})]

--- a/gcp_variant_transforms/transforms/merge_variants_test.py
+++ b/gcp_variant_transforms/transforms/merge_variants_test.py
@@ -36,8 +36,7 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'A1': 'some data',
-              'A2': ['data1', 'data2']},
+        info={'A1': 'some data', 'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -51,8 +50,7 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=20,
         filters=['q10'],
-        info={'A1': 'some data2',
-              'A3': ['data3', 'data4']},
+        info={'A1': 'some data2', 'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(
@@ -64,8 +62,7 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'],
         filters=['PASS', 'q10'], quality=20,
-        info={'A2': ['data1', 'data2'],
-              'A3': ['data3', 'data4']},
+        info={'A2': ['data1', 'data2'], 'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',

--- a/gcp_variant_transforms/transforms/merge_variants_test.py
+++ b/gcp_variant_transforms/transforms/merge_variants_test.py
@@ -36,8 +36,8 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=2,
         filters=['PASS'],
-        info={'A1': vcfio.VariantInfo('some data', '1'),
-              'A2': vcfio.VariantInfo(['data1', 'data2'], '2')},
+        info={'A1': 'some data',
+              'A2': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -51,8 +51,8 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'], quality=20,
         filters=['q10'],
-        info={'A1': vcfio.VariantInfo('some data2', '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A1': 'some data2',
+              'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(name='Sample3', genotype=[1, 1]),
             vcfio.VariantCall(
@@ -64,8 +64,8 @@ class MergeVariantsTest(unittest.TestCase):
         reference_name='19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1'],
         filters=['PASS', 'q10'], quality=20,
-        info={'A2': vcfio.VariantInfo(['data1', 'data2'], '2'),
-              'A3': vcfio.VariantInfo(['data3', 'data4'], '2')},
+        info={'A2': ['data1', 'data2'],
+              'A3': ['data3', 'data4']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -154,10 +154,10 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'IFR': vcfio.VariantInfo([0.1, 0.2], ''),
-              'IFR2': vcfio.VariantInfo([0.2, 0.3], ''),
-              'IS': vcfio.VariantInfo('some data', ''),
-              'ISR': vcfio.VariantInfo(['data1', 'data2'], '')},
+        info={'IFR': [0.1, 0.2],
+              'IFR2': [0.2, 0.3],
+              'IS': 'some data',
+              'ISR': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -204,7 +204,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='20', start=123, end=125, reference_bases='CT',
         alternate_bases=[], filters=['q10', 's10'],
-        info={'II': vcfio.VariantInfo(1234, '')})
+        info={'II': 1234})
     header_num_dict = {'II': '1'}
     row = {ColumnKeyConstants.REFERENCE_NAME: '20',
            ColumnKeyConstants.START_POSITION: 123,
@@ -231,7 +231,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='20', start=123, end=125, reference_bases='CT',
         alternate_bases=[], filters=['q10', 's10'],
-        info={'II': vcfio.VariantInfo(1234, '')},
+        info={'II': 1234},
         calls=[
             vcfio.VariantCall(
                 name='EmptySample', genotype=[], phaseset='*',
@@ -252,9 +252,9 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=[], filters=['PASS'],
-        info={'IFR': vcfio.VariantInfo(['0.1', '0.2'], ''),
-              'IS': vcfio.VariantInfo(1, ''),
-              'ISR': vcfio.VariantInfo(1, '')},
+        info={'IFR': ['0.1', '0.2'],
+              'IS': 1,
+              'ISR': 1},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -103,48 +103,18 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     return schema
 
   def _make_header(self, key_num_dict):
-    info_list = [
-        parser._Info(
-            id=None,
-            num='A',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None),
-        parser._Info(
-            id=None,
-            num='1',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None),
-        parser._Info(
-            id=None,
-            num='2',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None),
-        parser._Info(
-            id=None,
-            num='3',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None),
-        parser._Info(
-            id=None,
-            num='4',
-            type=None,
-            desc='some desc',
-            source=None,
-            version=None)]
     infos_dict = {}
     for k, v in key_num_dict.iteritems():
-      if v == 'A':
-        infos_dict[k] = info_list[0]
+      if v == '.':
+        infos_dict[k] = parser._Info(None, None, None, '', None, None)
+      elif v == 'A':
+        infos_dict[k] = parser._Info(None, -1, None, '', None, None)
+      elif v == 'G':
+        infos_dict[k] = parser._Info(None, -2, None, '', None, None)
+      elif v == 'R':
+        infos_dict[k] = parser._Info(None, -3, None, '', None, None)
       elif int(v) <= 4 and int(v) >= 1:
-        infos_dict[k] = info_list[int(v)]
+        infos_dict[k] = parser._Info(None, int(v), None, '', None, None)
       else:
         self.fail("given NUM value is not valid: " + v)
     return vcf_header_io.VcfHeader(infos=infos_dict)
@@ -154,10 +124,8 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
         filters=['PASS'],
-        info={'IFR': [0.1, 0.2],
-              'IFR2': [0.2, 0.3],
-              'IS': 'some data',
-              'ISR': ['data1', 'data2']},
+        info={'IFR': [0.1, 0.2], 'IFR2': [0.2, 0.3],
+              'IS': 'some data', 'ISR': ['data1', 'data2']},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',
@@ -252,9 +220,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     variant = vcfio.Variant(
         reference_name='chr19', start=11, end=12, reference_bases='C',
         alternate_bases=[], filters=['PASS'],
-        info={'IFR': ['0.1', '0.2'],
-              'IS': 1,
-              'ISR': 1},
+        info={'IFR': ['0.1', '0.2'], 'IS': 1, 'ISR': 1},
         calls=[
             vcfio.VariantCall(
                 name='Sample1', genotype=[0, 1], phaseset='*',


### PR DESCRIPTION
This PR includes two major changes:
1- Removing all occurrences VariantInfo
2- Modifying all unit tests that rely on VariantInfo.field_count and provide that in the header _Info.num