### PR TITLE
Raise error on unrecognized flags #205

### DIFF
--- a/gcp_variant_transforms/vcf_to_bq_common.py
+++ b/gcp_variant_transforms/vcf_to_bq_common.py
@@ -34,7 +34,6 @@ from gcp_variant_transforms.transforms import merge_headers
 # headers will be merged in beam.
 _SMALL_DATA_THRESHOLD = 100
 _LARGE_DATA_THRESHOLD = 50000
-_COMMAND_LINE_ARG_PREFIX = '-'
 
 
 class PipelineModes(enum.Enum):
@@ -129,4 +128,4 @@ def _raise_error_on_unrecognized_flags(pipeline_args):
       cls._add_argparse_args(parser)
   _, unknown = parser.parse_known_args(pipeline_args)
   if unknown:
-    raise ValueError('The flag {} is unrecognized.'.format(unknown))
+    raise ValueError('Unrecognized flag(s): {}'.format(unknown))


### PR DESCRIPTION
Raise an error and fail the pipeline if there are unrecognized flags.

A previous fix ([PR 302](https://github.com/googlegenomics/gcp-variant-transforms/pull/302)) cannot handle the case when the args have a `dest` specified (e.g., `--worker_machine_type` has a dest as `mathine_type`, in which case `worker_mathine_type` is not recognized).

Issue:  [#205](https://github.com/googlegenomics/gcp-variant-transforms/issues/205)
Tested: unit tests & integration tests