### PR TITLE
add data header in BQ to VCF pipeline #85

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -121,14 +121,11 @@ class _ToVcfRecordCoder(coders.Coder):
 
   def _encode_variant_calls(self, variant, format_keys):
     # type: (Variant, List[str]) -> str
-    """Encodes the calls of `Variant` in a VCF line.
-
-    The calls are encoded following the calls' natural order.
-    """
+    """Encodes the calls of `Variant` in a VCF line."""
     # Ensure that genotype is always the first key in format_keys
     assert not format_keys or format_keys[0] == GENOTYPE_FORMAT_KEY
     encoded_calls = []
-    for call in sorted(variant.calls):
+    for call in variant.calls:
       encoded_call_info = [self._encode_genotype(call.genotype, call.phaseset)]
       for key in format_keys[1:]:
         if key == PHASESET_FORMAT_KEY:
@@ -395,23 +392,3 @@ class WriteVcfDataLines(PTransform):
   """
   def expand(self, pcoll):
     return pcoll | 'WriteToVCF' >> beam.ParDo(_WriteVcfDataLinesFn())
-
-
-def write_vcf_data_header(sample_names, vcf_fixed_columns, file_path):
-  # type: (List[str], List[str], str) -> None
-  """Writes VCF data header.
-
-  It writes the header line with ` vcf_fixed_columns`, followed by sample
-  names in `sample_names` in sorted order. Example:
-  #CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  SAMPLE1  SAMPLE2
-
-  Args:
-    sample_names: The sample names appended to `vcf_fixed_columns`. The names
-      will be sorted in increasing order.
-    vcf_fixed_columns: The VCF fixed columns.
-    file_path: The location where the data header line is saved.
-  """
-  with filesystems.FileSystems.create(file_path) as file_to_write:
-    file_to_write.write(
-        str('\t'.join(vcf_fixed_columns + sorted(sample_names))))
-    file_to_write.write('\n')

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -26,6 +26,7 @@ from itertools import chain
 from itertools import permutations
 
 import apache_beam as beam
+from apache_beam.io import filesystems
 from apache_beam.io.filesystem import CompressionTypes
 import apache_beam.io.source_test_utils as source_test_utils
 from apache_beam.testing.test_pipeline import TestPipeline
@@ -38,6 +39,7 @@ from gcp_variant_transforms.beam_io.vcfio import ReadAllFromVcf
 from gcp_variant_transforms.beam_io.vcfio import ReadFromVcf
 from gcp_variant_transforms.beam_io.vcfio import Variant
 from gcp_variant_transforms.beam_io.vcfio import VariantCall
+from gcp_variant_transforms.testing import temp_dir
 from gcp_variant_transforms.testing import testdata_util
 from gcp_variant_transforms.testing.temp_dir import TempDir
 
@@ -836,6 +838,14 @@ class VcfSinkTest(unittest.TestCase):
     expected = '.	.	.	.	.	.	.	.	GT	.\n'
     self._assert_variant_lines_equal(coder.encode(variant), expected)
 
+  def test_encode_variant_calls_not_sorted(self):
+    coder = self._get_coder()
+    variant = Variant()
+    variant.calls.append(VariantCall(name='Sample2', genotype=[1, 0, 1]))
+    variant.calls.append(VariantCall(name='Sample1', genotype=-1))
+    expected = '.	1/0/1'
+    self.assertEqual(coder._encode_variant_calls(variant, []), expected)
+
   def test_missing_genotype(self):
     coder = self._get_coder()
     variant = Variant()
@@ -902,6 +912,18 @@ class VcfSinkTest(unittest.TestCase):
     self.assertEqual(read_result[0], 'foo')
     for actual, expected in zip(read_result[1:], self.variant_lines):
       self._assert_variant_lines_equal(actual, expected)
+
+  def test_write_vcf_data_header(self):
+    with temp_dir.TempDir() as tempdir:
+      file_path = filesystems.FileSystems.join(tempdir.get_path(),
+                                               'data_header')
+      vcfio.write_vcf_data_header(['Sample 1', 'Sample 2'],
+                                  ['#CHROM', 'POS', 'ID', 'REF', 'ALT'],
+                                  file_path)
+      expected_content = '#CHROM\tPOS\tID\tREF\tALT\tSample 1\tSample 2\n'
+      with filesystems.FileSystems.open(file_path) as f:
+        content = f.readlines()
+        self.assertEqual(content, [expected_content])
 
 
 if __name__ == '__main__':

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -47,8 +47,9 @@ from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs import vcf_file_composer
 from gcp_variant_transforms.options import variant_transform_options
 from gcp_variant_transforms.transforms import bigquery_to_variant
-from gcp_variant_transforms.transforms import densify_variants
 from gcp_variant_transforms.transforms import combine_call_names
+from gcp_variant_transforms.transforms import densify_variants
+
 
 _BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`;'
 _COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
@@ -68,13 +69,13 @@ def run(argv=None):
   if not google_cloud_options.temp_location or not google_cloud_options.project:
     raise ValueError('temp_location and project must be set.')
 
-  time_stamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+  timestamp_str = datetime.now().strftime('%Y%m%d_%H%M%S')
   vcf_data_temp_folder = filesystems.FileSystems.join(
       google_cloud_options.temp_location,
-      'bq_to_vcf_data_temp_files_{}'.format(time_stamp))
+      'bq_to_vcf_data_temp_files_{}'.format(timestamp_str))
   vcf_data_header_file_path = filesystems.FileSystems.join(
       google_cloud_options.temp_location,
-      'bq_to_vcf_data_header_{}'.format(time_stamp))
+      'bq_to_vcf_data_header_{}'.format(timestamp_str))
 
   _bigquery_to_vcf_shards(known_args,
                           options,
@@ -119,12 +120,12 @@ def _bigquery_to_vcf_shards(
                 | 'ReadFromBigQuery ' >> beam.io.Read(bq_source)
                 | bigquery_to_variant.BigQueryToVariant())
     call_names = (variants
-                  | 'CombineAndSortAllCallNames' >>
+                  | 'CombineCallNames' >>
                   combine_call_names.CallNamesCombiner())
 
     _ = (call_names
-         | 'GenerateVCFDataHeader' >>
-         beam.ParDo(vcfio.write_vcf_data_header,
+         | 'GenerateVcfDataHeader' >>
+         beam.ParDo(_write_vcf_data_header,
                     _VCF_FIXED_COLUMNS,
                     vcf_data_header_file_path))
 
@@ -135,6 +136,27 @@ def _bigquery_to_vcf_shards(
          | 'GroupVariantsByKey' >> beam.GroupByKey()
          | beam.ParDo(_get_file_path_and_sorted_variants, vcf_data_temp_folder)
          | vcfio.WriteVcfDataLines())
+
+
+def _write_vcf_data_header(sample_names, vcf_fixed_columns, file_path):
+  # type: (List[str], List[str], str) -> None
+  """Writes VCF data header.
+
+  It writes the header line with ` vcf_fixed_columns`, followed by sample
+  names in `sample_names`. Example:
+  #CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  SAMPLE1  SAMPLE2
+
+  Args:
+    sample_names: The sample names appended to `vcf_fixed_columns`.
+    vcf_fixed_columns: The VCF fixed columns.
+    file_path: The location where the data header line is saved.
+  """
+  # pylint: disable=redefined-outer-name,reimported
+  from apache_beam.io import filesystems
+  with filesystems.FileSystems.create(file_path) as file_to_write:
+    file_to_write.write(
+        str('\t'.join(vcf_fixed_columns + sample_names)))
+    file_to_write.write('\n')
 
 
 def _get_file_path_and_sorted_variants((file_name, variants), file_path_prefix):

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `bq_to_vcf` module."""
+
+import unittest
+
+from apache_beam.io import filesystems
+
+from gcp_variant_transforms import bq_to_vcf
+from gcp_variant_transforms.testing import temp_dir
+
+
+class BqToVcfTest(unittest.TestCase):
+  """Test cases for the `bq_to_vcf` module."""
+
+  def test_write_vcf_data_header(self):
+    with temp_dir.TempDir() as tempdir:
+      file_path = filesystems.FileSystems.join(tempdir.get_path(),
+                                               'data_header')
+      bq_to_vcf._write_vcf_data_header(['Sample 1', 'Sample 2'],
+                                       ['#CHROM', 'POS', 'ID', 'REF', 'ALT'],
+                                       file_path)
+      expected_content = '#CHROM\tPOS\tID\tREF\tALT\tSample 1\tSample 2\n'
+      with filesystems.FileSystems.open(file_path) as f:
+        content = f.readlines()
+        self.assertEqual(content, [expected_content])

--- a/gcp_variant_transforms/transforms/combine_call_names.py
+++ b/gcp_variant_transforms/transforms/combine_call_names.py
@@ -1,0 +1,36 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A PTransform to combine call names from all variants."""
+
+from typing import List  # pylint: disable=unused-import
+
+import apache_beam as beam
+
+from gcp_variant_transforms.beam_io import vcf_parser  # pylint: disable=unused-import
+
+
+class CallNamesCombiner(beam.PTransform):
+  """A PTransform to combine call names from all variants."""
+
+  def _get_call_names(self, variant):
+    # type: (vcf_parser.Variant) -> List[str]
+    """Returns the names of all calls for the variant."""
+    return [call.name for call in variant.calls]
+
+  def expand(self, pcoll):
+    return (pcoll
+            | 'GetCallNames' >> beam.FlatMap(self._get_call_names)
+            | 'RemoveDuplicates' >> beam.RemoveDuplicates()
+            | 'Combine' >> beam.combiners.ToList())

--- a/gcp_variant_transforms/transforms/densify_variants.py
+++ b/gcp_variant_transforms/transforms/densify_variants.py
@@ -25,28 +25,28 @@ __all__ = ['DensifyVariants']
 
 
 class DensifyVariants(beam.PTransform):
-  """Extends each Variant's calls to contain data for all samples."""
+  """Densifys each Variant's calls to contain data for `all_call_names`."""
 
   def __init__(self, all_call_names):
     # type: (List[str]) -> None
     """Initializes a `DensifyVariants` object.
 
     Args:
-      all_call_names: A list of sample names that used to extend each
+      all_call_names: A list of sample names that used to select/extend each
         variant'calls.
     """
     self._all_call_names = all_call_names
 
   def _densify_variants(self, variant, all_call_names):
     # type: (vcf_parser.Variant, List[str]) -> vcf_parser.Variant
-    """Adds all missing calls to the variant.
+    """Cherry-picks calls for the variant.
 
     The calls are in the same order as the `all_call_names`.
     Args:
       variant: The variant that will be modified to contain calls for
         `all_call_names`.
-      all_call_names: A list of sample names that used to extend each
-        variant'calls.
+      all_call_names: A list of sample names that used to cherry-pick each
+        variant'calls. If one call is missing, an empty `VariantCall` is added.
 
     Returns:
       `variant` modified to contain calls for `all_call_names`.
@@ -66,7 +66,7 @@ class DensifyVariants(beam.PTransform):
     return variant
 
   def expand(self, pcoll):
-    # Extend each variant's list of calls to contain all samples.
+    # Extend each variant's list of calls to contain `all_call_names`.
     return (pcoll
             | 'DensifyVariants' >> beam.Map(
                 self._densify_variants, all_call_names=self._all_call_names))

--- a/gcp_variant_transforms/transforms/densify_variants_test.py
+++ b/gcp_variant_transforms/transforms/densify_variants_test.py
@@ -30,13 +30,25 @@ from gcp_variant_transforms.transforms import densify_variants
 class DensifyVariantsTest(unittest.TestCase):
   """Test cases for the ``DensifyVariants`` transform."""
 
-  def test_add_missing_calls(self):
-    transform = densify_variants.DensifyVariants(None)
-    variant = vcfio.Variant(calls=[vcfio.VariantCall(name='sample2')])
-    new_variant = transform._densify_variants(
-        variant, ['sample1', 'sample2', 'sample3'])
-    call_names = [call.name for call in new_variant.calls]
-    self.assertItemsEqual(call_names, ['sample1', 'sample2', 'sample3'])
+  def test_densify_variants_pipeline_no_calls(self):
+    call_names = ['sample1', 'sample2', 'sample3']
+    variant_calls = [
+        vcfio.VariantCall(name=call_names[0]),
+        vcfio.VariantCall(name=call_names[1]),
+        vcfio.VariantCall(name=call_names[2]),
+    ]
+    variants = [
+        vcfio.Variant(calls=[variant_calls[0], variant_calls[1]]),
+        vcfio.Variant(calls=[variant_calls[1], variant_calls[2]]),
+    ]
+    pipeline = TestPipeline()
+    densified_variants = (
+        pipeline
+        | Create(variants)
+        | 'DensifyVariants' >> densify_variants.DensifyVariants([]))
+    assert_that(densified_variants, asserts.has_calls([]))
+
+    pipeline.run()
 
   def test_densify_variants_pipeline(self):
     call_names = ['sample1', 'sample2', 'sample3']

--- a/gcp_variant_transforms/transforms/densify_variants_test.py
+++ b/gcp_variant_transforms/transforms/densify_variants_test.py
@@ -31,11 +31,10 @@ class DensifyVariantsTest(unittest.TestCase):
   """Test cases for the ``DensifyVariants`` transform."""
 
   def test_densify_variants_pipeline_no_calls(self):
-    call_names = ['sample1', 'sample2', 'sample3']
     variant_calls = [
-        vcfio.VariantCall(name=call_names[0]),
-        vcfio.VariantCall(name=call_names[1]),
-        vcfio.VariantCall(name=call_names[2]),
+        vcfio.VariantCall(name='sample1'),
+        vcfio.VariantCall(name='sample2'),
+        vcfio.VariantCall(name='sample3'),
     ]
     variants = [
         vcfio.Variant(calls=[variant_calls[0], variant_calls[1]]),


### PR DESCRIPTION
- Add the VCF data header in the BQ to VCF pipeline.
- The call names in the header will be sorted.

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests & Manually run BQ to VCF.