### PR TITLE
write vcf files based on key and compose files to one

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -507,7 +507,11 @@ class _WriteVcfDataLinesFn(beam.DoFn):
 
 
 class WriteVcfDataLines(PTransform):
-  """A PTransform for writing VCF data lines."""
+  """A PTransform for writing VCF data lines.
 
+  This PTransform takes PCollection<`file_path`, `variants`> as input, and
+  writes `variants` to `file_path`. The PTransform `WriteToVcf` takes
+  PCollection<`Variant`> as input, and writes all variants to the same file.
+  """
   def expand(self, pcoll):
     return pcoll | 'WriteToVCF' >> beam.ParDo(_WriteVcfDataLinesFn())

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -171,6 +171,124 @@ class _ToVcfRecordCoder(coders.Coder):
     return MISSING_FIELD_VALUE
 
 
+class _ToVcfRecordCoder(coders.Coder):
+  """Coder for encoding :class:`Variant` objects as VCF text lines."""
+
+  def encode(self, variant):
+    # type: (Variant) -> str
+    """Converts a :class:`Variant` object back to a VCF line."""
+    encoded_info = self._encode_variant_info(variant)
+    format_keys = self._get_variant_format_keys(variant)
+    encoded_calls = self._encode_variant_calls(variant, format_keys)
+
+    columns = [
+        variant.reference_name,
+        None if variant.start is None else variant.start + 1,
+        ';'.join(variant.names),
+        variant.reference_bases,
+        ','.join(variant.alternate_bases),
+        variant.quality,
+        ';'.join(variant.filters),
+        encoded_info,
+        ':'.join(format_keys),
+    ]
+    if encoded_calls:
+      columns.append(encoded_calls)
+    columns = [self._encode_value(c) for c in columns]
+
+    return '\t'.join(columns) + '\n'
+
+  def _encode_value(self, value):
+    """Encodes a single :class:`Variant` column value for a VCF file line."""
+    if not value and value != 0:
+      return MISSING_FIELD_VALUE
+    elif isinstance(value, list):
+      return ','.join([self._encode_value(x) for x in value])
+    return str(value)
+
+  def _encode_variant_info(self, variant):
+    """Encodes the info of a :class:`Variant` for a VCF file line."""
+    encoded_infos = []
+    # Set END in info if it doesn't match start+len(reference_bases). This is
+    # usually the case for non-variant regions.
+    if (variant.start is not None
+        and variant.reference_bases
+        and variant.end
+        and variant.start + len(variant.reference_bases) != variant.end):
+      encoded_infos.append('END=%d' % variant.end)
+    # Set all other fields of info.
+    for k, v in variant.info.iteritems():
+      if v is True:
+        encoded_infos.append(k)
+      else:
+        encoded_infos.append('%s=%s' % (k, self._encode_value(v)))
+    return ';'.join(encoded_infos)
+
+  def _get_variant_format_keys(self, variant):
+    """Gets the format keys of a :class:`Variant`."""
+    if not variant.calls:
+      return []
+
+    format_keys = [GENOTYPE_FORMAT_KEY]
+    for call in variant.calls:
+      # If any calls have a set phaseset that is not `DEFAULT_PHASESET_VALUE`,
+      # the key will be added to the format field.
+      if self._is_alternate_phaseset(call.phaseset):
+        format_keys.append(PHASESET_FORMAT_KEY)
+      format_keys.extend([k for k in call.info])
+
+    # Sort all keys and remove duplicates after GENOTYPE_FORMAT_KEY
+    format_keys[1:] = sorted(list(set(format_keys[1:])))
+
+    return format_keys
+
+  def _encode_variant_calls(self, variant, format_keys):
+    """Encodes the calls of a :class:`Variant` in a VCF line."""
+    # Ensure that genotype is always the first key in format_keys
+    assert not format_keys or format_keys[0] == GENOTYPE_FORMAT_KEY
+    encoded_calls = []
+    for call in variant.calls:
+      encoded_call_info = [self._encode_genotype(call.genotype, call.phaseset)]
+      for key in format_keys[1:]:
+        if key == PHASESET_FORMAT_KEY:
+          encoded_call_info.append(self._encode_phaseset(call.phaseset))
+        else:
+          encoded_call_info.append(self._encode_call_info_value(call.info, key))
+
+      encoded_calls.append(':'.join(encoded_call_info))
+
+    return '\t'.join(encoded_calls)
+
+  def _encode_genotype(self, genotype, phaseset):
+    """Encodes the genotype of a :class:`VariantCall` for a VCF file line."""
+    if genotype == MISSING_GENOTYPE_VALUE:
+      return MISSING_FIELD_VALUE
+    encoded_genotype = []
+    for allele in genotype:
+      if allele == MISSING_GENOTYPE_VALUE:
+        encoded_genotype.append(MISSING_FIELD_VALUE)
+      else:
+        encoded_genotype.append(self._encode_value(allele))
+
+    phase_char = '|' if phaseset else '/'
+    return phase_char.join(encoded_genotype) or MISSING_FIELD_VALUE
+
+  def _encode_phaseset(self, phaseset):
+    """Encodes the phaseset of a :class:`VariantCall` for a VCF file line."""
+    if self._is_alternate_phaseset(phaseset):
+      return phaseset
+    return MISSING_FIELD_VALUE
+
+  def _is_alternate_phaseset(self, phaseset):
+    return phaseset and phaseset != DEFAULT_PHASESET_VALUE
+
+  def _encode_call_info_value(self, info, key):
+    """Encodes the info of a :class:`VariantCall` for a VCF file line."""
+    if key in info:
+      return self._encode_value(info[key])
+    return MISSING_FIELD_VALUE
+
+
 class _VcfSource(filebasedsource.FileBasedSource):
   """A source for reading VCF files.
 
@@ -328,6 +446,7 @@ class ReadAllFromVcf(PTransform):
     return pvalue | 'ReadAllFiles' >> self._read_all_files
 
 
+
 class WriteToVcf(PTransform):
   """A PTransform for writing to VCF files."""
 
@@ -370,3 +489,22 @@ class WriteToVcf(PTransform):
         coder=_ToVcfRecordCoder(),
         compression_type=self._compression_type,
         header=self._header)
+
+
+class _WriteVcfDataLinesFn(beam.DoFn):
+  """A function that writes variants to one VCF file."""
+
+  def process(self, file_path_and_variants, *args, **kwargs):
+    # type: (tuple[str, list]) -> None
+    file_path, variants = file_path_and_variants
+    coder = _ToVcfRecordCoder()
+    with filesystems.FileSystems.create(file_path) as file_to_write:
+      for variant in variants:
+        file_to_write.write(coder.encode(variant))
+
+
+class WriteVcfDataLines(PTransform):
+  """A PTransform for writing VCF data lines."""
+
+  def expand(self, pcoll):
+    return pcoll | 'WriteToVCF' >> beam.ParDo(_WriteVcfDataLinesFn())

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -21,8 +21,13 @@ from __future__ import absolute_import
 
 from functools import partial
 
+import vcf
+
+import apache_beam as beam
+
 from apache_beam.coders import coders
 from apache_beam.io import filebasedsource
+from apache_beam.io import filesystems
 from apache_beam.io import range_trackers  # pylint: disable=unused-import
 from apache_beam.io import textio
 from apache_beam.io.filesystem import CompressionTypes

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -16,12 +16,14 @@ r"""Pipeline for downloading BigQuery table to one VCF file. [EXPERIMENTAL]
 
 Run locally:
 python -m gcp_variant_transforms.bq_to_vcf \
-  --output_file <path to VCF file> \
+  --output_file <path to VCF file (blob name)> \
+  --bucket_name <bucket name in Google Cloud Storage> \
   --input_table projectname:bigquerydataset.tablename
 
 Run on Dataflow:
 python -m gcp_variant_transforms.bq_to_vcf \
-  --output_file <path to VCF file> \
+  --output_file <path to VCF file (blob name)> \
+  --bucket_name <bucket name in Google Cloud Storage> \
   --input_table projectname:bigquerydataset.tablename \
   --project projectname \
   --staging_location gs://bucket/staging \
@@ -32,12 +34,16 @@ python -m gcp_variant_transforms.bq_to_vcf \
 """
 
 import logging
+import os
 import sys
+from datetime import datetime
 from typing import List  # pylint: disable=unused-import
 
 import apache_beam as beam
 from apache_beam.io.gcp import bigquery
 from apache_beam.options import pipeline_options
+
+from google.cloud import storage
 
 from gcp_variant_transforms import vcf_to_bq_common
 from gcp_variant_transforms.beam_io import vcfio
@@ -48,6 +54,9 @@ from gcp_variant_transforms.transforms import densify_variants
 
 _BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`;'
 _COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
+# The maximum number of variants to include in a single VCF file.
+_NUMBER_OF_VARIANTS_PER_SHARD = 1000
+_MAX_NUM_OF_BLOBS_PER_COMPOSE = 32
 
 
 def run(argv=None):
@@ -56,19 +65,78 @@ def run(argv=None):
   logging.info('Command: %s', ' '.join(argv or sys.argv))
   known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
                                                           _COMMAND_LINE_OPTIONS)
+  (project, dataset, table) = bigquery_util.parse_table_reference(
+      known_args.input_table)
   bq_source = bigquery.BigQuerySource(
       query=_BASE_QUERY_TEMPLATE.format(
-          INPUT_TABLE='.'.join(bigquery_util.parse_table_reference(
-              known_args.input_table))),
+          INPUT_TABLE='.'.join([project, dataset, table])),
       validate=True,
       use_standard_sql=True)
 
   options = pipeline_options.PipelineOptions(pipeline_args)
+
+  blob_prefix = '_sharded_vcf_files_{}'.format(
+      datetime.now().strftime('%Y%m%d_%H%M%S'))
+  file_path_prefix = '/'.join(['gs:/', known_args.bucket_name, blob_prefix])
   with beam.Pipeline(options=options) as p:
     _ = (p | 'ReadFromBigQuery ' >> beam.io.Read(bq_source)
          | bigquery_to_variant.BigQueryToVariant()
          | densify_variants.DensifyVariants()
-         | vcfio.WriteToVcf(known_args.output_file))
+         | 'PairVariantWithKey' >> beam.Map(_pair_variant_with_key,
+                                            _NUMBER_OF_VARIANTS_PER_SHARD)
+         | 'GroupVariantsByKey' >> beam.GroupByKey()
+         | vcfio.WriteVcfDataLines(file_path_prefix))
+
+  client = storage.Client(project)
+  bucket = client.get_bucket(known_args.bucket_name)
+  composed_vcf_data_file = _compose_multiple_files_to_one(bucket, blob_prefix)
+  output_file_blob = bucket.blob(known_args.output_file)
+  output_file_blob.content_type = 'text/plain'
+  output_file_blob.rewrite(composed_vcf_data_file)
+  bucket.delete_blobs(bucket.list_blobs(prefix=blob_prefix))
+
+
+def _pair_variant_with_key(variant, number_of_variants_per_shard):
+  return ('_%s_%011d' % (variant.reference_name,
+                         variant.start / number_of_variants_per_shard *
+                         number_of_variants_per_shard),
+          variant)
+
+
+def _compose_multiple_files_to_one(bucket, blob_prefix):
+  # type: (storage.Bucket, str) -> storage.Bucket
+  """Composes multiple files in GCS to one.
+
+  Note that Cloud Storage allows to compose up to 32 objects. This method
+  composes the VCF files recursively until there is only one file.
+
+  Args:
+    bucket: the bucket in which the VCF files will be composed.
+    blob_prefix: the prefix used to filter blobs. Only the VCF files with this
+      prefix will be composed.
+
+  Returns:
+    The final blob that all VCFs composed to.
+  """
+  blobs_to_be_composed = list(bucket.list_blobs(prefix=blob_prefix))
+  if len(blobs_to_be_composed) == 1:
+    return blobs_to_be_composed[0]
+  new_blob_prefix = '_composed' + blob_prefix
+  for blobs_chunk in (_break_list_in_chunks(blobs_to_be_composed,
+                                            _MAX_NUM_OF_BLOBS_PER_COMPOSE)):
+    directory, file_name = os.path.split(blobs_chunk[0].name)
+    composed_file_name = directory + '_composed' + file_name
+    output_file_blob = bucket.blob(composed_file_name)
+    output_file_blob.content_type = 'text/plain'
+    output_file_blob.compose(blobs_chunk)
+  return _compose_multiple_files_to_one(bucket, new_blob_prefix)
+
+
+def _break_list_in_chunks(blob_list, chunk_size):
+  # type: (List, int) -> Iterable[List]
+  """Breaks blob_list into n-size chunks."""
+  for i in range(0, len(blob_list), chunk_size):
+    yield blob_list[i:i + chunk_size]
 
 
 if __name__ == '__main__':

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -144,7 +144,9 @@ def _get_file_path_and_sorted_variants((file_name, variants), file_path_prefix):
       pipeline. The files written will begin with this prefix, followed by the
       `file_name`.
   """
-  file_path = '/'.join([file_path_prefix, file_name])
+  # pylint: disable=redefined-outer-name,reimported
+  from apache_beam.io import filesystems
+  file_path = filesystems.FileSystems.join(file_path_prefix, file_name)
   yield (file_path, sorted(variants))
 
 

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -16,7 +16,7 @@ r"""Pipeline for loading BigQuery table to one VCF file. [EXPERIMENTAL]
 
 The pipeline reads the variants from BigQuery table, groups a collection of
 variants within a contiguous region of the genome (the size of the collection is
-adjustable through flag --number_of_bases_per_shard), sorts them, and then
+adjustable through flag `--number_of_bases_per_shard`), sorts them, and then
 writes to one VCF shard. At the end, it consolidates VCF shards into one.
 
 Run on Dataflow:
@@ -35,9 +35,10 @@ import logging
 import os
 import sys
 from datetime import datetime
-from typing import List  # pylint: disable=unused-import
+from typing import Iterable, List, Tuple  # pylint: disable=unused-import
 
 import apache_beam as beam
+from apache_beam.io import filesystems
 from apache_beam.io.gcp import bigquery
 from apache_beam.io.gcp import gcsio
 from apache_beam.options import pipeline_options
@@ -65,27 +66,27 @@ def run(argv=None):
   options = pipeline_options.PipelineOptions(pipeline_args)
   google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)
   # TODO(allieychen): Add support for local location.
-  if not google_cloud_options.temp_location:
-    raise ValueError('temp_location must be set.')
+  if not google_cloud_options.temp_location or not google_cloud_options.project:
+    raise ValueError('temp_location and project must be set.')
 
-  shards_folder = 'intermediate_files_{}/'.format(
+  shards_folder = 'bq_to_vcf_temp_files_{}'.format(
       datetime.now().strftime('%Y%m%d_%H%M%S'))
-  file_path_prefix = '/'.join([google_cloud_options.temp_location,
-                               shards_folder])
+  bq_to_vcf_temp_folder = filesystems.FileSystems.join(
+      google_cloud_options.temp_location, shards_folder)
 
-  _bigquery_to_shards(known_args, options, file_path_prefix)
-  _compose_intermediate_files(known_args,
-                              google_cloud_options.temp_location,
-                              shards_folder)
+  _bigquery_to_vcf_shards(known_args, options, bq_to_vcf_temp_folder)
+  _compose_temp_files(google_cloud_options.project,
+                      known_args.output_file,
+                      bq_to_vcf_temp_folder)
 
 
-def _bigquery_to_shards(known_args, options, file_path_prefix):
+def _bigquery_to_vcf_shards(known_args, options, bq_to_vcf_temp_folder):
   # type: (argparse.Namespace, pipeline_options.PipelineOptions, str) -> None
   """Runs BigQuery to VCF shards pipelines.
 
   It reads the variants from BigQuery table, groups a collection of variants
   within a contiguous region of the genome (the size of the collection is
-  adjustable through flag --number_of_bases_per_shard), sorts them, and then
+  adjustable through flag `--number_of_bases_per_shard`), sorts them, and then
   writes to one VCF shard.
 
   TODO(allieychen): Eventually, it also generates the meta information file and
@@ -105,30 +106,43 @@ def _bigquery_to_shards(known_args, options, file_path_prefix):
          | 'PairVariantWithKey' >>
          beam.Map(_pair_variant_with_key, known_args.number_of_bases_per_shard)
          | 'GroupVariantsByKey' >> beam.GroupByKey()
-         | beam.ParDo(vcfio.get_file_path_and_sorted_variants, file_path_prefix)
+         | beam.ParDo(_get_file_path_and_sorted_variants, bq_to_vcf_temp_folder)
          | vcfio.WriteVcfDataLines())
 
 
-def _compose_intermediate_files(known_args, temp_location, shards_folder):
-  # type: (argparse.Namespace, str, str) -> str
+def _compose_temp_files(project, output_file, bq_to_vcf_temp_folder):
+  # type: (str, str, str) -> None
   """Composes intermediate files to one VCF file.
 
   It composes VCF data shards to one VCF data file and deletes the intermediate
   VCF shards.
   TODO(allieychen): Eventually, it further consolidates the meta information,
   data header line, and the composed VCF data file into the `output_file`.
+  TODO(allieychen): Move the composing logic into a separate library.
   """
-  project, _, _ = bigquery_util.parse_table_reference(known_args.input_table)
-  bucket_name, object_name = gcsio.parse_gcs_path(temp_location)
-  blob_prefix = '/'.join([object_name, shards_folder])
+  bucket_name, blob_prefix = gcsio.parse_gcs_path(bq_to_vcf_temp_folder)
   client = storage.Client(project)
   bucket = client.get_bucket(bucket_name)
   composed_vcf_data_file = _compose_vcf_shards_to_one(bucket, blob_prefix)
-  _, file_object_name = gcsio.parse_gcs_path(known_args.output_file)
-  output_file_blob = bucket.blob(file_object_name)
-  output_file_blob.content_type = 'text/plain'
+  output_file_blob = _create_blob(client, output_file)
   output_file_blob.rewrite(composed_vcf_data_file)
   bucket.delete_blobs(bucket.list_blobs(prefix=blob_prefix))
+
+
+def _get_file_path_and_sorted_variants((file_name, variants), file_path_prefix):
+  # type: (Tuple[str, List], str) -> Iterable[Tuple[str, List]]
+  """Returns the file path and the sorted variants.
+
+  Args:
+    file_name: The file name that associated with the `variants`, which is used
+      to form the file path where the `variants` are written to.
+    variants: A collection of variants within a contiguous region of the genome.
+    file_path_prefix: The common file prefix for all VCF files generated in the
+      pipeline. The files written will begin with this prefix, followed by the
+      `file_name`.
+  """
+  file_path = '/'.join([file_path_prefix, file_name])
+  yield (file_path, sorted(variants))
 
 
 def _pair_variant_with_key(variant, number_of_variants_per_shard):
@@ -139,7 +153,7 @@ def _pair_variant_with_key(variant, number_of_variants_per_shard):
 
 
 def _compose_vcf_shards_to_one(bucket, blob_prefix):
-  # type: (storage.Bucket, str) -> storage.Bucket
+  # type: (storage.Bucket, str) -> storage.Blob
   """Composes multiple VCF shards in GCS to one.
 
   Note that Cloud Storage allows to compose up to 32 objects. This method
@@ -156,11 +170,11 @@ def _compose_vcf_shards_to_one(bucket, blob_prefix):
   blobs_to_be_composed = list(bucket.list_blobs(prefix=blob_prefix))
   if len(blobs_to_be_composed) == 1:
     return blobs_to_be_composed[0]
-  new_blob_prefix = blob_prefix + 'composed_'
+  new_blob_prefix = filesystems.FileSystems.join(blob_prefix, 'composed_')
   for blobs_chunk in (_break_list_in_chunks(blobs_to_be_composed,
                                             _MAX_NUM_OF_BLOBS_PER_COMPOSE)):
-    directory, file_name = os.path.split(blobs_chunk[0].name)
-    composed_file_name = '/'.join([directory, 'composed_' + file_name])
+    _, file_name = os.path.split(blobs_chunk[0].name)
+    composed_file_name = ''.join([new_blob_prefix + file_name])
     output_file_blob = bucket.blob(composed_file_name)
     output_file_blob.content_type = 'text/plain'
     output_file_blob.compose(blobs_chunk)
@@ -172,6 +186,14 @@ def _break_list_in_chunks(blob_list, chunk_size):
   """Breaks blob_list into n-size chunks."""
   for i in range(0, len(blob_list), chunk_size):
     yield blob_list[i:i + chunk_size]
+
+
+def _create_blob(client, file_path):
+  # type: (storage.Client, str) -> storage.Blob
+  bucket_name, blob_name = gcsio.parse_gcs_path(file_path)
+  file_blob = client.get_bucket(bucket_name).blob(blob_name)
+  file_blob.content_type = 'text/plain'
+  return file_blob
 
 
 if __name__ == '__main__':

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -12,18 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-r"""Pipeline for downloading BigQuery table to one VCF file. [EXPERIMENTAL]
+r"""Pipeline for loading BigQuery table to one VCF file. [EXPERIMENTAL]
 
-Run locally:
-python -m gcp_variant_transforms.bq_to_vcf \
-  --output_file <path to VCF file (blob name)> \
-  --bucket_name <bucket name in Google Cloud Storage> \
-  --input_table projectname:bigquerydataset.tablename
+The pipeline reads the variants from BigQuery table, groups a collection of
+variants within a contiguous region of the genome (the size of the collection is
+adjustable through flag --number_of_bases_per_shard), sorts them, and then
+writes to one VCF shard. At the end, it consolidates VCF shards into one.
 
 Run on Dataflow:
 python -m gcp_variant_transforms.bq_to_vcf \
-  --output_file <path to VCF file (blob name)> \
-  --bucket_name <bucket name in Google Cloud Storage> \
+  --output_file <path to VCF file> \
   --input_table projectname:bigquerydataset.tablename \
   --project projectname \
   --staging_location gs://bucket/staging \
@@ -41,6 +39,7 @@ from typing import List  # pylint: disable=unused-import
 
 import apache_beam as beam
 from apache_beam.io.gcp import bigquery
+from apache_beam.io.gcp import gcsio
 from apache_beam.options import pipeline_options
 
 from google.cloud import storage
@@ -54,8 +53,6 @@ from gcp_variant_transforms.transforms import densify_variants
 
 _BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`;'
 _COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
-# The maximum number of variants to include in a single VCF file.
-_NUMBER_OF_VARIANTS_PER_SHARD = 1000
 _MAX_NUM_OF_BLOBS_PER_COMPOSE = 32
 
 
@@ -65,47 +62,85 @@ def run(argv=None):
   logging.info('Command: %s', ' '.join(argv or sys.argv))
   known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
                                                           _COMMAND_LINE_OPTIONS)
-  (project, dataset, table) = bigquery_util.parse_table_reference(
-      known_args.input_table)
+  options = pipeline_options.PipelineOptions(pipeline_args)
+  google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)
+  # TODO(allieychen): Add support for local location.
+  if not google_cloud_options.temp_location:
+    raise ValueError('temp_location must be set.')
+
+  shards_folder = 'intermediate_files_{}/'.format(
+      datetime.now().strftime('%Y%m%d_%H%M%S'))
+  file_path_prefix = '/'.join([google_cloud_options.temp_location,
+                               shards_folder])
+
+  _bigquery_to_shards(known_args, options, file_path_prefix)
+  _compose_intermediate_files(known_args,
+                              google_cloud_options.temp_location,
+                              shards_folder)
+
+
+def _bigquery_to_shards(known_args, options, file_path_prefix):
+  # type: (argparse.Namespace, pipeline_options.PipelineOptions, str) -> None
+  """Runs BigQuery to VCF shards pipelines.
+
+  It reads the variants from BigQuery table, groups a collection of variants
+  within a contiguous region of the genome (the size of the collection is
+  adjustable through flag --number_of_bases_per_shard), sorts them, and then
+  writes to one VCF shard.
+
+  TODO(allieychen): Eventually, it also generates the meta information file and
+  data header file.
+  """
   bq_source = bigquery.BigQuerySource(
       query=_BASE_QUERY_TEMPLATE.format(
-          INPUT_TABLE='.'.join([project, dataset, table])),
+          INPUT_TABLE='.'.join(bigquery_util.parse_table_reference(
+              known_args.input_table))),
       validate=True,
       use_standard_sql=True)
 
-  options = pipeline_options.PipelineOptions(pipeline_args)
-
-  blob_prefix = '_sharded_vcf_files_{}'.format(
-      datetime.now().strftime('%Y%m%d_%H%M%S'))
-  file_path_prefix = '/'.join(['gs:/', known_args.bucket_name, blob_prefix])
   with beam.Pipeline(options=options) as p:
     _ = (p | 'ReadFromBigQuery ' >> beam.io.Read(bq_source)
          | bigquery_to_variant.BigQueryToVariant()
          | densify_variants.DensifyVariants()
-         | 'PairVariantWithKey' >> beam.Map(_pair_variant_with_key,
-                                            _NUMBER_OF_VARIANTS_PER_SHARD)
+         | 'PairVariantWithKey' >>
+         beam.Map(_pair_variant_with_key, known_args.number_of_bases_per_shard)
          | 'GroupVariantsByKey' >> beam.GroupByKey()
-         | vcfio.WriteVcfDataLines(file_path_prefix))
+         | beam.ParDo(vcfio.get_file_path_and_sorted_variants, file_path_prefix)
+         | vcfio.WriteVcfDataLines())
 
+
+def _compose_intermediate_files(known_args, temp_location, shards_folder):
+  # type: (argparse.Namespace, str, str) -> str
+  """Composes intermediate files to one VCF file.
+
+  It composes VCF data shards to one VCF data file and deletes the intermediate
+  VCF shards.
+  TODO(allieychen): Eventually, it further consolidates the meta information,
+  data header line, and the composed VCF data file into the `output_file`.
+  """
+  project, _, _ = bigquery_util.parse_table_reference(known_args.input_table)
+  bucket_name, object_name = gcsio.parse_gcs_path(temp_location)
+  blob_prefix = '/'.join([object_name, shards_folder])
   client = storage.Client(project)
-  bucket = client.get_bucket(known_args.bucket_name)
-  composed_vcf_data_file = _compose_multiple_files_to_one(bucket, blob_prefix)
-  output_file_blob = bucket.blob(known_args.output_file)
+  bucket = client.get_bucket(bucket_name)
+  composed_vcf_data_file = _compose_vcf_shards_to_one(bucket, blob_prefix)
+  _, file_object_name = gcsio.parse_gcs_path(known_args.output_file)
+  output_file_blob = bucket.blob(file_object_name)
   output_file_blob.content_type = 'text/plain'
   output_file_blob.rewrite(composed_vcf_data_file)
   bucket.delete_blobs(bucket.list_blobs(prefix=blob_prefix))
 
 
 def _pair_variant_with_key(variant, number_of_variants_per_shard):
-  return ('_%s_%011d' % (variant.reference_name,
-                         variant.start / number_of_variants_per_shard *
-                         number_of_variants_per_shard),
+  return ('%s_%011d' % (variant.reference_name,
+                        variant.start / number_of_variants_per_shard *
+                        number_of_variants_per_shard),
           variant)
 
 
-def _compose_multiple_files_to_one(bucket, blob_prefix):
+def _compose_vcf_shards_to_one(bucket, blob_prefix):
   # type: (storage.Bucket, str) -> storage.Bucket
-  """Composes multiple files in GCS to one.
+  """Composes multiple VCF shards in GCS to one.
 
   Note that Cloud Storage allows to compose up to 32 objects. This method
   composes the VCF files recursively until there is only one file.
@@ -121,15 +156,15 @@ def _compose_multiple_files_to_one(bucket, blob_prefix):
   blobs_to_be_composed = list(bucket.list_blobs(prefix=blob_prefix))
   if len(blobs_to_be_composed) == 1:
     return blobs_to_be_composed[0]
-  new_blob_prefix = '_composed' + blob_prefix
+  new_blob_prefix = blob_prefix + 'composed_'
   for blobs_chunk in (_break_list_in_chunks(blobs_to_be_composed,
                                             _MAX_NUM_OF_BLOBS_PER_COMPOSE)):
     directory, file_name = os.path.split(blobs_chunk[0].name)
-    composed_file_name = directory + '_composed' + file_name
+    composed_file_name = '/'.join([directory, 'composed_' + file_name])
     output_file_blob = bucket.blob(composed_file_name)
     output_file_blob.content_type = 'text/plain'
     output_file_blob.compose(blobs_chunk)
-  return _compose_multiple_files_to_one(bucket, new_blob_prefix)
+  return _compose_vcf_shards_to_one(bucket, new_blob_prefix)
 
 
 def _break_list_in_chunks(blob_list, chunk_size):

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -438,13 +438,17 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
     parser.add_argument(
         '--output_file',
         required=True,
-        help='The path of the VCF file to store the result inside the bucket.')
+        help='The full path of the VCF file to store the result.')
     parser.add_argument(
         '--input_table',
         required=True,
         help=('BigQuery table that will be loaded to VCF. It must be in the '
               'format of (PROJECT:DATASET.TABLE).'))
     parser.add_argument(
-        '--bucket_name',
-        required=True,
-        help='The bucket name where the VCF file will be stored in GCS.')
+        '--number_of_bases_per_shard',
+        type=int, default=10000,
+        help=('The maximum number of base pairs per chromosome to include in a '
+              'single VCF file (one shard). A shard is a collection of data '
+              'within a contiguous region of the genome. This parameter will '
+              'have an impact on memory requirements since the data in a '
+              'single shard must be sorted.'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -438,9 +438,13 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
     parser.add_argument(
         '--output_file',
         required=True,
-        help='The full path of the VCF file to store the result.')
+        help='The path of the VCF file to store the result inside the bucket.')
     parser.add_argument(
         '--input_table',
         required=True,
         help=('BigQuery table that will be loaded to VCF. It must be in the '
               'format of (PROJECT:DATASET.TABLE).'))
+    parser.add_argument(
+        '--bucket_name',
+        required=True,
+        help='The bucket name where the VCF file will be stored in GCS.')


### PR DESCRIPTION
1. replaced the textio.WriteToText with file_system.
2. Generates a separate file for variants with the same key in `bucket_name`.
3. Combine the files to the `output_file` provided at the end.

Issue: [issue 85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests & manual pipeline test