### PR TITLE
raise error on unknown flags  #205

### DIFF
--- a/gcp_variant_transforms/vcf_to_bq_common.py
+++ b/gcp_variant_transforms/vcf_to_bq_common.py
@@ -25,6 +25,7 @@ import enum
 import apache_beam as beam
 from apache_beam import pvalue  # pylint: disable=unused-import
 from apache_beam.io import filesystems
+from apache_beam.options import pipeline_options
 
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.transforms import merge_headers
@@ -33,6 +34,7 @@ from gcp_variant_transforms.transforms import merge_headers
 # headers will be merged in beam.
 _SMALL_DATA_THRESHOLD = 100
 _LARGE_DATA_THRESHOLD = 50000
+_COMMAND_LINE_ARG_PREFIX = '--'
 
 
 class PipelineModes(enum.Enum):
@@ -59,6 +61,7 @@ def parse_args(argv, command_line_options):
   known_args, pipeline_args = parser.parse_known_args(argv)
   for transform_options in options:
     transform_options.validate(known_args)
+  _raise_error_on_unrecognized_flags(pipeline_args)
   return known_args, pipeline_args
 
 
@@ -115,3 +118,19 @@ def write_headers(merged_header, file_path):
   """Writes a PCollection of ``VcfHeader`` to location ``file_path``."""
   _ = (merged_header | 'WriteHeaders' >>
        vcf_header_io.WriteVcfHeaders(file_path))
+
+
+def _raise_error_on_unrecognized_flags(pipeline_args):
+  # type: (List[str]) -> None
+  """Raises an error if there are unrecognized flags."""
+  options = pipeline_options.PipelineOptions(pipeline_args).get_all_options()
+  for flag in _get_flag_names(pipeline_args):
+    if not any(str.startswith(option, flag) for option in options):
+      raise ValueError('The flag {} is unrecognized.'.format(flag))
+
+
+def _get_flag_names(pipeline_args):
+  # type: (List[str]) -> List[str]
+  """Returns a list of flag names that starts with `COMMAND_LINE_ARG_PREFIX`."""
+  return [arg[len(_COMMAND_LINE_ARG_PREFIX):] for arg in pipeline_args
+          if str.startswith(arg, _COMMAND_LINE_ARG_PREFIX)]

--- a/gcp_variant_transforms/vcf_to_bq_common.py
+++ b/gcp_variant_transforms/vcf_to_bq_common.py
@@ -34,7 +34,7 @@ from gcp_variant_transforms.transforms import merge_headers
 # headers will be merged in beam.
 _SMALL_DATA_THRESHOLD = 100
 _LARGE_DATA_THRESHOLD = 50000
-_COMMAND_LINE_ARG_PREFIX = '--'
+_COMMAND_LINE_ARG_PREFIX = '-'
 
 
 class PipelineModes(enum.Enum):
@@ -125,12 +125,14 @@ def _raise_error_on_unrecognized_flags(pipeline_args):
   """Raises an error if there are unrecognized flags."""
   options = pipeline_options.PipelineOptions(pipeline_args).get_all_options()
   for flag in _get_flag_names(pipeline_args):
-    if not any(str.startswith(option, flag) for option in options):
+    # Cannot use exact match since the argparse allows long options to be
+    # abbreviated to a prefix.
+    if not any(option.startswith(flag) for option in options):
       raise ValueError('The flag {} is unrecognized.'.format(flag))
 
 
 def _get_flag_names(pipeline_args):
   # type: (List[str]) -> List[str]
   """Returns a list of flag names that starts with `COMMAND_LINE_ARG_PREFIX`."""
-  return [arg[len(_COMMAND_LINE_ARG_PREFIX):] for arg in pipeline_args
-          if str.startswith(arg, _COMMAND_LINE_ARG_PREFIX)]
+  return [arg.lstrip(_COMMAND_LINE_ARG_PREFIX) for arg in pipeline_args
+          if arg.startswith(_COMMAND_LINE_ARG_PREFIX)]

--- a/gcp_variant_transforms/vcf_to_bq_common_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_common_test.py
@@ -88,7 +88,7 @@ class DataProcessorTest(unittest.TestCase):
       self.assertEqual(vcf_to_bq_common.get_pipeline_mode(args.input_pattern),
                        PipelineModes.MEDIUM)
 
-  def test_fail_on_unrecognized_flags_1(self):
+  def test_fail_on_unrecognized_flags(self):
     pipeline_args = ['--project',
                      'gcp-variant-transforms-test',
                      '--staging_location',
@@ -98,7 +98,7 @@ class DataProcessorTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       vcf_to_bq_common._raise_error_on_unrecognized_flags(pipeline_args)
 
-  def test_fail_on_unrecognized_flags_2(self):
+  def test_fail_on_unrecognized_flags_no_failure(self):
     pipeline_args = ['--project',
                      'gcp-variant-transforms-test',
                      '--staging_location',

--- a/gcp_variant_transforms/vcf_to_bq_common_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_common_test.py
@@ -87,3 +87,21 @@ class DataProcessorTest(unittest.TestCase):
     with mock.patch.object(FileSystems, 'match', return_value=[match]):
       self.assertEqual(vcf_to_bq_common.get_pipeline_mode(args.input_pattern),
                        PipelineModes.MEDIUM)
+
+  def test_fail_on_unrecognized_flags_1(self):
+    pipeline_args = ['--project',
+                     'gcp-variant-transforms-test',
+                     '--staging_location',
+                     'gs://integration_test_runs/staging',
+                     '--unknown_flag',
+                     'some value']
+    with self.assertRaises(ValueError):
+      vcf_to_bq_common._raise_error_on_unrecognized_flags(pipeline_args)
+
+  def test_fail_on_unrecognized_flags_2(self):
+    pipeline_args = ['--project',
+                     'gcp-variant-transforms-test',
+                     '--staging_location',
+                     'gs://integration_test_runs/staging']
+
+    vcf_to_bq_common._raise_error_on_unrecognized_flags(pipeline_args)


### PR DESCRIPTION
Raise an error and fail the pipeline if there are unrecognized flags.

Issue: [#205](https://github.com/googlegenomics/gcp-variant-transforms/issues/205)
Tested: unit tests & integration tests
