### PR TITLE
change the null numeric value replacement #221

### DIFF
--- a/docs/bigquery_schema.md
+++ b/docs/bigquery_schema.md
@@ -31,8 +31,7 @@ In addition, the schema from Variant Transforms has the following properties:
   but values within the record must each have a value). For instance, if a
   VCF INFO field is `1,.,2`, we cannot load `1,null,2` to BigQuery and need to
   use a numeric replacement for the null value. The replacement value is
-  currently set to `-sys.maxint` (equal to `-9223372036854775807` on
-  64-bit machines).
+  currently set to `-2^31` (equal to `-2147483648`).
   [Issue #68](https://github.com/googlegenomics/gcp-variant-transforms/issues/68)
   tracks the feature to make this value configurable. The alternative is to
   convert such values to a string and use `.` to represent the null value.

--- a/gcp_variant_transforms/libs/bigquery_row_generator.py
+++ b/gcp_variant_transforms/libs/bigquery_row_generator.py
@@ -162,9 +162,9 @@ class BigQueryRowGenerator(object):
       alt_record = {bigquery_util.ColumnKeyConstants.ALTERNATE_BASES_ALT:
                     alt.alternate_bases}
       for key, data in alt.info.iteritems():
-        if key not in alt.annotation_field_names:
-          alt_record[bigquery_util.get_bigquery_sanitized_field_name(key)] = (
-              bigquery_util.get_bigquery_sanitized_field(data))
+        alt_record[bigquery_util.get_bigquery_sanitized_field_name(key)] = (
+            data if key in alt.annotation_field_names else
+            bigquery_util.get_bigquery_sanitized_field(data))
       row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES].append(alt_record)
     # Add info.
     for key, data in variant.non_alt_info.iteritems():

--- a/gcp_variant_transforms/libs/bigquery_row_generator_test.py
+++ b/gcp_variant_transforms/libs/bigquery_row_generator_test.py
@@ -17,7 +17,6 @@
 from __future__ import absolute_import
 
 import json
-import sys
 import unittest
 import mock
 
@@ -282,9 +281,10 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         ColumnKeyConstants.ALTERNATE_BASES: [],
         ColumnKeyConstants.FILTER: ['q10'],
         ColumnKeyConstants.CALLS: [],
-        'IIR': [0, 1, -sys.maxint],
+        'IIR': [0, 1, bigquery_util._DEFAULT_NULL_NUMERIC_VALUE_REPLACEMENT],
         'IBR': [True, False, False],
-        'IFR': [0.1, 0.2, -sys.maxint, 0.4],
+        'IFR': [0.1, 0.2, bigquery_util._DEFAULT_NULL_NUMERIC_VALUE_REPLACEMENT,
+                0.4],
         'ISR': ['.', 'data1', 'data2']}
     self.assertEqual([expected_row],
                      self._get_row_list_from_variant(variant, header_num_dict))
@@ -323,7 +323,6 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
               'IF3': [float('-inf'), float('nan'), float('inf'), 1.2]},
     )
     header_num_dict = {'IF': '1', 'IFR': '3', 'IF2': '1', 'IF3': 'A'}
-    null_replacement_value = -sys.maxint
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -344,7 +343,9 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
             }
         ],
         'IF': bigquery_util._INF_FLOAT_VALUE,
-        'IFR': [-bigquery_util._INF_FLOAT_VALUE, null_replacement_value, 1.2],
+        'IFR': [-bigquery_util._INF_FLOAT_VALUE,
+                bigquery_util._DEFAULT_NULL_NUMERIC_VALUE_REPLACEMENT,
+                1.2],
         'IF2': None
     }
     self.assertEqual([expected_row],

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -75,6 +75,7 @@ _FALLBACK_FIELD_NAME_PREFIX = 'field_'
 # A big number to represent infinite float values. The division by 10 is to
 # prevent unintentional overflows when doing subsequent operations.
 _INF_FLOAT_VALUE = sys.float_info.max / 10
+_DEFAULT_NULL_NUMERIC_VALUE_REPLACEMENT = -pow(2, 32)
 
 
 def parse_table_reference(input_table):
@@ -142,7 +143,9 @@ def get_python_type_from_bigquery_type(bigquery_type):
 
 
 def get_bigquery_sanitized_field(
-    field, null_numeric_value_replacement=-sys.maxint):
+    field,
+    null_numeric_value_replacement=_DEFAULT_NULL_NUMERIC_VALUE_REPLACEMENT
+    ):
   # type: (Any, int) ->  Any
   """Returns sanitized field according to BigQuery restrictions.
 

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -75,7 +75,7 @@ _FALLBACK_FIELD_NAME_PREFIX = 'field_'
 # A big number to represent infinite float values. The division by 10 is to
 # prevent unintentional overflows when doing subsequent operations.
 _INF_FLOAT_VALUE = sys.float_info.max / 10
-_DEFAULT_NULL_NUMERIC_VALUE_REPLACEMENT = -pow(2, 32)
+_DEFAULT_NULL_NUMERIC_VALUE_REPLACEMENT = -2 ^ 31
 
 
 def parse_table_reference(input_table):


### PR DESCRIPTION
Update the default `null_numeric_value_replacement` value. 

The pipeline fails when a float value is `nan`. The reason is that the default `null_numeric_value_replacement`value (-sys.maxint) is too large to convert to a float. The converted value and the original value are incompatible.

Issues: [221](https://github.com/googlegenomics/gcp-variant-transforms/issues/221)
Tested: unit tests and manually ran `vcf_to_bq` pipeline. 