### PR TITLE
BQ to VCF Prototype #85

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -711,7 +711,7 @@ class WriteToVcf(PTransform):
     self._header = headers and '\n'.join([h.strip() for h in headers]) + '\n'
 
   def expand(self, pcoll):
-    return pcoll | 'Write to VCF' >> textio.WriteToText(
+    return pcoll | 'WriteToVCF' >> textio.WriteToText(
         self._file_path,
         append_trailing_newlines=False,
         num_shards=self._num_shards,

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -711,7 +711,7 @@ class WriteToVcf(PTransform):
     self._header = headers and '\n'.join([h.strip() for h in headers]) + '\n'
 
   def expand(self, pcoll):
-    return pcoll | textio.WriteToText(
+    return pcoll | 'Write to VCF' >> textio.WriteToText(
         self._file_path,
         append_trailing_newlines=False,
         num_shards=self._num_shards,

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -1,0 +1,72 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+r"""Pipeline for downloading BigQuery table to one VCF file.
+
+Run locally:
+python -m gcp_variant_transforms.bq_to_vcf \
+  --output_file <path to VCF file> \
+  --input_table projectname:bigquerydataset.tablename
+
+Run on Dataflow:
+python -m gcp_variant_transforms.bq_to_vcf \
+  --output_file <path to VCF file> \
+  --input_table projectname:bigquerydataset.tablename \
+  --project projectname \
+  --staging_location gs://bucket/staging \
+  --temp_location gs://bucket/temp \
+  --job_name bq-to-vcf \
+  --setup_file ./setup.py \
+  --runner DataflowRunner
+"""
+
+import logging
+import sys
+from typing import List  # pylint: disable=unused-import
+
+import apache_beam as beam
+from apache_beam.io.gcp import bigquery
+from apache_beam.options import pipeline_options
+
+from gcp_variant_transforms import vcf_to_bq_common
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.options import variant_transform_options
+from gcp_variant_transforms.transforms import bigquery_to_variant
+
+_COMMAND_LINE_OPTIONS = [variant_transform_options.BQtoVcfOptions]
+
+
+def run(argv=None):
+  # type: (List[str]) -> None
+  """Runs BigQuery to VCF pipeline."""
+  logging.info('Command: %s', ' '.join(argv or sys.argv))
+  known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
+                                                          _COMMAND_LINE_OPTIONS)
+  bq_source = bigquery.BigQuerySource(
+      query=''.join(['select * from `',
+                     known_args.input_table.replace(':', '.', 1),
+                     '`']),
+      validate=True,
+      use_standard_sql=True)
+
+  options = pipeline_options.PipelineOptions(pipeline_args)
+  with beam.Pipeline(options=options) as p:
+    _ = (p | 'Read BigQuery ' >> beam.io.Read(bq_source)
+         | bigquery_to_variant.BigQueryToVariant()
+         | vcfio.WriteToVcf(known_args.output_file))
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  run()

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""Pipeline for downloading BigQuery table to one VCF file.
+r"""Pipeline for downloading BigQuery table to one VCF file. [EXPERIMENTAL]
 
 Run locally:
 python -m gcp_variant_transforms.bq_to_vcf \

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -17,7 +17,7 @@
 import re
 import math
 import sys
-from typing import List  # pylint: disable=unused-import
+from typing import List, Tuple  # pylint: disable=unused-import
 
 from gcp_variant_transforms.beam_io import vcfio
 
@@ -75,6 +75,25 @@ _FALLBACK_FIELD_NAME_PREFIX = 'field_'
 # A big number to represent infinite float values. The division by 10 is to
 # prevent unintentional overflows when doing subsequent operations.
 _INF_FLOAT_VALUE = sys.float_info.max / 10
+
+
+def parse_table_reference(input_table):
+  # type: (str) -> Tuple[str, str, str]
+  """Parses a table reference.
+
+  Args:
+    input_table: a table reference in the format of PROJECT:DATASET.TABLE.
+
+  Returns:
+    A tuple (PROJECT, DATASET, TABLE).
+  """
+  table_re_match = re.match(
+      r'^((?P<project>.+):)(?P<dataset>\w+)\.(?P<table>[\w\$]+)$', input_table)
+  if not table_re_match:
+    raise ValueError('Expected a table reference (PROJECT:DATASET.TABLE) ')
+  return (table_re_match.group('project'),
+          table_re_match.group('dataset'),
+          table_re_match.group('table'))
 
 
 def get_bigquery_sanitized_field_name(field_name):

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -421,3 +421,49 @@ class PartitionOptions(VariantTransformsOptions):
               'by chromosome (one table per chromosome) which is located at: '
               'gcp_variant_transforms/data/partition_configs/'
               'homo_sapiens_default.yaml'))
+
+
+class BQtoVcfOptions(VariantTransformsOptions):
+  """Options for BigQuery to VCF pipelines."""
+
+  def add_arguments(self, parser):
+    # type: (argparse.ArgumentParser) -> None
+    parser.add_argument(
+        '--output_file',
+        required=True,
+        help='The full path of the VCF file to store the result.')
+    parser.add_argument(
+        '--input_table',
+        required=True,
+        help=('BigQuery table that will be downloaded. It must be in the '
+              'format of (PROJECT:DATASET.TABLE).'))
+
+  def validate(self, parsed_args, client=None):
+    # type: (argparse.Namespace, bigquery.BigqueryV2) -> None
+    table_re_match = re.match(
+        r'^((?P<project>.+):)(?P<dataset>\w+)\.(?P<table>[\w\$]+)$',
+        parsed_args.input_table)
+    if not table_re_match:
+      raise ValueError(
+          'Expected a table reference (PROJECT:DATASET.TABLE) '
+          'instead of {}.'.format(parsed_args.input_table))
+    if not client:
+      credentials = GoogleCredentials.get_application_default().create_scoped(
+          ['https://www.googleapis.com/auth/bigquery'])
+      client = bigquery.BigqueryV2(credentials=credentials)
+    project_id = table_re_match.group('project')
+    dataset_id = table_re_match.group('dataset')
+    table_id = table_re_match.group('table')
+    try:
+      client.tables.Get(bigquery.BigqueryTablesGetRequest(
+          projectId=project_id,
+          datasetId=dataset_id,
+          tableId=table_id))
+
+    except exceptions.HttpError as e:
+      if e.status_code == 404:
+        raise ValueError('Table %s:%s.%s does not exist.' %
+                         (project_id, dataset_id, table_id))
+      else:
+        # For the rest of the errors, use BigQuery error message.
+        raise

--- a/gcp_variant_transforms/transforms/bigquery_to_variant.py
+++ b/gcp_variant_transforms/transforms/bigquery_to_variant.py
@@ -46,6 +46,7 @@ class BigQueryToVariant(beam.PTransform):
     return (pcoll | 'BigQueryToVariant' >> beam.Map(
         self._convert_bq_row_to_variant))
 
+  # TODO (yifangchen): Move this to a separate module so that it can be reused.
   def _convert_bq_row_to_variant(self, row):
     # type: (Dict[str, Any]) -> vcfio.Variant
     return vcfio.Variant(

--- a/gcp_variant_transforms/transforms/bigquery_to_variant.py
+++ b/gcp_variant_transforms/transforms/bigquery_to_variant.py
@@ -1,0 +1,109 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A PTransform to convert BigQuery table rows to a PCollection of `Variant`."""
+
+from typing import Any, Dict, List  # pylint: disable=unused-import
+
+import apache_beam as beam
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.libs import bigquery_util
+
+# Constants for column names in the BigQuery schema.
+BQ_COLUMN_KEY_CONSTANTS = [bigquery_util.ColumnKeyConstants.REFERENCE_NAME,
+                           bigquery_util.ColumnKeyConstants.START_POSITION,
+                           bigquery_util.ColumnKeyConstants.END_POSITION,
+                           bigquery_util.ColumnKeyConstants.REFERENCE_BASES,
+                           bigquery_util.ColumnKeyConstants.ALTERNATE_BASES,
+                           bigquery_util.ColumnKeyConstants.NAMES,
+                           bigquery_util.ColumnKeyConstants.QUALITY,
+                           bigquery_util.ColumnKeyConstants.FILTER,
+                           bigquery_util.ColumnKeyConstants.CALLS]
+
+VARIANT_CALL_CONSTANTS = [bigquery_util.ColumnKeyConstants.CALLS_NAME,
+                          bigquery_util.ColumnKeyConstants.CALLS_GENOTYPE,
+                          bigquery_util.ColumnKeyConstants.CALLS_PHASESET]
+
+
+class BigQueryToVariant(beam.PTransform):
+  """Transforms BigQuery table rows to PCollection of `Variant`."""
+
+  def expand(self, pcoll):
+    return (pcoll | 'BigQuery to Variant' >> beam.Map(
+        self._convert_bq_row_to_variant))
+
+  def _convert_bq_row_to_variant(self, row):
+    # type: (Dict[str, Any]) -> vcfio.Variant
+    return vcfio.Variant(
+        reference_name=row[bigquery_util.ColumnKeyConstants.REFERENCE_NAME],
+        start=row[bigquery_util.ColumnKeyConstants.START_POSITION],
+        end=row[bigquery_util.ColumnKeyConstants.END_POSITION],
+        reference_bases=row[bigquery_util.ColumnKeyConstants.REFERENCE_BASES],
+        alternate_bases=self._get_alternate_bases(
+            row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES]),
+        names=row[bigquery_util.ColumnKeyConstants.NAMES],
+        quality=row[bigquery_util.ColumnKeyConstants.QUALITY],
+        filters=row[bigquery_util.ColumnKeyConstants.FILTER],
+        info=self._get_variant_info(row),
+        calls=self._get_variant_calls(
+            row[bigquery_util.ColumnKeyConstants.CALLS])
+    )
+
+  def _get_alternate_bases(self, alternate_base_records):
+    # type: (List[Dict[str, Any]]) -> List[str]
+    alternate_bases = []
+    for record in alternate_base_records:
+      alternate_bases.append(
+          record[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES_ALT])
+    return alternate_bases
+
+  def _get_variant_info(self, row):
+    # type: (Dict[str, Any]) -> Dict[str, Any]
+    info = {}
+    for key, value in row.iteritems():
+      if key not in BQ_COLUMN_KEY_CONSTANTS and self._is_value_valid(value):
+        info.update({key: value})
+    for alt_base in row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES]:
+      for key, value in alt_base.iteritems():
+        if (key != bigquery_util.ColumnKeyConstants.ALTERNATE_BASES_ALT and
+            self._is_value_valid(value)):
+          if key not in info:
+            info.update({key: []})
+          info[key].append(value)
+    return info
+
+  def _get_variant_calls(self, variant_call_records):
+    # type: (List[Dict[str, Any]]) -> List[vcfio.VariantCall]
+    variant_calls = []
+    for call_record in variant_call_records:
+      info = {}
+      for key, value in call_record.iteritems():
+        if key not in VARIANT_CALL_CONSTANTS and self._is_value_valid(value):
+          info.update({key: value})
+      variant_call = vcfio.VariantCall(
+          name=call_record[bigquery_util.ColumnKeyConstants.CALLS_NAME],
+          genotype=call_record[bigquery_util.ColumnKeyConstants.CALLS_GENOTYPE],
+          phaseset=call_record[bigquery_util.ColumnKeyConstants.CALLS_PHASESET],
+          info=info)
+      variant_calls.append(variant_call)
+    return variant_calls
+
+  def _is_value_valid(self, value):
+    # type: (Any) -> bool
+    if value is None:
+      return False
+    if isinstance(value, list) and not value:
+      return False
+    return True

--- a/gcp_variant_transforms/transforms/bigquery_to_variant_test.py
+++ b/gcp_variant_transforms/transforms/bigquery_to_variant_test.py
@@ -1,0 +1,109 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for bigquery_to_variant module."""
+
+import unittest
+
+from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
+from gcp_variant_transforms.transforms import bigquery_to_variant
+from gcp_variant_transforms.beam_io import vcfio
+
+
+class BigQueryToVariantTest(unittest.TestCase):
+
+  def _get_big_query_row(self):
+    return {unicode(ColumnKeyConstants.REFERENCE_NAME): unicode('chr19'),
+            unicode(ColumnKeyConstants.START_POSITION): 11,
+            unicode(ColumnKeyConstants.END_POSITION): 12,
+            unicode(ColumnKeyConstants.REFERENCE_BASES): 'C',
+            unicode(ColumnKeyConstants.NAMES): ['rs1', 'rs2'],
+            unicode(ColumnKeyConstants.QUALITY): 2,
+            unicode(ColumnKeyConstants.FILTER): ['PASS'],
+            unicode(ColumnKeyConstants.CALLS): [
+                {unicode(ColumnKeyConstants.CALLS_NAME): unicode('Sample1'),
+                 unicode(ColumnKeyConstants.CALLS_GENOTYPE): [0, 1],
+                 unicode(ColumnKeyConstants.CALLS_PHASESET): unicode('*'),
+                 unicode('GQ'): 20, unicode('FIR'): [10, 20]},
+                {unicode(ColumnKeyConstants.CALLS_NAME): unicode('Sample2'),
+                 unicode(ColumnKeyConstants.CALLS_GENOTYPE): [1, 0],
+                 unicode(ColumnKeyConstants.CALLS_PHASESET): None,
+                 unicode('GQ'): 10, unicode('FB'): True}
+            ],
+            unicode(ColumnKeyConstants.ALTERNATE_BASES): [
+                {unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('A'),
+                 unicode('IFR'): None,
+                 unicode('IFR2'): 0.2},
+                {unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('TT'),
+                 unicode('IFR'): 0.2,
+                 unicode('IFR2'): 0.3}
+            ],
+            unicode('IS'): unicode('some data'),
+            unicode('ISR'): [unicode('data1'), unicode('data2')]}
+
+  def test_alternate_bases(self):
+    alternate_base_records = self._get_big_query_row()[
+        ColumnKeyConstants.ALTERNATE_BASES]
+
+    expected_alternate_bases = ['A', 'TT']
+    bq_to_variant = bigquery_to_variant.BigQueryToVariant()
+    self.assertEqual(expected_alternate_bases,
+                     bq_to_variant._get_alternate_bases(alternate_base_records))
+
+  def test_get_variant_info(self):
+    row = self._get_big_query_row()
+    expected_variant_info = {'IFR': [0.2],
+                             'IFR2': [0.2, 0.3],
+                             'IS': 'some data',
+                             'ISR': ['data1', 'data2']}
+    bq_to_variant = bigquery_to_variant.BigQueryToVariant()
+    self.assertEqual(expected_variant_info,
+                     bq_to_variant._get_variant_info(row))
+
+  def test_get_variant_calls(self):
+    variant_call_records = self._get_big_query_row()[ColumnKeyConstants.CALLS]
+
+    expected_calls = [
+        vcfio.VariantCall(
+            name='Sample1', genotype=[0, 1], phaseset='*',
+            info={'GQ': 20, 'FIR': [10, 20]}),
+        vcfio.VariantCall(
+            name='Sample2', genotype=[1, 0],
+            info={'GQ': 10, 'FB': True}),
+    ]
+
+    bq_to_variant = bigquery_to_variant.BigQueryToVariant()
+    self.assertEqual(expected_calls,
+                     bq_to_variant._get_variant_calls(variant_call_records))
+
+  def test_convert_bq_row_to_variant(self):
+    row = self._get_big_query_row()
+    expected_variant = vcfio.Variant(
+        reference_name='chr19', start=11, end=12, reference_bases='C',
+        alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
+        filters=['PASS'],
+        info={'IFR': [0.2], 'IFR2': [0.2, 0.3],
+              'IS': 'some data', 'ISR': ['data1', 'data2']},
+        calls=[
+            vcfio.VariantCall(
+                name='Sample1', genotype=[0, 1], phaseset='*',
+                info={'GQ': 20, 'FIR': [10, 20]}),
+            vcfio.VariantCall(
+                name='Sample2', genotype=[1, 0],
+                info={'GQ': 10, 'FB': True})
+        ]
+    )
+    bq_to_variant = bigquery_to_variant.BigQueryToVariant()
+    self.assertEqual(expected_variant,
+                     bq_to_variant._convert_bq_row_to_variant(row))


### PR DESCRIPTION
First version (simplest) of BQ to VCF.
- only variants (not sorted) are exported.
- it assumes each variant' list of calls contain all samples.


Issue: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests