### PR TITLE
densify variants #85

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -321,6 +321,8 @@ class _ToVcfRecordCoder(coders.Coder):
 
   def _encode_genotype(self, genotype, phaseset):
     """Encodes the genotype of a :class:`VariantCall` for a VCF file line."""
+    if genotype == MISSING_GENOTYPE_VALUE:
+      return MISSING_FIELD_VALUE
     encoded_genotype = []
     for allele in genotype:
       if allele == MISSING_GENOTYPE_VALUE:

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -831,6 +831,14 @@ class VcfSinkTest(unittest.TestCase):
 
     self._assert_variant_lines_equal(coder.encode(variant), expected)
 
+  def test_empty_sample_calls(self):
+    coder = self._get_coder()
+    variant = Variant()
+    variant.calls.append(
+        VariantCall(name='Sample2', genotype=-1))
+    expected = '.	.	.	.	.	.	.	.	GT	.\n'
+    self._assert_variant_lines_equal(coder.encode(variant), expected)
+
   def test_missing_genotype(self):
     coder = self._get_coder()
     variant = Variant()

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -44,6 +44,7 @@ from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.options import variant_transform_options
 from gcp_variant_transforms.transforms import bigquery_to_variant
+from gcp_variant_transforms.transforms import densify_variants
 
 _BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`;'
 _COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
@@ -66,6 +67,7 @@ def run(argv=None):
   with beam.Pipeline(options=options) as p:
     _ = (p | 'ReadFromBigQuery ' >> beam.io.Read(bq_source)
          | bigquery_to_variant.BigQueryToVariant()
+         | densify_variants.DensifyVariants()
          | vcfio.WriteToVcf(known_args.output_file))
 
 


### PR DESCRIPTION
Add `Densify Variants` transform to the BigQuery to VCF pipeline, which extends each variant's calls with data for all samples.

issues: [#85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests