### PR TITLE
Make setup_file flag required.

### DIFF
--- a/gcp_variant_transforms/vcf_to_bq_common_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_common_test.py
@@ -25,7 +25,7 @@ from gcp_variant_transforms.vcf_to_bq_common import PipelineModes
 
 
 class VcfToBqCommonTest(unittest.TestCase):
-  """Tests cases for the ``general_process`` script."""
+  """Tests cases for the ``vcf_to_bq_common`` script."""
 
   def _create_mock_args(self, **args):
     return collections.namedtuple('MockArgs', args.keys())(*args.values())

--- a/gcp_variant_transforms/vcf_to_bq_common_test.py
+++ b/gcp_variant_transforms/vcf_to_bq_common_test.py
@@ -24,7 +24,7 @@ from gcp_variant_transforms import vcf_to_bq_common
 from gcp_variant_transforms.vcf_to_bq_common import PipelineModes
 
 
-class DataProcessorTest(unittest.TestCase):
+class VcfToBqCommonTest(unittest.TestCase):
   """Tests cases for the ``general_process`` script."""
 
   def _create_mock_args(self, **args):
@@ -88,20 +88,24 @@ class DataProcessorTest(unittest.TestCase):
       self.assertEqual(vcf_to_bq_common.get_pipeline_mode(args.input_pattern),
                        PipelineModes.MEDIUM)
 
-  def test_fail_on_unrecognized_flags(self):
-    pipeline_args = ['--project',
-                     'gcp-variant-transforms-test',
-                     '--staging_location',
-                     'gs://integration_test_runs/staging',
-                     '--unknown_flag',
-                     'some value']
-    with self.assertRaises(ValueError):
-      vcf_to_bq_common._raise_error_on_unrecognized_flags(pipeline_args)
-
-  def test_fail_on_unrecognized_flags_no_failure(self):
+  def test_fail_on_invalid_flags(self):
+    # Start with valid flags, without setup.py.
     pipeline_args = ['--project',
                      'gcp-variant-transforms-test',
                      '--staging_location',
                      'gs://integration_test_runs/staging']
+    vcf_to_bq_common._raise_error_on_invalid_flags(pipeline_args)
 
-    vcf_to_bq_common._raise_error_on_unrecognized_flags(pipeline_args)
+    # Add Dataflow runner (requires --setup_file).
+    pipeline_args.extend(['--runner', 'DataflowRunner'])
+    with self.assertRaisesRegexp(ValueError, 'setup_file'):
+      vcf_to_bq_common._raise_error_on_invalid_flags(pipeline_args)
+
+    # Add setup.py (required for Variant Transforms run). This is now valid.
+    pipeline_args.extend(['--setup_file', 'setup.py'])
+    vcf_to_bq_common._raise_error_on_invalid_flags(pipeline_args)
+
+    # Add an unknown flag.
+    pipeline_args.extend(['--unknown_flag', 'somevalue'])
+    with self.assertRaisesRegexp(ValueError, 'Unrecognized.*unknown_flag'):
+      vcf_to_bq_common._raise_error_on_invalid_flags(pipeline_args)


### PR DESCRIPTION
setup_file is required when running w/ Dataflow for Variant Transforms. If it's not provided, no error is actually thrown and the pipeline just hangs; very difficult to debug and identify the problem.