### PR TITLE
Add warning

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import
 
 import argparse  # pylint: disable=unused-import
+import logging
 import re
 
 from apache_beam.io.gcp.internal.clients import bigquery
@@ -90,6 +91,14 @@ class VcfReadOptions(VariantTransformsOptions):
               'variants. This is useful when there are header fields in '
               'variants not defined in the header sections, or the definition '
               'of the the header fields do not match the field values.'))
+
+  def validate(self, parsed_args):
+    # type: (argparse.Namespace) -> None
+    if parsed_args.infer_headers and parsed_args.representative_header_file:
+      logging.warning('Both --infer_headers and --representative_header_file '
+                      'are passed! In this case, --infer_headers will be '
+                      'ignored and the header values from the '
+                      'representative_header_file will be used.')
 
 
 class BigQueryWriteOptions(VariantTransformsOptions):


### PR DESCRIPTION
Add warnings when both infer_headers and representative_header_file are used.

Issues: [issue 305](https://github.com/googlegenomics/gcp-variant-transforms/issues/305)
Tested: unit tests