### PR TITLE
Moving annotation parsing logic into its own module.

### DIFF
--- a/gcp_variant_transforms/libs/annotation/annotation_parser.py
+++ b/gcp_variant_transforms/libs/annotation/annotation_parser.py
@@ -1,0 +1,334 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module for parsing annotation fields.
+
+The main class is `Parser`; see its documentation for usage. There are also
+some helper methods that can be used in different contexts.
+"""
+
+from __future__ import absolute_import
+
+import re
+
+from typing import Dict, List, Tuple  # pylint: disable=unused-import
+
+# The key in annotation maps that keeps the original alternate allele in an
+# annotation string (and the field name in the BigQuery table that holds that
+# information).
+ANNOTATION_ALT = 'allele'
+
+# The annotation field that VEP uses to record the index of the alternate
+# allele (i.e., ALT) that an annotation list is for.
+_ALLELE_NUM_ANNOTATION = 'ALLELE_NUM'
+
+# The representation of a deletion variant in VEP.
+_COMPLETELY_DELETED_ALT = '-'
+
+# Regular expressions to identify symbolic and breakend ALTs used in
+# annotation alt matching.
+# Check the VCF spec for symbolic and breakend ALT formats.
+_SYMBOLIC_ALT_RE = re.compile(r'^<(?P<ID>.*)>$')
+_BREAKEND_ALT_RE = (re.compile(
+    r'^(?P<up_to_chr>.*([\[\]]).*):(?P<pos>.*)([\[\]]).*$'))
+
+class AnnotationParserException(Exception):
+  pass
+class AlleleNumMissing(AnnotationParserException):
+  pass
+class InvalidAlleleNumValue(AnnotationParserException):
+  pass
+class AmbiguousAnnotationAllele(AnnotationParserException):
+  pass
+class AnnotationAltNotFound(AnnotationParserException):
+  pass
+
+
+class Parser(object):
+  """The main class for parsing annotation fields of a single variant record.
+
+  The expected usage is to pass information about one variant record, namely the
+  reference sequence and list of alternate allele sequences, plus some metadata
+  like list of annotation names (coming from VCF headers),  and how to do allele
+  matching, then call `parse_and_match_alt` method for each annotation string
+  of that variant.
+  """
+
+  def __init__(
+      self,
+      reference,  # type: str
+      alt_list,  # type: List[str]
+      annotation_names,  # type: List[str]
+      use_allele_num,  # type: bool
+      do_minimal_match  # type: bool
+  ):
+    """Constructs an instance for parsing annotations of one variant record.
+
+    In the variable name choices and documentations, when it says "alt" or "ALT"
+    it refers to the alternate alleles of the variant. If alternate allele part
+    of an annotation string is meant, "annotation_alt" or "annotation ALT" is
+    used.
+
+    Args:
+      reference: The reference sequence, e.g., 'AT'
+      alt_list: List of alternate alleles, e.g., ['ATT', 'C']
+      annotation_names: List of expected annotations, e.g., ['Consequence',
+        'IMPACT', 'SYMBOL'].
+      use_allele_num: Whether to use 'ALLELE_NUM' annotation for ALT matching.
+      do_minimal_match: Whether to simulate the minimal mode of VEP.
+    """
+    self._reference = reference or ''
+    self._alt_list = alt_list or []
+    self._annotation_names = annotation_names or []
+    self._use_allele_num = use_allele_num
+    self._do_minimal_match = do_minimal_match
+    self._common_prefix = self._find_common_alt_ref_prefix_char(
+        reference, alt_list)
+
+  def _find_common_alt_ref_prefix_char(self, ref, alt_list):
+    # type: (str, List[str]) -> str
+    if not ref:
+      return ''
+    common_char = ref[0]
+    for alt in alt_list:
+      if not alt or alt[0] != common_char:
+        return ''
+    return common_char
+
+  def parse_and_match_alt(self, annotation_str):
+    # type: (str) -> Tuple[int, Dict[str, str]]
+    """Parses the given annotation string and returns the matching ALT index.
+
+    Args:
+      annotation_str: The annotation string to parse, e.g.,
+        'ATT|upstream_gene_variant|MODIFIER|PSMF1'
+
+    Returns:
+      A tuple consisting of an integer and a map. The integer is the index of
+        the ALT that matches the given annotation string. For the above example
+        and an instance constructed with the example in `__init__`, the returned
+        index is 0 since 'ATT' is the first ALT. The returned map is:
+        { 'Consequence': 'upstream_gene_variant',
+          'IMPACT': 'MODIFIER',
+          'SYMBOL': 'PSMF1'}
+
+    Raises:
+      AlleleNumMissing: When matching by 'ALLELE_NUM' but that field is not
+        present in the given `annotation_str`.
+      AmbiguousAnnotationAllele: If simulating minimal mode and the allele part
+        of `annotation_str` matches more than one of variant ALTs.
+      AnnotationAltNotFound: If the allele part of `annotation_str` does not
+        match any of the variant ALTs.
+      InvalidAlleleNumValue: When matching by 'ALLELE_NUM' but the value in that
+        field is wrong, e.g., not a number or out of range of ALTs.
+      ValueError: In a few other error cases, the exception message should be
+        descriptive enough.
+    """
+    annotations = _extract_annotation_list_with_alt(annotation_str)
+    annotation_map = self._create_map(annotations)
+    alt_ind = self._find_alt_index(annotation_map)
+    return alt_ind, annotation_map
+
+  def _create_map(self, annotations):
+    # type: (List[str], List[str]) -> Dict[str, str]
+    if len(self._annotation_names) != len(annotations) - 1:
+      raise ValueError('Expected {} annotations, got {}'.format(
+          len(self._annotation_names), len(annotations) - 1))
+    annotation_dict = {}
+    annotation_dict[ANNOTATION_ALT] = annotations[0]
+    for index, name in enumerate(self._annotation_names):
+      annotation_dict[name] = annotations[index + 1]
+    return annotation_dict
+
+  def _find_alt_index(self, annotation_map):
+    # type: (Dict[str, str]) -> int
+    if self._use_allele_num:
+      return self._find_alt_index_by_allele_num(annotation_map)
+    else:
+      annotation_alt = annotation_map[ANNOTATION_ALT]
+      return self._find_matching_alt_index(annotation_alt)
+
+  def _find_matching_alt_index(self, annotation_alt):
+    # type: (str) -> int
+    """Searches among ALTs to find one that matches `annotation_alt`.
+
+    Args:
+      annotation_alt: The ALT part of annotation data, e.g., 'ATT'. Note that
+        this is not necessarily equal to an ALT string of the original variant
+        as the matching rules are not always exact match.
+
+    Returns:
+      The index in the variant ALT list (`self._alt_list`) that matches
+        `annotation_alt`.
+
+    Raises:
+      AnnotationAltNotFound: If the given `annotation_alt` does not match any of
+        the ALTs.
+      AmbiguousAnnotationAllele: If `self._do_minimal_match` and the given
+        `annotation_alt` matches more than one ALT.
+    """
+    # This assumes that number of alternate bases and annotation segments
+    # are not too big. If this assumption is not true, we should replace the
+    # following loop with a hash table search and avoid the quadratic time.
+    for ind, alt in enumerate(self._alt_list):
+      if self._alt_matches_annotation_alt(alt, annotation_alt):
+        return ind
+    found_alt_ind = -1
+    if self._do_minimal_match:
+      for ind, alt in enumerate(self._alt_list):
+        if self._alt_matches_annotation_alt_minimal_mode(alt, annotation_alt):
+          if found_alt_ind >= 0:
+            raise AmbiguousAnnotationAllele(
+                'Annotation ALT {} matches both ALTs {} and {} '
+                'with reference bases {}'.format(
+                    annotation_alt, self._alt_list[found_alt_ind], alt,
+                    self._reference))
+          found_alt_ind = ind
+          # Note we do not `break` in this case because we want to know if this
+          # match was an ambiguous match or an exact one.
+    if found_alt_ind < 0:
+      raise AnnotationAltNotFound(
+          'Matching alternate bases for annotation ALT {} not found'.format(
+              annotation_alt))
+    return found_alt_ind
+
+  def _alt_matches_annotation_alt(self, alt, annotation_alt):
+    # type: (str, str) -> bool
+    """Returns true if `alt` matches `annotation_alt`
+
+    See the "VCF" and "Complex VCF entries" sections of
+    https://ensembl.org/info/docs/tools/vep/vep_formats.html
+    for details of prefix matching and indels. Some examples:
+    REF      ALT         annotation-ALT
+    A        T           T
+    AT       ATT,A       TT,-
+    A        <ID>        ID
+    A        .[13:123[   .[13
+    """
+    if not self._do_minimal_match:
+      # Check equality without the common prefix.
+      # Note according to VCF spec the length of this common prefix should be
+      # at most one. This string matching is skipped if in minimal_match mode.
+      # TODO(bashir2): This is a VEP specific issue and should be updated once
+      # we need to import annotations generated by other programs.
+      if alt[len(self._common_prefix):] == annotation_alt:
+        return True
+      # Handling deletion.
+      if (len(self._common_prefix) == len(alt)
+          and annotation_alt == _COMPLETELY_DELETED_ALT):
+        return True
+    # Handling symbolic ALTs.
+    id_match = _SYMBOLIC_ALT_RE.match(alt)
+    if id_match and id_match.group('ID') == annotation_alt:
+      return True
+    # Handling breakend ALTs.
+    # TODO(bashir2): Check if the following logic is documented anywhere! I
+    # could not find it explicitly in any documentation but that's how I saw
+    # VEP does it in some examples I ran.
+    breakend_match = _BREAKEND_ALT_RE.match(alt)
+    if breakend_match and breakend_match.group('up_to_chr') == annotation_alt:
+      return True
+    return False
+
+  def _alt_matches_annotation_alt_minimal_mode(self, alt, annotation_alt):
+    # type: (str, str) -> bool
+    """Returns true if ALTs match in the --minimal mode of VEP.
+
+    Note in the minimal mode, the matching can be non-deterministic, so this
+    should only be done if _alt_matches_annotation_alt which is deterministic
+    has not succeeded. For details of ALT matching in the --minimal mode of VEP,
+    see the "Complex VCF entries" sections of
+    https://useast.ensembl.org/info/docs/tools/vep/vep_formats.html
+    Basically, each ALT is independently checked with REF and the common prefix
+    and suffix is removed from ALT. The remaining part is the annotation ALT:
+    REF      ALT         annotation-ALT
+    A        T           T
+    AT       TT,A        T,-
+    C        CT,T        T               -> Note this is ambiguous.
+    """
+    if not alt or not annotation_alt:
+      return False
+    # Finding common leading and trailing sub-strings of ALT and REF.
+    leading = 0
+    trailing = 0
+    min_len = min(len(alt), len(self._reference))
+    while (leading < min_len and
+           alt[leading] == self._reference[leading]):
+      leading += 1
+    while (trailing + leading < min_len and  # TODO check this condition
+           alt[len(alt) - trailing - 1] ==
+           self._reference[len(self._reference) - trailing - 1]):
+      trailing += 1
+    if alt[leading:len(alt) - trailing] == annotation_alt:
+      return True
+    if (leading + trailing == len(alt) and
+        annotation_alt == _COMPLETELY_DELETED_ALT):
+      return True
+    return False
+
+  def _find_alt_index_by_allele_num(self, annotation_map):
+    # type: (Dict[str, str]) -> int
+    if _ALLELE_NUM_ANNOTATION not in annotation_map:
+      raise AlleleNumMissing
+    index_str = annotation_map[_ALLELE_NUM_ANNOTATION]
+    try:
+      alt_index = int(index_str) - 1
+      if alt_index >= len(self._alt_list) or alt_index < 0:
+        raise InvalidAlleleNumValue('{} out of ALT range [{}, {}]'.format(
+            alt_index + 1, 1, len(self._alt_list)))
+      return alt_index
+    except ValueError as e:
+      raise InvalidAlleleNumValue(e)
+
+
+def _extract_annotation_list_with_alt(annotation_str):
+  # type: (str) -> List[str]
+  """Extracts annotations from an annotation INFO field.
+
+  This works by dividing the `annotation_str` on '|'. The first element is
+  the alternate allele and the rest are the annotations. For example, for
+  'G|upstream_gene_variant|MODIFIER|PSMF1' as `annotation_str`, it returns
+  ['G', 'upstream_gene_variant', 'MODIFIER', 'PSMF1'].
+
+  Args:
+    annotation_str: The content of annotation field for one alt.
+
+  Returns:
+    The list of annotations with the first element being the alternate.
+  """
+  return annotation_str.split('|')
+
+
+def extract_annotation_names(description):
+  # type: (str) -> List[str]
+  """Extracts annotation list from the description of an annotation INFO field.
+
+  This is similar to extract_extract_annotation_list_with_alt with the
+  difference that it ignores everything before the first '|'. For example, for
+  'some desc ... Format: Allele|Consequence|IMPACT|SYMBOL|Gene', it returns
+  ['Consequence', 'IMPACT', 'SYMBOL', 'Gene']
+
+  Args:
+    description: The "Description" part of the annotation INFO field
+      in the header of VCF.
+
+  Returns:
+    The list of annotation names.
+  """
+  annotation_names = _extract_annotation_list_with_alt(description)
+  if len(annotation_names) < 2:
+    raise ValueError(
+        'Expected at least one | in annotation description {}'.format(
+            description))
+  return annotation_names[1:]

--- a/gcp_variant_transforms/libs/annotation/annotation_parser.py
+++ b/gcp_variant_transforms/libs/annotation/annotation_parser.py
@@ -43,14 +43,23 @@ _SYMBOLIC_ALT_RE = re.compile(r'^<(?P<ID>.*)>$')
 _BREAKEND_ALT_RE = (re.compile(
     r'^(?P<up_to_chr>.*([\[\]]).*):(?P<pos>.*)([\[\]]).*$'))
 
+
 class AnnotationParserException(Exception):
   pass
+
+
 class AlleleNumMissing(AnnotationParserException):
   pass
+
+
 class InvalidAlleleNumValue(AnnotationParserException):
   pass
+
+
 class AmbiguousAnnotationAllele(AnnotationParserException):
   pass
+
+
 class AnnotationAltNotFound(AnnotationParserException):
   pass
 

--- a/gcp_variant_transforms/libs/annotation/annotation_parser_test.py
+++ b/gcp_variant_transforms/libs/annotation/annotation_parser_test.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the annotaiton_parser module.
+
+NOTE(bashir2): Most of the real unit-tests for annotation_parser module are
+through unit-testing of processed_variant module.
+"""
+
+from __future__ import absolute_import
+
+import unittest
+
+from gcp_variant_transforms.libs.annotation import annotation_parser
+
+
+class AnnotationParserTest(unittest.TestCase):
+
+  def test_extract_annotation_names(self):
+    annotation_str = 'some desc|Consequence|IMPACT|SYMBOL|Gene'
+    name_list = annotation_parser.extract_annotation_names(annotation_str)
+    self.assertEqual(name_list, ['Consequence', 'IMPACT', 'SYMBOL', 'Gene'])
+
+  def test_extract_annotation_names_error(self):
+    annotation_str = 'some desc-Consequence-IMPACT-SYMBOL-Gene'
+    with self.assertRaisesRegexp(ValueError, 'Expected at least one.*'):
+      annotation_parser.extract_annotation_names(annotation_str)

--- a/gcp_variant_transforms/libs/processed_variant.py
+++ b/gcp_variant_transforms/libs/processed_variant.py
@@ -345,8 +345,8 @@ class _AnnotationProcessor(object):
       if field not in header_fields.infos:
         raise ValueError('{} INFO not found in the header'.format(field))
       header_desc = header_fields.infos[field][_HeaderKeyConstants.DESC]
-      self._annotation_names_map[
-          field] = annotation_parser.extract_annotation_names(header_desc)
+      self._annotation_names_map[field] = (
+          annotation_parser.extract_annotation_names(header_desc))
     self._alt_match_counter = counter_factory.create_counter(
         _CounterEnum.ANNOTATION_ALT_MATCH.value)
     self._alt_minimal_ambiguous_counter = counter_factory.create_counter(

--- a/gcp_variant_transforms/libs/processed_variant.py
+++ b/gcp_variant_transforms/libs/processed_variant.py
@@ -24,10 +24,8 @@ from __future__ import absolute_import
 
 import enum
 import logging
-import re
 
-from collections import defaultdict
-from typing import Dict, List, Any, Tuple, Optional  # pylint: disable=unused-import
+from typing import Dict, List, Any  # pylint: disable=unused-import
 
 import vcf
 
@@ -37,23 +35,10 @@ from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import metrics_util
 from gcp_variant_transforms.libs import bigquery_util
+from gcp_variant_transforms.libs.annotation import annotation_parser
 
 
 _FIELD_COUNT_ALTERNATE_ALLELE = 'A'
-
-# The representation of a deletion variant in VEP.
-_COMPLETELY_DELETED_ALT = '-'
-
-# The field name in the BigQuery table that holds annotation ALT.
-_ANNOTATION_ALT = 'allele'
-
-# The field name in the BigQuery table that indicates whether the annotation ALT
-# matching was ambiguous or not.
-_ANNOTATION_ALT_AMBIGUOUS = 'ambiguous_allele'
-
-# The annotation field that VEP uses to record the index of the alternate
-# allele (i.e., ALT) that an annotation list is for.
-_ALLELE_NUM_ANNOTATION = 'ALLELE_NUM'
 
 # An alias for the header key constants to make referencing easier.
 _HeaderKeyConstants = vcf_header_io.VcfParserHeaderKeyConstants
@@ -63,7 +48,6 @@ _HeaderKeyConstants = vcf_header_io.VcfParserHeaderKeyConstants
 class _CounterEnum(enum.Enum):
   VARIANT = 'variant_counter'
   ANNOTATION_ALT_MATCH = 'annotation_alt_match_counter'
-  ANNOTATION_ALT_MINIMAL_MATCH = 'annotation_alt_minimal_match_counter'
   ANNOTATION_ALT_MINIMAL_AMBIGUOUS = 'annotation_alt_minimal_ambiguous_counter'
   ANNOTATION_ALT_MISMATCH = 'annotation_alt_mismatch_counter'
   ALLELE_NUM_MISSING = 'allele_num_missing'
@@ -296,7 +280,7 @@ class ProcessedVariantFactory(object):
     for annot_field in self._annotation_field_set:
       if annot_field not in self._header_fields.infos:
         raise ValueError('Annotation field {} not found'.format(annot_field))
-      annotation_names = _extract_annotation_names(
+      annotation_names = annotation_parser.extract_annotation_names(
           self._header_fields.infos[annot_field][_HeaderKeyConstants.DESC])
       annotation_record = bigquery.TableFieldSchema(
           name=bigquery_util.get_bigquery_sanitized_field(annot_field),
@@ -305,16 +289,10 @@ class ProcessedVariantFactory(object):
           description='List of {} annotations for this alternate.'.format(
               annot_field))
       annotation_record.fields.append(bigquery.TableFieldSchema(
-          name=_ANNOTATION_ALT,
+          name=annotation_parser.ANNOTATION_ALT,
           type=bigquery_util.TableFieldConstants.TYPE_STRING,
           mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
           description='The ALT part of the annotation field.'))
-      if self._minimal_match:
-        annotation_record.fields.append(bigquery.TableFieldSchema(
-            name=_ANNOTATION_ALT_AMBIGUOUS,
-            type=bigquery_util.TableFieldConstants.TYPE_BOOLEAN,
-            mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
-            description='Whether the annotation ALT matching was ambiguous.'))
       for annotation_name in annotation_names:
         annotation_record.fields.append(bigquery.TableFieldSchema(
             name=bigquery_util.get_bigquery_sanitized_field(annotation_name),
@@ -341,12 +319,6 @@ class ProcessedVariantFactory(object):
 class _AnnotationProcessor(object):
   """This is for handling all annotation related logic for variants."""
 
-  # Regular expressions to identify symbolic and breakend ALTs used in
-  # annotation alt matching.
-  # Check the VCF spec for symbolic and breakend ALT formats.
-  _SYMBOLIC_ALT_RE = re.compile(r'^<(?P<ID>.*)>$')
-  _BREAKEND_ALT_RE = (re.compile(
-      r'^(?P<up_to_chr>.*([\[\]]).*):(?P<pos>.*)([\[\]]).*$'))
 
   def __init__(self,
                annotation_fields,  # type: List[str]
@@ -373,12 +345,10 @@ class _AnnotationProcessor(object):
       if field not in header_fields.infos:
         raise ValueError('{} INFO not found in the header'.format(field))
       header_desc = header_fields.infos[field][_HeaderKeyConstants.DESC]
-      self._annotation_names_map[field] = _extract_annotation_names(
-          header_desc)
+      self._annotation_names_map[
+          field] = annotation_parser.extract_annotation_names(header_desc)
     self._alt_match_counter = counter_factory.create_counter(
         _CounterEnum.ANNOTATION_ALT_MATCH.value)
-    self._alt_minimal_match_counter = counter_factory.create_counter(
-        _CounterEnum.ANNOTATION_ALT_MINIMAL_MATCH.value)
     self._alt_minimal_ambiguous_counter = counter_factory.create_counter(
         _CounterEnum.ANNOTATION_ALT_MINIMAL_AMBIGUOUS.value)
     self._alt_mismatch_counter = counter_factory.create_counter(
@@ -416,283 +386,30 @@ class _AnnotationProcessor(object):
 
         Allele|Consequence|IMPACT|SYMBOL|Gene|...
     """
-    common_prefix = self._find_common_alt_ref_prefix_char(proc_var)
-    alt_annotation_map = self._convert_annotation_strs_to_alt_map(
-        annotation_field_name, data)
-    for alt_bases, annotations_list in alt_annotation_map.iteritems():
-      if self._use_allele_num:
-        # TODO(bashir2): This class needs a major refactoring which should be
-        # done as part of creating a class for holding annotation data. The
-        # choice of mapping annotation lists to their annotation ALT string
-        # needs to be revisited in case of using ALLELE_NUM.
-        for annotation_dict in annotations_list:
-          self._add_annotations_by_allele_num(
-              proc_var, annotation_dict, annotation_field_name)
-      else:
-        alt, ambiguous = self._find_matching_alt(
-            proc_var, common_prefix, alt_bases, annotation_field_name)
-        if alt:
-          if self._minimal_match:
-            self._add_ambiguous_fields(annotations_list, ambiguous)
-          alt._info[annotation_field_name] = annotations_list
-
-  def _find_common_alt_ref_prefix_char(self, proc_var):
-    # type: (ProcessedVariant) -> str
-    if not proc_var.reference_bases:
-      return ''
-    common_char = proc_var.reference_bases[0]
-    for alt in proc_var._alternate_datas:
-      if not alt.alternate_bases or alt.alternate_bases[0] != common_char:
-        return ''
-    return common_char
-
-  def _convert_annotation_strs_to_alt_map(
-      self, annotation_field_name, field_data):
-    # type: (str, List[str]) -> Dict[str, List[Dict[str, str]]]
-    """Given the list of annotation data, extracts ALTs and annotations.
-
-    Args:
-      annotation_field_name: The name of the annotation field, e.g., ANN or CSQ.
-      field_data: A list of data strings. One element of this list looks like:
-
-        G|upstream_gene_variant|MODIFIER|PSMF1|ENSG00000125818|...
-
-        This function splits these strings on '|', uses the first element (i.e.,
-        the ALT identifier) as the key and creates a dictionary for annotations,
-        e.g.,
-          Consequence: upstream_gene_variant
-          IMPACT: MODIFIER
-          SYMBOL: PSMF1
-          Gene: ENSG00000125818
-          ...
-        Note that a single ALT can have multiple annotation sets. That is why
-        the value elements in the returned map are lists of dictionaries.
-    """
-    # TODO(bashir2): Instead of a `Dict[str, List[Dict[str, str]]]` define a new
-    # class for holding annotation data.
-    if annotation_field_name not in self._annotation_names_map:
-      raise ValueError('{} not in annotation fields'.format(
-          annotation_field_name))
-    annotation_names = self._annotation_names_map[annotation_field_name]
-    alt_annotation_map = defaultdict(list)
-    for annotation_str in field_data:
-      annotations = _extract_annotation_list_with_alt(annotation_str)
-      alt_annotation_map[annotations[0]].append(
-          self._create_map(annotations, annotation_names))
-    return alt_annotation_map
-
-  def _create_map(self, annotations, annotation_names):
-    # type: (List[str], List[str]) -> Dict[str, str]
-    if len(annotation_names) != len(annotations) - 1:
-      raise ValueError('Expected {} annotations, got {}'.format(
-          len(annotation_names), len(annotations) - 1))
-    annotation_dict = {}
-    annotation_dict[_ANNOTATION_ALT] = annotations[0]
-    for index, name in enumerate(annotation_names):
-      annotation_dict[name] = annotations[index + 1]
-    return annotation_dict
-
-  def _add_ambiguous_fields(self, annotations_list, ambiguous):
-    # type: (List[Dict[str, str]], bool) -> None
-    for annotation_map in annotations_list:
-      annotation_map[_ANNOTATION_ALT_AMBIGUOUS] = ambiguous
-
-  def _find_matching_alt(self,
-                         proc_var,  # type: ProcessedVariant
-                         common_prefix,  # type: str
-                         alt_bases,  # type: str
-                         annotation_field_name  # type: str
-                        ):
-    # type: (...) -> Tuple[Optional[AlternateBaseData], bool]
-    """Searches among ALTs of `proc_var` to find one that matches `alt_bases`.
-
-    Args:
-      proc_var: The object to which the annotations are being added.
-      common_prefix: The common prefix of all ALTs and REF string.
-      alt_bases: The ALT part of annotation data. Note that this is not
-        necessarily equal to an ALT string in `proc_var` as the matching rules
-        are not always exact match.
-      annotations_list: The lists of annotation dictionaries. Each element of
-        this list is a map of annotation names to values, see the example in
-        `_convert_annotation_strs_to_alt_map` which creates these maps.
-      annotation_field_name: The name of the annotation field, e.g., ANN, CSQ.
-
-    Returns:
-      The `AlternateBaseData` object from proc_var that matches or None. It also
-        returns whether the matching was ambiguous or not.
-    """
-    found_alt = None
-    is_ambiguous = False
-    # This assumes that number of alternate bases and annotation segments
-    # are not too big. If this assumption is not true, we should replace the
-    # following loop with a hash table search and avoid the quadratic time.
-    for alt in proc_var._alternate_datas:
-      if self._alt_matches_annotation_alt(
-          common_prefix, alt.alternate_bases, alt_bases):
+    alt_list = [a.alternate_bases for a in proc_var._alternate_datas]
+    parser = annotation_parser.Parser(
+        proc_var.reference_bases, alt_list,
+        self._annotation_names_map[annotation_field_name], self._use_allele_num,
+        self._minimal_match)
+    for annotation_str in data:
+      try:
+        ind, annotation_map = parser.parse_and_match_alt(annotation_str)
         self._alt_match_counter.inc()
-        found_alt = alt
-        break
-    if not found_alt and self._minimal_match:
-      for alt in proc_var._alternate_datas:
-        if self._alt_matches_annotation_alt_minimal_mode(
-            proc_var.reference_bases or '', alt.alternate_bases, alt_bases):
-          if found_alt:
-            is_ambiguous = True
-            self._alt_minimal_ambiguous_counter.inc()
-            logging.warning(
-                'Annotation ALT %s of field %s matches both ALTs %s and %s '
-                'with reference bases %s at reference %s start %s', alt_bases,
-                annotation_field_name, found_alt.alternate_bases,
-                alt.alternate_bases, proc_var.reference_bases,
-                proc_var.reference_name, proc_var.start)
-          else:
-            self._alt_minimal_match_counter.inc()
-          found_alt = alt
-          # Note we do not `break` in this case because we want to know if this
-          # match was an ambiguous match or an exact one.
-    if not found_alt:
-      self._alt_mismatch_counter.inc()
-      logging.warning(
-          'Could not find matching alternate bases for %s in '
-          'annotation filed %s for variant at reference %s start %s', alt_bases,
-          annotation_field_name, proc_var.reference_name, proc_var.start)
-    return found_alt, is_ambiguous
-
-  def _alt_matches_annotation_alt(
-      self, common_prefix, alt_bases, annotation_alt):
-    # type: (str, str, str) -> bool
-    """Returns true if `alt_bases` matches `annotation_alt`
-
-    See the "VCF" and "Complex VCF entries" sections of
-    https://ensembl.org/info/docs/tools/vep/vep_formats.html
-    for details of prefix matching and indels. Some examples:
-    REF      ALT         annotation-ALT
-    A        T           T
-    AT       ATT,A       TT,-
-    A        <ID>        ID
-    A        .[13:123[   .[13
-    """
-    if not self._minimal_match:
-      # Check equality without the common prefix.
-      # Note according to VCF spec the length of this common prefix should be
-      # at most one. This string matching is skipped if in minimal_match mode.
-      # TODO(bashir2): This is a VEP specific issue and should be updated once
-      # we need to import annotations generated by other programs.
-      if alt_bases[len(common_prefix):] == annotation_alt:
-        return True
-      # Handling deletion.
-      if (len(common_prefix) == len(alt_bases)
-          and annotation_alt == _COMPLETELY_DELETED_ALT):
-        return True
-    # Handling symbolic ALTs.
-    id_match = self._SYMBOLIC_ALT_RE.match(alt_bases)
-    if id_match and id_match.group('ID') == annotation_alt:
-      return True
-    # Handling breakend ALTs.
-    # TODO(bashir2): Check if the following logic is documented anywhere! I
-    # could not find it explicitly in any documentation but that's how I saw
-    # VEP does it in some examples I ran.
-    breakend_match = self._BREAKEND_ALT_RE.match(alt_bases)
-    if breakend_match and breakend_match.group('up_to_chr') == annotation_alt:
-      return True
-    return False
-
-  def _alt_matches_annotation_alt_minimal_mode(
-      self, referece_bases, alt_bases, annotation_alt):
-    # type: (str, str, str) -> bool
-    """Returns true if ALTs match in the --minimal mode of VEP.
-
-    Note in the minimal mode, the matching can be non-deterministic, so this
-    should only be done if _alt_matches_annotation_alt which is deterministic
-    has not succeeded. For details of ALT matching in the --minimal mode of VEP,
-    see the "Complex VCF entries" sections of
-    https://useast.ensembl.org/info/docs/tools/vep/vep_formats.html
-    Basically, each ALT is independently checked with REF and the common prefix
-    and suffix is removed from ALT. The remaining part is the annotation ALT:
-    REF      ALT         annotation-ALT
-    A        T           T
-    AT       TT,A        T,-
-    C        CT,T        T               -> Note this is ambiguous.
-    """
-    if not alt_bases or not annotation_alt:
-      return False
-    # Finding common leading and trailing sub-strings of ALT and REF.
-    leading = 0
-    trailing = 0
-    min_len = min(len(alt_bases), len(referece_bases))
-    while (leading < min_len and
-           alt_bases[leading] == referece_bases[leading]):
-      leading += 1
-    while (trailing + leading < min_len and  # TODO check this condition
-           alt_bases[len(alt_bases) - trailing - 1] ==
-           referece_bases[len(referece_bases) - trailing - 1]):
-      trailing += 1
-    if alt_bases[leading:len(alt_bases) - trailing] == annotation_alt:
-      return True
-    if (leading + trailing == len(alt_bases) and
-        annotation_alt == _COMPLETELY_DELETED_ALT):
-      return True
-    return False
-
-  def _add_annotations_by_allele_num(
-      self, proc_var, annotation_dict, annotation_field_name):
-    # type: (ProcessedVariant, Dict[str, str], str) -> None
-    if _ALLELE_NUM_ANNOTATION not in annotation_dict:
-      self._allele_num_missing_counter.inc()
-      return
-    index_str = annotation_dict[_ALLELE_NUM_ANNOTATION]
-    try:
-      alt_index = int(index_str) - 1
-      alt_list = proc_var._alternate_datas
-      if alt_index >= len(alt_list) or alt_index < 0:
-        raise ValueError
-      alt = alt_list[alt_index]
-      self._alt_match_counter.inc()
-      if annotation_field_name not in alt._info:
-        alt._info[annotation_field_name] = [annotation_dict]
-      else:
-        alt._info[annotation_field_name].append(annotation_dict)
-    except ValueError:
-      self._allele_num_incorrect_counter.inc()
-
-
-def _extract_annotation_list_with_alt(annotation_str):
-  # type: (str) -> List[str]
-  """Extracts annotations from an annotation INFO field.
-
-  This works by dividing the `annotation_str` on '|'. The first element is
-  the alternate allele and the rest are the annotations. For example, for
-  'G|upstream_gene_variant|MODIFIER|PSMF1' as `annotation_str`, it returns
-  ['G', 'upstream_gene_variant', 'MODIFIER', 'PSMF1'].
-
-  Args:
-    annotation_str: The content of annotation field for one alt.
-
-  Returns:
-    The list of annotations with the first element being the alternate.
-  """
-  return annotation_str.split('|')
-
-
-def _extract_annotation_names(description):
-  # type: (str) -> List[str]
-  """Extracts annotation list from the description of an annotation INFO field.
-
-  This is similar to extract_extract_annotation_list_with_alt with the
-  difference that it ignores everything before the first '|'. For example, for
-  'some desc ... Format: Allele|Consequence|IMPACT|SYMBOL|Gene', it returns
-  ['Consequence', 'IMPACT', 'SYMBOL', 'Gene']
-
-  Args:
-    description: The "Description" part of the annotation INFO field
-      in the header of VCF.
-
-  Returns:
-    The list of annotation names.
-  """
-  annotation_names = _extract_annotation_list_with_alt(description)
-  if len(annotation_names) < 2:
-    raise ValueError(
-        'Expected at least one | in annotation description {}'.format(
-            description))
-  return annotation_names[1:]
+        alt_datas = proc_var._alternate_datas[ind]
+        if annotation_field_name not in alt_datas._info:
+          alt_datas._info[annotation_field_name] = [annotation_map]
+        else:
+          alt_datas._info[annotation_field_name].append(annotation_map)
+      except annotation_parser.AnnotationParserException as e:
+        logging.warning(
+            'Parsing of annotation field %s failed at reference %s start %d: '
+            '%s', annotation_field_name, proc_var.reference_name,
+            proc_var.start, str(e))
+        if isinstance(e, annotation_parser.AnnotationAltNotFound):
+          self._alt_mismatch_counter.inc()
+        elif isinstance(e, annotation_parser.AlleleNumMissing):
+          self._allele_num_missing_counter.inc()
+        elif isinstance(e, annotation_parser.InvalidAlleleNumValue):
+          self._allele_num_incorrect_counter.inc()
+        elif isinstance(e, annotation_parser.AmbiguousAnnotationAllele):
+          self._alt_minimal_ambiguous_counter.inc()

--- a/gcp_variant_transforms/libs/processed_variant_test.py
+++ b/gcp_variant_transforms/libs/processed_variant_test.py
@@ -23,6 +23,7 @@ from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import metrics_util
 from gcp_variant_transforms.libs import processed_variant
+from gcp_variant_transforms.libs.annotation import annotation_parser
 # This is intentionally breaking the style guide because without this the lines
 # referencing the counter names are too long and hard to read.
 from gcp_variant_transforms.libs.processed_variant import _CounterEnum as CEnum
@@ -130,16 +131,16 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1._info = {
         'A2': 'data1',
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'A', 'Consequence': 'C1',
+            {annotation_parser.ANNOTATION_ALT: 'A', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'},
-            {processed_variant._ANNOTATION_ALT: 'A', 'Consequence': 'C3',
+            {annotation_parser.ANNOTATION_ALT: 'A', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     alt2 = processed_variant.AlternateBaseData('TT')
     alt2._info = {
         'A2': 'data2',
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'TT', 'Consequence': 'C2',
+            {annotation_parser.ANNOTATION_ALT: 'TT', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
@@ -148,7 +149,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     self.assertEqual(counter_factory.counter_map[
         CEnum.VARIANT.value].get_value(), 1)
     self.assertEqual(counter_factory.counter_map[
-        CEnum.ANNOTATION_ALT_MATCH.value].get_value(), 2)
+        CEnum.ANNOTATION_ALT_MATCH.value].get_value(), 3)
     self.assertEqual(
         counter_factory.counter_map[
             CEnum.ANNOTATION_ALT_MISMATCH.value].get_value(), 0)
@@ -171,16 +172,16 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1._info = {
         'A2': 'data1',
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'A', 'Consequence': 'C1',
+            {annotation_parser.ANNOTATION_ALT: 'A', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'},
-            {processed_variant._ANNOTATION_ALT: 'A', 'Consequence': 'C3',
+            {annotation_parser.ANNOTATION_ALT: 'A', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     alt2 = processed_variant.AlternateBaseData('TT')
     alt2._info = {
         'A2': 'data2',
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'TT', 'Consequence': 'C2',
+            {annotation_parser.ANNOTATION_ALT: 'TT', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
@@ -189,7 +190,7 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     self.assertEqual(counter_factory.counter_map[
         CEnum.VARIANT.value].get_value(), 1)
     self.assertEqual(counter_factory.counter_map[
-        CEnum.ANNOTATION_ALT_MATCH.value].get_value(), 2)
+        CEnum.ANNOTATION_ALT_MATCH.value].get_value(), 3)
     self.assertEqual(
         counter_factory.counter_map[
             CEnum.ANNOTATION_ALT_MISMATCH.value].get_value(), 1)
@@ -215,19 +216,19 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('<SYMBOLIC>')
     alt1._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'SYMBOLIC', 'Consequence': 'C1',
+            {annotation_parser.ANNOTATION_ALT: 'SYMBOLIC', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
     }
     alt2 = processed_variant.AlternateBaseData('[13:123457[.')
     alt2._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: '[13', 'Consequence': 'C2',
+            {annotation_parser.ANNOTATION_ALT: '[13', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     alt3 = processed_variant.AlternateBaseData('C[10:10357[.')
     alt3._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'C[10', 'Consequence': 'C3',
+            {annotation_parser.ANNOTATION_ALT: 'C[10', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2, alt3])
@@ -259,19 +260,19 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('CT')
     alt1._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'T', 'Consequence': 'C1',
+            {annotation_parser.ANNOTATION_ALT: 'T', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
     }
     alt2 = processed_variant.AlternateBaseData('CC')
     alt2._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'C', 'Consequence': 'C2',
+            {annotation_parser.ANNOTATION_ALT: 'C', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     alt3 = processed_variant.AlternateBaseData('CCC')
     alt3._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'CC', 'Consequence': 'C3',
+            {annotation_parser.ANNOTATION_ALT: 'CC', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2, alt3])
@@ -303,19 +304,19 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('CCT')
     alt1._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'CT', 'Consequence': 'C1',
+            {annotation_parser.ANNOTATION_ALT: 'CT', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
     }
     alt2 = processed_variant.AlternateBaseData('CCC')
     alt2._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'CC', 'Consequence': 'C2',
+            {annotation_parser.ANNOTATION_ALT: 'CC', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     alt3 = processed_variant.AlternateBaseData('CCCC')
     alt3._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'CCC', 'Consequence': 'C3',
+            {annotation_parser.ANNOTATION_ALT: 'CCC', 'Consequence': 'C3',
              'IMPACT': 'I3', 'SYMBOL': 'S3', 'Gene': 'G3'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2, alt3])
@@ -347,13 +348,13 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('AA')
     alt1._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'AA', 'Consequence': 'C1',
+            {annotation_parser.ANNOTATION_ALT: 'AA', 'Consequence': 'C1',
              'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
     }
     alt2 = processed_variant.AlternateBaseData('AAA')
     alt2._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'AAA', 'Consequence': 'C2',
+            {annotation_parser.ANNOTATION_ALT: 'AAA', 'Consequence': 'C2',
              'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
@@ -365,9 +366,6 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     self.assertEqual(
         counter_factory.counter_map[
             CEnum.ANNOTATION_ALT_MISMATCH.value].get_value(), 0)
-    self.assertEqual(
-        counter_factory.counter_map[
-            CEnum.ANNOTATION_ALT_MINIMAL_MATCH.value].get_value(), 0)
 
   def test_create_processed_variant_annotation_alt_minimal(self):
     # The returned variant is ignored as we create a custom one next.
@@ -393,17 +391,11 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('CT')
     alt1._info = {}
     alt2 = processed_variant.AlternateBaseData('CCT')
-    alt2._info = {
-        'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'T',
-             processed_variant._ANNOTATION_ALT_AMBIGUOUS: True,
-             'Consequence': 'C1', 'IMPACT': 'I1', 'SYMBOL': 'S1', 'Gene': 'G1'}]
-    }
+    alt2._info = {}
     alt3 = processed_variant.AlternateBaseData('C')
     alt3._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: '-',
-             processed_variant._ANNOTATION_ALT_AMBIGUOUS: False,
+            {annotation_parser.ANNOTATION_ALT: '-',
              'Consequence': 'C2', 'IMPACT': 'I2', 'SYMBOL': 'S2', 'Gene': 'G2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2, alt3])
@@ -411,13 +403,10 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     self.assertEqual(counter_factory.counter_map[
         CEnum.VARIANT.value].get_value(), 1)
     self.assertEqual(counter_factory.counter_map[
-        CEnum.ANNOTATION_ALT_MATCH.value].get_value(), 0)
+        CEnum.ANNOTATION_ALT_MATCH.value].get_value(), 1)
     self.assertEqual(
         counter_factory.counter_map[
             CEnum.ANNOTATION_ALT_MISMATCH.value].get_value(), 0)
-    self.assertEqual(
-        counter_factory.counter_map[
-            CEnum.ANNOTATION_ALT_MINIMAL_MATCH.value].get_value(), 2)
     self.assertEqual(
         counter_factory.counter_map[
             CEnum.ANNOTATION_ALT_MINIMAL_AMBIGUOUS.value].get_value(), 1)
@@ -452,13 +441,13 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     alt1 = processed_variant.AlternateBaseData('T')
     alt1._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'T',
+            {annotation_parser.ANNOTATION_ALT: 'T',
              'Consequence': 'C1', 'IMPACT': 'I1', 'ALLELE_NUM': '1'}]
     }
     alt2 = processed_variant.AlternateBaseData('CT')
     alt2._info = {
         'CSQ': [
-            {processed_variant._ANNOTATION_ALT: 'T',
+            {annotation_parser.ANNOTATION_ALT: 'T',
              'Consequence': 'C2', 'IMPACT': 'I2', 'ALLELE_NUM': '2'}]
     }
     self.assertEqual(proc_var.alternate_data_list, [alt1, alt2])
@@ -470,9 +459,6 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
     self.assertEqual(
         counter_factory.counter_map[
             CEnum.ANNOTATION_ALT_MISMATCH.value].get_value(), 0)
-    self.assertEqual(
-        counter_factory.counter_map[
-            CEnum.ANNOTATION_ALT_MINIMAL_MATCH.value].get_value(), 0)
     self.assertEqual(
         counter_factory.counter_map[
             CEnum.ANNOTATION_ALT_MINIMAL_AMBIGUOUS.value].get_value(), 0)


### PR DESCRIPTION
Fixes #186 

Tested: unit-tests updated

Some notes about this PR:
* Counter handling is kept in the `processed_variant`; the new `annotation_parser` is purely responsible for annotation parsing and to signal errors it uses different exceptions. The caller (i.e., `processed_variant`) converts those exceptions to counter increments.
* This is mostly a refactoring and from a user's perspective it is almost a no-op; the exceptions are:
* There is no `ambiguous_allele` column in the output BigQuery table (or the map out of the parser). This column was conditional on the `minimal_match` case before but I decided to remove it completely and instead drop the annotations that have ambiguous ALT matching. In general, I think the `minimal_match` mode should be avoided if possible, but if it is used, it is better to drop ambiguous annotations.
* There was a `_convert_annotation_strs_to_alt_map` in the old code which was producing `Dict[str, List[Dict[str, str]]]`. This was ugly, hard to understand, and I never liked it. The reason for this structure was some minor performance gains. Instead of relying on this complex structure, each annotation string is matched independently. 
* As a result of the above change, the semantics of the `annotation_alt_match_counter` has slightly changed. Note that independent processing of annotation strings was done for `_use_allelel_num` even in the old code, so this change fixes the inconsistency between the counter semantics.
* `annotation_alt_minimal_match_counter` is dropped; all matching alts are counted under `annotation_alt_match`