### PR TITLE
Adding the second VcfParser class: NucleusParser

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -22,13 +22,14 @@ from __future__ import absolute_import
 import logging
 from collections import namedtuple
 
-from nucleus.io.python import vcf_reader as nucleus
-from nucleus.protos import variants_pb2 as nucleus_proto
 import os
 import tempfile
+
+from nucleus.io import vcf as nucleus
 import vcf
 
 from apache_beam.coders import coders
+from apache_beam.io.filesystems import FileSystems
 from apache_beam.io import textio
 
 
@@ -474,24 +475,41 @@ class NucleusParser(VcfParser):
   """An Iterator for processing a single VCF file using Nucleus."""
 
   def __init__(self,
-	       file_name,  # type: str
-	       range_tracker,  # type: range_trackers.OffsetRangeTracker
-	       file_pattern,  # type: str
-	       compression_type,  # type: str
-	       allow_malformed_records,  # type: bool
-	       representative_header_lines=None,  # type:  List[str]
-	       **kwargs  # type: **str
-	      ):
+               file_name,  # type: str
+               range_tracker,  # type: range_trackers.OffsetRangeTracker
+               file_pattern,  # type: str
+               compression_type,  # type: str
+               allow_malformed_records,  # type: bool
+               representative_header_lines=None,  # type:  List[str]
+               **kwargs  # type: **str
+              ):
     # type: (...) -> None
     super(NucleusParser, self).__init__(file_name,
-                                      range_tracker,
-                                      file_pattern,
-                                      compression_type,
-                                      allow_malformed_records,
-                                      representative_header_lines,
-                                      **kwargs)
+                                        range_tracker,
+                                        file_pattern,
+                                        compression_type,
+                                        allow_malformed_records,
+                                        representative_header_lines,
+                                        **kwargs)
     # This member will be properly initiated in _init_with_header().
     self._vcf_reader = None
+    # These members will be properly initiated in _extract_header_fields().
+    self._is_info_repeated = {}
+    self._is_format_repeated = {}
+    # This is a temporary solution until from_string will be fixed.
+    self._temp_local_file = self._write_to_local_file(file_name)
+
+  def _write_to_local_file(self, remote_file_name):
+    (temp_file, temp_file_name) = tempfile.mkstemp(text=True)
+    with FileSystems.open(remote_file_name) as f:
+      while True:
+        line = f.readline()
+        if line:
+          os.write(temp_file, line)
+        else:
+          os.close(temp_file)
+          break
+    return temp_file_name
 
   def _store_to_temp_local_file(self, header_lines):
     (temp_file, temp_file_name) = tempfile.mkstemp(text=True)
@@ -501,39 +519,129 @@ class NucleusParser(VcfParser):
     return temp_file_name
 
   def _init_with_header(self, header_lines):
-    # This optional header line is needed by Nucleus.
+    # This header line is needed by Nucleus.
     header_lines = ['##fileformat=VCFv4.2'] + header_lines
     try:
-      self._vcf_reader = nucleus.VcfReader.from_file(
-          self._store_to_temp_local_file(header_lines),
-          nucleus_proto.VcfReaderOptions())
+      # This is a temporary solution until from_string will be fixed.
+      self._vcf_reader = nucleus.VcfReader(self._temp_local_file,
+                                           use_index=False)
+
     except SyntaxError as e:
       raise ValueError(
           'Invalid VCF header in %s: %s' % (self._file_name, str(e)))
+    self._extract_header_fields()
+
+  def _extract_header_fields(self):
+    header = self._vcf_reader.header
+    for info in header.infos:
+      if info.number in ('0', '1'):
+        self._is_info_repeated[info.id] = False
+      else:
+        self._is_info_repeated[info.id] = True
+
+    for format_info in header.formats:
+      if format_info.number in ('0', '1'):
+        self._is_format_repeated[format_info.id] = False
+      else:
+        self._is_format_repeated[format_info.id] = True
 
   def _get_variant(self, data_line):
     try:
-      record = self._vcf_reader.from_string(data_line)
+      # This is a temporary solution until from_string will be fixed.
+      record = next(self._vcf_reader)
       return self._convert_to_variant(record)
     except (LookupError, ValueError) as e:
       logging.warning('VCF record read failed in %s for line %s: %s',
                       self._file_name, data_line, str(e))
       return MalformedVcfRecord(self._file_name, data_line, str(e))
 
-  def _convert_to_variant_record(
-      self,
-      record,  # type: nucleus_proto
-      ):
-    # type: (...) -> Variant
+  def _convert_to_variant(self, record):
+    # type: (nucleus_proto.Variant) -> Variant
     return Variant(
         reference_name=record.reference_name,
         start=record.start,
         end=record.end,
-        reference_bases=(
-            record.reference_bases if record.reference_bases != MISSING_FIELD_VALUE else None),
-        alternate_bases=map(str, record.alternate_bases) if record.alternate_bases else [],
+        reference_bases=(record.reference_bases
+                         if record.reference_bases != MISSING_FIELD_VALUE
+                         else None),
+        alternate_bases=(
+            map(str, record.alternate_bases) if record.alternate_bases else []),
         names=map(str, record.names) if record.names else [],
         quality=record.quality,
-        filters=[PASS_FILTER] if record.filter == [] else map(str, record.filter),
-        info=record.info)#,
-        #calls=self._get_variant_calls(record))
+        filters=(
+            [PASS_FILTER] if record.filter == [] else map(str, record.filter)),
+        info=self._get_variant_info(record),
+        calls=self._get_variant_calls(record))
+
+  def _get_variant_info(self, record):
+    info = {}
+    for k in record.info:
+      data = self._convert_list_value(record.info[k],
+                                      self._is_info_repeated.get(k, False))
+      # Prevents including missing flags as 'false' flag.
+      if isinstance(data, bool) and not data:
+        continue
+      info[k] = data
+    return info
+
+  def _convert_list_value(self, list_values, is_repeated):
+    """Converts an object of ListValue to python native types.
+
+    if is_repeated is set the output will be a list otherwise a single value.
+    """
+    output_list = []
+    for value in list_values.values:
+      if value.HasField('null_value'):
+        output_list.append(value.null_value)
+      elif value.HasField('number_value'):
+        output_list.append(value.number_value)
+      elif value.HasField('int_value'):
+        output_list.append(value.int_value)
+      elif value.HasField('string_value'):
+        output_list.append(value.string_value)
+      elif value.HasField('bool_value'):
+        output_list.append(value.bool_value)
+      elif value.HasField('struct_value'):
+        output_list.append(value.struct_value)
+      elif value.HasField('list_value'):
+        output_list.append(self._convert_list_value(value.list_value, True))
+      else:
+        raise ValueError('ListValue object has an unexpected value: %s' % value)
+
+    if is_repeated:
+      return output_list
+    if not output_list:
+      return None
+    if len(output_list) == 1:
+      return output_list[0]
+    raise ValueError('a not repeated field has more than 1 value')
+
+  def _get_variant_calls(self, record):
+    calls = []
+    for sample in record.calls:
+      call = VariantCall()
+      call.name = sample.call_set_name
+      if not sample.genotype:
+        call.genotype.append(MISSING_GENOTYPE_VALUE)
+      else:
+        for v in sample.genotype:
+          call.genotype.append(v)
+
+      phaseset_from_format = (
+          sample.info[PHASESET_FORMAT_KEY].values[0].string_value
+          if sample.info.get(PHASESET_FORMAT_KEY, None)
+          else None)
+      # Note: Call is considered phased if it contains the 'PS' key regardless
+      # of whether it uses '|'.
+      if phaseset_from_format or sample.is_phased:
+        call.phaseset = (phaseset_from_format if phaseset_from_format
+                         else DEFAULT_PHASESET_VALUE)
+      for k in sample.info:
+        # Genotype and phaseset (if present) are already included.
+        if k in (GENOTYPE_FORMAT_KEY, PHASESET_FORMAT_KEY):
+          continue
+        is_repeated = self._is_format_repeated.get(k, False)
+        data = self._convert_list_value(sample.info[k], is_repeated)
+        call.info[k] = data
+      calls.append(call)
+    return calls

--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -25,7 +25,8 @@ from collections import namedtuple
 import os
 import tempfile
 
-from nucleus.io import vcf as nucleus
+#from nucleus.io import vcf as nucleus
+import nucleus
 import vcf
 
 from apache_beam.coders import coders
@@ -523,8 +524,8 @@ class NucleusParser(VcfParser):
     header_lines = ['##fileformat=VCFv4.2'] + header_lines
     try:
       # This is a temporary solution until from_string will be fixed.
-      self._vcf_reader = nucleus.VcfReader(self._temp_local_file,
-                                           use_index=False)
+      self._vcf_reader = nucleus.io.vcf.VcfReader(
+          self._temp_local_file, use_index=False)
 
     except SyntaxError as e:
       raise ValueError(

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -186,7 +186,8 @@ class _VcfSource(filebasedsource.FileBasedSource):
                compression_type=CompressionTypes.AUTO,  # type: str
                buffer_size=DEFAULT_VCF_READ_BUFFER_SIZE,  # type: int
                validate=True,  # type: bool
-               allow_malformed_records=False  # type: bool
+               allow_malformed_records=False,  # type: bool
+               use_nucleus=True  # type: bool
               ):
     # type: (...) -> None
     super(_VcfSource, self).__init__(file_pattern,
@@ -196,21 +197,33 @@ class _VcfSource(filebasedsource.FileBasedSource):
     self._compression_type = compression_type
     self._buffer_size = buffer_size
     self._allow_malformed_records = allow_malformed_records
+    self._use_nucleus = use_nucleus
 
   def read_records(self,
                    file_name,  # type: str
                    range_tracker  # type: range_trackers.OffsetRangeTracker
                   ):
     # type: (...) -> Iterable[MalformedVcfRecord]
-    record_iterator = vcf_parser.PyVcfParser(
-        file_name,
-        range_tracker,
-        self._pattern,
-        self._compression_type,
-        self._allow_malformed_records,
-        self._representative_header_lines,
-        buffer_size=self._buffer_size,
-        skip_header_lines=0)
+    if self._use_nucleus:
+      record_iterator = vcf_parser.NucleusParser(
+          file_name,
+          range_tracker,
+          self._pattern,
+          self._compression_type,
+          self._allow_malformed_records,
+          self._representative_header_lines,
+          buffer_size=self._buffer_size,
+          skip_header_lines=0)
+    else:
+      record_iterator = vcf_parser.PyVcfParser(
+          file_name,
+          range_tracker,
+          self._pattern,
+          self._compression_type,
+          self._allow_malformed_records,
+          self._representative_header_lines,
+          buffer_size=self._buffer_size,
+          skip_header_lines=0)
 
     # Convert iterator to generator to abstract behavior
     for record in record_iterator:

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -187,7 +187,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
                buffer_size=DEFAULT_VCF_READ_BUFFER_SIZE,  # type: int
                validate=True,  # type: bool
                allow_malformed_records=False,  # type: bool
-               use_nucleus=True  # type: bool
+               use_nucleus=False  # type: bool
               ):
     # type: (...) -> None
     super(_VcfSource, self).__init__(file_pattern,

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -120,13 +120,13 @@ class _ToVcfRecordCoder(coders.Coder):
     return format_keys
 
   def _encode_variant_calls(self, variant, format_keys):
-    """Encodes the calls of a :class:`Variant` in a VCF line."""
+    # type: (Variant, List[str]) -> str
+    """Encodes the calls of `Variant` in a VCF line."""
     # Ensure that genotype is always the first key in format_keys
     assert not format_keys or format_keys[0] == GENOTYPE_FORMAT_KEY
     encoded_calls = []
     for call in variant.calls:
-      encoded_call_info = [self._encode_genotype(
-          call.genotype, call.phaseset)]
+      encoded_call_info = [self._encode_genotype(call.genotype, call.phaseset)]
       for key in format_keys[1:]:
         if key == PHASESET_FORMAT_KEY:
           encoded_call_info.append(

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -47,10 +47,14 @@ from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs import vcf_file_composer
 from gcp_variant_transforms.options import variant_transform_options
 from gcp_variant_transforms.transforms import bigquery_to_variant
+from gcp_variant_transforms.transforms import combine_call_names
 from gcp_variant_transforms.transforms import densify_variants
+
 
 _BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`;'
 _COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
+_VCF_FIXED_COLUMNS = ['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER',
+                      'INFO', 'FORMAT']
 
 
 def run(argv=None):
@@ -65,24 +69,32 @@ def run(argv=None):
   if not google_cloud_options.temp_location or not google_cloud_options.project:
     raise ValueError('temp_location and project must be set.')
 
-  shards_folder = 'bq_to_vcf_temp_files_{}'.format(
-      datetime.now().strftime('%Y%m%d_%H%M%S'))
-  bq_to_vcf_temp_folder = filesystems.FileSystems.join(
-      google_cloud_options.temp_location, shards_folder)
+  timestamp_str = datetime.now().strftime('%Y%m%d_%H%M%S')
+  vcf_data_temp_folder = filesystems.FileSystems.join(
+      google_cloud_options.temp_location,
+      'bq_to_vcf_data_temp_files_{}'.format(timestamp_str))
+  vcf_data_header_file_path = filesystems.FileSystems.join(
+      google_cloud_options.temp_location,
+      'bq_to_vcf_data_header_{}'.format(timestamp_str))
 
-  _bigquery_to_vcf_shards(known_args, options, bq_to_vcf_temp_folder)
-  vcf_file_composer.compose_vcf_data_files(google_cloud_options.project,
-                                           bq_to_vcf_temp_folder,
-                                           known_args.output_file)
+  _bigquery_to_vcf_shards(known_args,
+                          options,
+                          vcf_data_temp_folder,
+                          vcf_data_header_file_path)
+  vcf_file_composer.compose_vcf_shards(google_cloud_options.project,
+                                       vcf_data_header_file_path,
+                                       vcf_data_temp_folder,
+                                       known_args.output_file)
 
-  # TODO(allieychen): Eventually, it further consolidates the meta information,
-  # data header line, and the composed VCF data file into the `output_file`.
+  # TODO(allieychen): Eventually, it further consolidates the meta information
+  # into the `output_file`.
 
 
 def _bigquery_to_vcf_shards(
     known_args,  # type: argparse.Namespace
     beam_pipeline_options,  # type: pipeline_options.PipelineOptions
-    bq_to_vcf_temp_folder  # type: str
+    vcf_data_temp_folder,  # type: str
+    vcf_data_header_file_path,  # type: str
     ):
   # type: (...) -> None
   """Runs BigQuery to VCF shards pipelines.
@@ -90,10 +102,11 @@ def _bigquery_to_vcf_shards(
   It reads the variants from BigQuery table, groups a collection of variants
   within a contiguous region of the genome (the size of the collection is
   adjustable through flag `--number_of_bases_per_shard`), sorts them, and then
-  writes to one VCF shard.
+  writes to one VCF file. All VCF data files are saved in
+  `vcf_data_temp_folder`.
 
-  TODO(allieychen): Eventually, it also generates the meta information file and
-  data header file.
+  Also, it writes the data header to `vcf_data_header_file_path`.
+  TODO(allieychen): Eventually, it also generates the meta information file.
   """
   bq_source = bigquery.BigQuerySource(
       query=_BASE_QUERY_TEMPLATE.format(
@@ -103,14 +116,47 @@ def _bigquery_to_vcf_shards(
       use_standard_sql=True)
 
   with beam.Pipeline(options=beam_pipeline_options) as p:
-    _ = (p | 'ReadFromBigQuery ' >> beam.io.Read(bq_source)
-         | bigquery_to_variant.BigQueryToVariant()
-         | densify_variants.DensifyVariants()
+    variants = (p
+                | 'ReadFromBigQuery ' >> beam.io.Read(bq_source)
+                | bigquery_to_variant.BigQueryToVariant())
+    call_names = (variants
+                  | 'CombineCallNames' >>
+                  combine_call_names.CallNamesCombiner())
+
+    _ = (call_names
+         | 'GenerateVcfDataHeader' >>
+         beam.ParDo(_write_vcf_data_header,
+                    _VCF_FIXED_COLUMNS,
+                    vcf_data_header_file_path))
+
+    _ = (variants
+         | densify_variants.DensifyVariants(beam.pvalue.AsSingleton(call_names))
          | 'PairVariantWithKey' >>
          beam.Map(_pair_variant_with_key, known_args.number_of_bases_per_shard)
          | 'GroupVariantsByKey' >> beam.GroupByKey()
-         | beam.ParDo(_get_file_path_and_sorted_variants, bq_to_vcf_temp_folder)
+         | beam.ParDo(_get_file_path_and_sorted_variants, vcf_data_temp_folder)
          | vcfio.WriteVcfDataLines())
+
+
+def _write_vcf_data_header(sample_names, vcf_fixed_columns, file_path):
+  # type: (List[str], List[str], str) -> None
+  """Writes VCF data header.
+
+  It writes the header line with ` vcf_fixed_columns`, followed by sample
+  names in `sample_names`. Example:
+  #CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  SAMPLE1  SAMPLE2
+
+  Args:
+    sample_names: The sample names appended to `vcf_fixed_columns`.
+    vcf_fixed_columns: The VCF fixed columns.
+    file_path: The location where the data header line is saved.
+  """
+  # pylint: disable=redefined-outer-name,reimported
+  from apache_beam.io import filesystems
+  with filesystems.FileSystems.create(file_path) as file_to_write:
+    file_to_write.write(
+        str('\t'.join(vcf_fixed_columns + sample_names)))
+    file_to_write.write('\n')
 
 
 def _get_file_path_and_sorted_variants((file_name, variants), file_path_prefix):

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -1,0 +1,38 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `bq_to_vcf` module."""
+
+import unittest
+
+from apache_beam.io import filesystems
+
+from gcp_variant_transforms import bq_to_vcf
+from gcp_variant_transforms.testing import temp_dir
+
+
+class BqToVcfTest(unittest.TestCase):
+  """Test cases for the `bq_to_vcf` module."""
+
+  def test_write_vcf_data_header(self):
+    with temp_dir.TempDir() as tempdir:
+      file_path = filesystems.FileSystems.join(tempdir.get_path(),
+                                               'data_header')
+      bq_to_vcf._write_vcf_data_header(['Sample 1', 'Sample 2'],
+                                       ['#CHROM', 'POS', 'ID', 'REF', 'ALT'],
+                                       file_path)
+      expected_content = '#CHROM\tPOS\tID\tREF\tALT\tSample 1\tSample 2\n'
+      with filesystems.FileSystems.open(file_path) as f:
+        content = f.readlines()
+        self.assertEqual(content, [expected_content])

--- a/gcp_variant_transforms/transforms/combine_call_names.py
+++ b/gcp_variant_transforms/transforms/combine_call_names.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A PTransform to combine call names from all variants."""
+
+from typing import List, Tuple  # pylint: disable=unused-import
+
+import apache_beam as beam
+
+from gcp_variant_transforms.beam_io import vcf_parser  # pylint: disable=unused-import
+
+
+class CallNamesCombiner(beam.PTransform):
+  """A PTransform to combine call names from all variants."""
+
+  def _get_call_names(self, variant):
+    # type: (vcf_parser.Variant) -> Tuple[str]
+    """Returns the names of all calls for the variant."""
+    call_names = [call.name for call in variant.calls]
+    if len(call_names) != len(set(call_names)):
+      raise ValueError('There are duplicate call names in the variant {}'.
+                       format(variant))
+    return tuple(call_names)
+
+  def _combine_unique_call_names(self, call_names):
+    # type: (List[Tuple[str]]) -> List[str]
+    """Combines unique call names from all variants.
+
+    If there is only one unique call name tuple in `call_names`, it means that
+    the call names from all variants are the same. For this case, return this
+    call name tuple directly. Otherwise, return the call names in sorted order.
+    """
+    if len(call_names) == 1:
+      return list(call_names[0])
+    return (call_names
+            | 'FlattenCallNames' >> beam.Flatten()
+            | 'RemoveDuplicates' >> beam.RemoveDuplicates()
+            | 'Combine' >> beam.combiners.ToList()
+            | 'SortCallNames' >> beam.ParDo(sorted))
+
+  def expand(self, pcoll):
+    return (pcoll
+            | 'GetCallNames' >> beam.Map(self._get_call_names)
+            | 'RemoveDuplicates' >> beam.RemoveDuplicates()
+            | 'Combine' >> beam.combiners.ToList()
+            | 'CombineUniqueCallNames'
+            >> beam.ParDo(self._combine_unique_call_names)
+            | beam.combiners.ToList())

--- a/gcp_variant_transforms/transforms/combine_call_names_test.py
+++ b/gcp_variant_transforms/transforms/combine_call_names_test.py
@@ -1,0 +1,85 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `combine_call_names` module."""
+
+import unittest
+
+from apache_beam import transforms
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.transforms import combine_call_names
+
+
+class GetCallNamesTest(unittest.TestCase):
+  """Test cases for the `CallNamesCombiner` transform."""
+
+  def test_call_names_combiner_pipeline(self):
+    call_names = ['sample1', 'sample2', 'sample3']
+    variant_calls = [
+        vcfio.VariantCall(name=call_names[0]),
+        vcfio.VariantCall(name=call_names[1]),
+        vcfio.VariantCall(name=call_names[2])
+    ]
+    variants = [
+        vcfio.Variant(calls=[variant_calls[0], variant_calls[1]]),
+        vcfio.Variant(calls=[variant_calls[1], variant_calls[2]])
+    ]
+
+    pipeline = TestPipeline()
+    combined_call_names = (
+        pipeline
+        | transforms.Create(variants)
+        | 'CombineCallNames' >> combine_call_names.CallNamesCombiner())
+    assert_that(combined_call_names, equal_to([call_names]))
+    pipeline.run()
+
+  def test_call_names_combiner_pipeline_same_call_names(self):
+    call_names = ['sample2', 'sample1', 'sample3']
+    variant_calls = [
+        vcfio.VariantCall(name=call_names[0]),
+        vcfio.VariantCall(name=call_names[1]),
+        vcfio.VariantCall(name=call_names[2])
+    ]
+    variants = [
+        vcfio.Variant(calls=[variant_calls[0],
+                             variant_calls[1],
+                             variant_calls[2]]),
+        vcfio.Variant(calls=[variant_calls[0],
+                             variant_calls[1],
+                             variant_calls[2]])
+    ]
+
+    pipeline = TestPipeline()
+    combined_call_names = (
+        pipeline
+        | transforms.Create(variants)
+        | 'CombineCallNames' >> combine_call_names.CallNamesCombiner())
+    assert_that(combined_call_names, equal_to([call_names]))
+    pipeline.run()
+
+  def test_call_names_combiner_pipeline_duplicate_call_names(self):
+    variant_call = vcfio.VariantCall(name='sample1')
+    variants = [vcfio.Variant(calls=[variant_call, variant_call])]
+
+    pipeline = TestPipeline()
+    _ = (
+        pipeline
+        | transforms.Create(variants)
+        | 'CombineCallNames' >> combine_call_names.CallNamesCombiner())
+    with self.assertRaises(ValueError):
+      pipeline.run()

--- a/gcp_variant_transforms/transforms/densify_variants_test.py
+++ b/gcp_variant_transforms/transforms/densify_variants_test.py
@@ -30,13 +30,24 @@ from gcp_variant_transforms.transforms import densify_variants
 class DensifyVariantsTest(unittest.TestCase):
   """Test cases for the ``DensifyVariants`` transform."""
 
-  def test_add_missing_calls(self):
-    transform = densify_variants.DensifyVariants()
-    variant = vcfio.Variant(calls=[vcfio.VariantCall(name='sample2')])
-    new_variant = transform._densify_variants(
-        variant, ['sample1', 'sample2', 'sample3'])
-    call_names = [call.name for call in new_variant.calls]
-    self.assertItemsEqual(call_names, ['sample1', 'sample2', 'sample3'])
+  def test_densify_variants_pipeline_no_calls(self):
+    variant_calls = [
+        vcfio.VariantCall(name='sample1'),
+        vcfio.VariantCall(name='sample2'),
+        vcfio.VariantCall(name='sample3'),
+    ]
+    variants = [
+        vcfio.Variant(calls=[variant_calls[0], variant_calls[1]]),
+        vcfio.Variant(calls=[variant_calls[1], variant_calls[2]]),
+    ]
+    pipeline = TestPipeline()
+    densified_variants = (
+        pipeline
+        | Create(variants)
+        | 'DensifyVariants' >> densify_variants.DensifyVariants([]))
+    assert_that(densified_variants, asserts.has_calls([]))
+
+    pipeline.run()
 
   def test_densify_variants_pipeline(self):
     call_names = ['sample1', 'sample2', 'sample3']
@@ -54,7 +65,7 @@ class DensifyVariantsTest(unittest.TestCase):
     densified_variants = (
         pipeline
         | Create(variants)
-        | 'DensifyVariants' >> densify_variants.DensifyVariants())
+        | 'DensifyVariants' >> densify_variants.DensifyVariants(call_names))
     assert_that(densified_variants, asserts.has_calls(call_names))
 
     pipeline.run()

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIRED_PACKAGES = [
     'google-api-python-client>=1.6',
     'intervaltree>=2.1.0,<2.2.0',
     'pyvcf<0.7.0',
+    'nucleus',
     'mmh3<2.6',
     # Need to explicitly install v<=1.2.0. apache-beam requires
     # google-cloud-pubsub 0.26.0, which relies on google-cloud-core<0.26dev,
@@ -62,6 +63,10 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+    ],
+
+    dependency_links=[
+        'https://storage.googleapis.com/gcp-variant-transforms-setupfiles/nucleus/Nucleus-0.1.0-py2-none-any.whl',
     ],
 
     setup_requires=REQUIRED_SETUP_PACKAGES,


### PR DESCRIPTION
After defining the VCFParser interface and PyVcfParser in a previous PR, here we add a new parser,
NucleusParser.

Following points must be highlighted:
 * This new parser is hidden behind a flag (use_nucleus=False).
 * Since we are not still able to create a Wheel file that have the
 from_string() method, we use a hack to make Nucleus work: write the whole
 file to a local temporary file and send it as input to Nucleus.
 * Currently we don't have any unit tests or integration test. We
 manually cheked the sanity of Nucleus output by comparing its output
 table with PyVcf output. Tests must be added in the next step.