### PR TITLE
clean up infer_undefined_headers #258

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -72,13 +72,13 @@ You can fix this by:
   `--representative_header_file <file_path>`, where you provide a merged view
   of all headers in all files. You can add any missing fields to that file.
   We are working on a tool to make this process easier and provide
-  recommandations for missing fields.
+  recommendations for missing fields.
 
-* Coming soon: Run the pipeline with `--infer_undefined_headers`. This will do
-  two passes on the data and will infer definition for undefined headers. You
-  do not need to make any changes to the VCF files or provide a representative
-  header file. However, running with this option adds ~30% more compute to the
-  pipeline.
+* Run the pipeline with `--infer_headers`. This will do two passes on the data
+  and will infer definition for undefined headers and mismatched headers (header
+  field definition does not match the field value). You do not need to make any
+  changes to the VCF files or provide a representative header file. However,
+  running with this option adds ~30% more compute to the pipeline.
 
 ## Error: "BigQuery schema has no such field"
 

--- a/gcp_variant_transforms/libs/bigquery_row_generator.py
+++ b/gcp_variant_transforms/libs/bigquery_row_generator.py
@@ -190,7 +190,7 @@ class BigQueryRowGenerator(object):
       raise ValueError('BigQuery schema has no such field: {}.\n'
                        'This can happen if the field is not defined in '
                        'the VCF headers, or is not inferred automatically. '
-                       'Retry pipeline with --infer_undefined_headers.'
+                       'Retry pipeline with --infer_headers.'
                        .format(field_name))
     sanitized_field_data = bigquery_util.get_bigquery_sanitized_field(data)
     field_schema = schema_descriptor.get_field_descriptor(field_name)

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -82,12 +82,13 @@ class VcfReadOptions(VariantTransformsOptions):
               'Note that each VCF file must still contain valid header files '
               'even if this is provided.'))
     parser.add_argument(
-        '--infer_undefined_headers',
+        '--infer_headers',
         type='bool', default=False, nargs='?', const=True,
         help=('If true, header fields (e.g. FORMAT, INFO) are not only '
               'extracted from header section of VCF files, but also from '
               'variants. This is useful when there are header fields in '
-              'variants not defined in the header sections.'))
+              'variants not defined in the header sections, or the definition '
+              'of the the header fields do not match the field values.'))
 
 
 class BigQueryWriteOptions(VariantTransformsOptions):

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -83,6 +83,7 @@ class VcfReadOptions(VariantTransformsOptions):
               'even if this is provided.'))
     parser.add_argument(
         '--infer_headers',
+        '--infer_undefined_headers',
         type='bool', default=False, nargs='?', const=True,
         help=('If true, header fields (e.g. FORMAT, INFO) are not only '
               'extracted from header section of VCF files, but also from '

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
@@ -3,7 +3,7 @@
     "test_name": "test-1000-genomes-no-merge",
     "table_name": "test_1000_genomes_no_merge",
     "input_pattern": "gs://genomics-public-data/1000-genomes/vcf/*.vcf",
-    "infer_undefined_headers": "True",
+    "infer_headers": "True",
     "allow_incompatible_records": "True",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-64",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/infer_header_fields.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/infer_header_fields.json
@@ -3,7 +3,7 @@
     "test_name": "infer-header-fields",
     "table_name": "infer_header_fields",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/infer-header-fields.vcf",
-    "infer_undefined_headers": "True",
+    "infer_headers": "True",
     "allow_incompatible_records": "True",
     "runner": "DirectRunner",
     "zones": ["us-west1-b"],

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -152,7 +152,7 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
 
   # Always run pipeline locally if data is small.
   if (pipeline_mode == vcf_to_bq_common.PipelineModes.SMALL and
-      not known_args.infer_undefined_headers):
+      not known_args.infer_headers):
     options.view_as(pipeline_options.StandardOptions).runner = 'DirectRunner'
 
   google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)
@@ -178,7 +178,7 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
         headers,
         known_args.split_alternate_allele_info_fields,
         known_args.allow_incompatible_records)
-    if known_args.infer_undefined_headers:
+    if known_args.infer_headers:
       merged_header = _add_inferred_headers(p, known_args, merged_header)
     vcf_to_bq_common.write_headers(merged_header, temp_merged_headers_file_path)
     known_args.representative_header_file = temp_merged_headers_file_path


### PR DESCRIPTION
Follow up on [PR 283](https://github.com/googlegenomics/gcp-variant-transforms/pull/283).

Now the `infer headers` applies to both undefined headers and mismatched headers. This PR replaces all `infer_undefined_headers` with `infer_headers`. Update the corresponding doc as well.

Issue: [258](https://github.com/googlegenomics/gcp-variant-transforms/issues/258).
