### PR TITLE
Only enable auto-partitioning if variant merging is enabled.

### DIFF
--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -221,7 +221,8 @@ def run(argv=None):
       counter_factory)
 
   partitioner = None
-  if known_args.optimize_for_large_inputs or known_args.partition_config_path:
+  if ((known_args.optimize_for_large_inputs and variant_merger) or
+      known_args.partition_config_path):
     partitioner = variant_partition.VariantPartition(
         known_args.partition_config_path)
 


### PR DESCRIPTION
Auto partitioning is only helpful if we want to merge records. Otherwise, it can cause unnecessary computation.

Tested: ran presubmit integration tests.