### PR TITLE
Add labels to output BigQuery tables

### DIFF
--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -14,10 +14,13 @@
 
 """Constants and simple utility functions related to BigQuery."""
 
-import re
+import logging
 import math
+import re
 import sys
 from typing import List  # pylint: disable=unused-import
+
+from google.cloud import bigquery
 
 from gcp_variant_transforms.beam_io import vcfio
 
@@ -76,6 +79,35 @@ _FALLBACK_FIELD_NAME_PREFIX = 'field_'
 # prevent unintentional overflows when doing subsequent operations.
 _INF_FLOAT_VALUE = sys.float_info.max / 10
 
+
+def label_tables(output_table, partitioner):
+  # type: (str, VariantPartition) -> None
+  """Adds labels to the freshly created BigQuery tables."""
+  output_table_re_match = re.match(
+      r'^((?P<project>.+):)(?P<dataset>\w+)\.(?P<table>[\w\$]+)$', output_table)
+  if not output_table_re_match:
+    raise ValueError('Expected a table reference (PROJECT:DATASET.TABLE) '
+                     'instead of {}.'.format(output_table))
+  project_id = output_table_re_match.group('project')
+  dataset_id = output_table_re_match.group('dataset')
+  table_prefix = output_table_re_match.group('table')
+
+  client = bigquery.Client(project=project_id)
+  for i in range(partitioner.get_num_partitions()):
+    if not partitioner.should_keep_partition(i):
+      continue
+    table_id = table_prefix + '_' + partitioner.get_partition_name(i)
+    table = client.get_table(client.dataset(dataset_id).table(table_id))
+
+    if table.labels != {}:
+      logging.warning('Table %s has some labels which might be erased: %s',
+                      table_id, table.labels)
+    table.labels = partitioner.get_partition_labels(i)
+    table = client.update_table(table, ['labels'])  # API request
+    if table.labels != partitioner.get_partition_labels(i):
+      logging.warning('Some of the labels were not added to the table %s, '
+                      'expected %s, got %s', table_id,
+                      partitioner.get_partition_labels(i), table.labels)
 
 def get_bigquery_sanitized_field_name(field_name):
   # type: (str) -> str

--- a/gcp_variant_transforms/libs/variant_partition_test.py
+++ b/gcp_variant_transforms/libs/variant_partition_test.py
@@ -154,6 +154,33 @@ class VariantPartitionTest(unittest.TestCase):
     self.assertEqual(partitioner.get_partition_name(6), 'chr3_02')
     self.assertEqual(partitioner.get_partition_name(7), 'all_remaining')
 
+  def test_config_get_partition_labels(self):
+    partitioner = variant_partition.VariantPartition(
+        'gcp_variant_transforms/testing/data/partition_configs/'
+        'residual_at_end.yaml')
+    self.assertFalse(partitioner.should_flatten())
+    self.assertEqual(partitioner.get_num_partitions(), 8)
+    for i in range(partitioner.get_num_partitions()):
+      self.assertTrue(partitioner.should_keep_partition(i))
+
+    self.assertEqual(partitioner.get_partition_labels(0),
+                     {'label-0': 'chr1-0-1000000'})
+    self.assertEqual(partitioner.get_partition_labels(1),
+                     {'label-0': 'chr1-1000000-2000000'})
+    self.assertEqual(partitioner.get_partition_labels(2),
+                     {'label-0': 'chr1-2000000-999999999'})
+    self.assertEqual(partitioner.get_partition_labels(3),
+                     {'label-0': 'chr2', 'label-1': 'chr2_alternate_name1',
+                      'label-2': 'chr2_alternate_name2', 'label-3': '2'})
+    self.assertEqual(partitioner.get_partition_labels(4),
+                     {'label-0': 'chr4', 'label-1': 'chr5',
+                      'label-2': 'chr6-1000000-2000000'})
+    self.assertEqual(partitioner.get_partition_labels(5),
+                     {'label-0': '3-0-500000'})
+    self.assertEqual(partitioner.get_partition_labels(6),
+                     {'label-0': '3-500000-1000000'})
+    self.assertEqual(partitioner.get_partition_labels(7),
+                     {'label-0': 'residual'})
 
   def test_config_non_existent_partition_name(self):
     partitioner = variant_partition.VariantPartition(

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -47,6 +47,7 @@ from apache_beam.options import pipeline_options
 
 from gcp_variant_transforms import vcf_to_bq_common
 from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs import metrics_util
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_header_parser
@@ -279,6 +280,8 @@ def run(argv=None):
 
   metrics_util.log_all_counters(result)
 
+  if partitioner and not partitioner.should_flatten():
+    bigquery_util.label_tables(known_args.output_table, partitioner)
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
In order to automize finding relevant tables for each query based on its
`WHERE` clause, we need to add labels to each table to highlight their
content.
solves issue #248 

TESTED=unit_tests and presubmit_tests