### PR TITLE
Adding the second VcfParser class: NucleusParser 

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -25,7 +25,7 @@ from collections import namedtuple
 import os
 import tempfile
 
-from nucleus.io import vcf as nucleus
+import nucleus
 import vcf
 
 from apache_beam.coders import coders
@@ -525,8 +525,8 @@ class NucleusParser(VcfParser):
     header_lines = ['##fileformat=VCFv4.2'] + header_lines
     try:
       # This is a temporary solution until from_string will be fixed.
-      self._vcf_reader = nucleus.VcfReader(self._temp_local_file,
-                                           use_index=False)
+      self._vcf_reader = nucleus.io.vcf.VcfReader(
+          self._temp_local_file, use_index=False)
 
     except SyntaxError as e:
       raise ValueError(

--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -22,6 +22,10 @@ from __future__ import absolute_import
 import logging
 from collections import namedtuple
 
+from nucleus.io.python import vcf_reader as nucleus
+from nucleus.protos import variants_pb2 as nucleus_proto
+import os
+import tempfile
 import vcf
 
 from apache_beam.coders import coders
@@ -466,3 +470,72 @@ class PyVcfParser(VcfParser):
         call.info[field] = data
       calls.append(call)
     return calls
+
+
+class NucleusParser(VcfParser):
+  """An Iterator for processing a single VCF file using Nucleus."""
+
+  def __init__(self,
+	       file_name,  # type: str
+	       range_tracker,  # type: range_trackers.OffsetRangeTracker
+	       file_pattern,  # type: str
+	       compression_type,  # type: str
+	       allow_malformed_records,  # type: bool
+	       representative_header_lines=None,  # type:  List[str]
+	       **kwargs  # type: **str
+	      ):
+    # type: (...) -> None
+    super(NucleusParser, self).__init__(file_name,
+                                      range_tracker,
+                                      file_pattern,
+                                      compression_type,
+                                      allow_malformed_records,
+                                      representative_header_lines,
+                                      **kwargs)
+    # This member will be properly initiated in _init_with_header().
+    self._vcf_reader = None
+
+  def _store_to_temp_local_file(self, header_lines):
+    (temp_file, temp_file_name) = tempfile.mkstemp(text=True)
+    for line in header_lines:
+      os.write(temp_file, line)
+    os.close(temp_file)
+    return temp_file_name
+
+  def _init_with_header(self, header_lines):
+    # This optional header line is needed by Nucleus.
+    header_lines = ['##fileformat=VCFv4.2'] + header_lines
+    try:
+      self._vcf_reader = nucleus.VcfReader.from_file(
+          self._store_to_temp_local_file(header_lines),
+          nucleus_proto.VcfReaderOptions())
+    except SyntaxError as e:
+      raise ValueError(
+          'Invalid VCF header in %s: %s' % (self._file_name, str(e)))
+
+  def _get_variant(self, data_line):
+    try:
+      record = self._vcf_reader.from_string(data_line)
+      return self._convert_to_variant(record)
+    except (LookupError, ValueError) as e:
+      logging.warning('VCF record read failed in %s for line %s: %s',
+                      self._file_name, data_line, str(e))
+      return MalformedVcfRecord(self._file_name, data_line, str(e))
+
+  def _convert_to_variant_record(
+      self,
+      record,  # type: nucleus_proto
+      ):
+    # type: (...) -> Variant
+    return Variant(
+        reference_name=record.reference_name,
+        start=record.start,
+        end=record.end,
+        reference_bases=(
+            record.reference_bases if record.reference_bases != MISSING_FIELD_VALUE else None),
+        alternate_bases=map(str, record.alternate_bases) if record.alternate_bases else [],
+        names=map(str, record.names) if record.names else [],
+        quality=record.quality,
+        filters=[PASS_FILTER] if record.filter == [] else map(str, record.filter),
+        info=record.info)#,
+        #calls=self._get_variant_calls(record))

--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -565,7 +565,7 @@ class NucleusParser(VcfParser):
     try:
       variant_proto = self._vcf_reader.from_string(data_line)
       return self._convert_to_variant(variant_proto)
-    except (ValueError) as e:
+    except ValueError as e:
       logging.warning('VCF variant_proto read failed in %s for line %s: %s',
                       self._file_name, data_line, str(e))
       return MalformedVcfRecord(self._file_name, data_line, str(e))

--- a/gcp_variant_transforms/beam_io/vcf_parser_test.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser_test.py
@@ -1,0 +1,90 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for vcf_parser module."""
+
+from __future__ import absolute_import
+
+import logging
+import unittest
+from itertools import permutations
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.beam_io.vcfio import Variant
+from gcp_variant_transforms.beam_io.vcfio import VariantCall
+
+
+class VariantTest(unittest.TestCase):
+
+  def _assert_variants_equal(self, actual, expected):
+    self.assertEqual(
+        sorted(expected),
+        sorted(actual))
+
+  def test_sort_variants(self):
+    sorted_variants = [
+        Variant(reference_name='a', start=20, end=22),
+        Variant(reference_name='a', start=20, end=22, quality=20),
+        Variant(reference_name='b', start=20, end=22),
+        Variant(reference_name='b', start=21, end=22),
+        Variant(reference_name='b', start=21, end=23)]
+
+    for permutation in permutations(sorted_variants):
+      self.assertEqual(sorted(permutation), sorted_variants)
+
+  def test_variant_equality(self):
+    base_variant = Variant(reference_name='a', start=20, end=22,
+                           reference_bases='a', alternate_bases=['g', 't'],
+                           names=['variant'], quality=9, filters=['q10'],
+                           info={'key': 'value'},
+                           calls=[VariantCall(genotype=[0, 0])])
+    equal_variant = Variant(reference_name='a', start=20, end=22,
+                            reference_bases='a', alternate_bases=['g', 't'],
+                            names=['variant'], quality=9, filters=['q10'],
+                            info={'key': 'value'},
+                            calls=[VariantCall(genotype=[0, 0])])
+    different_calls = Variant(reference_name='a', start=20, end=22,
+                              reference_bases='a', alternate_bases=['g', 't'],
+                              names=['variant'], quality=9, filters=['q10'],
+                              info={'key': 'value'},
+                              calls=[VariantCall(genotype=[1, 0])])
+    missing_field = Variant(reference_name='a', start=20, end=22,
+                            reference_bases='a', alternate_bases=['g', 't'],
+                            names=['variant'], quality=9, filters=['q10'],
+                            info={'key': 'value'})
+
+    self.assertEqual(base_variant, equal_variant)
+    self.assertNotEqual(base_variant, different_calls)
+    self.assertNotEqual(base_variant, missing_field)
+
+
+class VariantCallTest(unittest.TestCase):
+
+  def _default_variant_call(self):
+    return vcfio.VariantCall(
+        name='Sample1', genotype=[1, 0],
+        phaseset=vcfio.DEFAULT_PHASESET_VALUE, info={'GQ': 48})
+
+  def test_variant_call_order(self):
+    variant_call_1 = self._default_variant_call()
+    variant_call_2 = self._default_variant_call()
+    self.assertEqual(variant_call_1, variant_call_2)
+    variant_call_1.phaseset = 0
+    variant_call_2.phaseset = 1
+    self.assertGreater(variant_call_2, variant_call_1)
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -212,30 +212,23 @@ class _VcfSource(filebasedsource.FileBasedSource):
                    range_tracker  # type: range_trackers.OffsetRangeTracker
                   ):
     # type: (...) -> Iterable[MalformedVcfRecord]
+    vcf_parser_class = None
     if self._vcf_parser_type == VcfParserType.PYVCF:
-      record_iterator = vcf_parser.PyVcfParser(
-          file_name,
-          range_tracker,
-          self._pattern,
-          self._compression_type,
-          self._allow_malformed_records,
-          self._representative_header_lines,
-          buffer_size=self._buffer_size,
-          skip_header_lines=0)
+      vcf_parser_class = vcf_parser.PyVcfParser
     elif self._vcf_parser_type == VcfParserType.NUCLEUS:
-      record_iterator = vcf_parser.NucleusParser(
-          file_name,
-          range_tracker,
-          self._pattern,
-          self._compression_type,
-          self._allow_malformed_records,
-          self._representative_header_lines,
-          buffer_size=self._buffer_size,
-          skip_header_lines=0)
+      vcf_parser_class = vcf_parser.NucleusParser
     else:
       raise ValueError(
           'Unrecognized _vcf_parser_type: %s.' % str(self._vcf_parser_type))
-
+    record_iterator = vcf_parser_class(
+        file_name,
+        range_tracker,
+        self._pattern,
+        self._compression_type,
+        self._allow_malformed_records,
+        self._representative_header_lines,
+        buffer_size=self._buffer_size,
+        skip_header_lines=0)
 
     # Convert iterator to generator to abstract behavior
     for record in record_iterator:

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -188,7 +188,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
                buffer_size=DEFAULT_VCF_READ_BUFFER_SIZE,  # type: int
                validate=True,  # type: bool
                allow_malformed_records=False,  # type: bool
-               use_nucleus=True  # type: bool
+               use_nucleus=False  # type: bool
               ):
     # type: (...) -> None
     super(_VcfSource, self).__init__(file_pattern,

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -187,7 +187,8 @@ class _VcfSource(filebasedsource.FileBasedSource):
                compression_type=CompressionTypes.AUTO,  # type: str
                buffer_size=DEFAULT_VCF_READ_BUFFER_SIZE,  # type: int
                validate=True,  # type: bool
-               allow_malformed_records=False  # type: bool
+               allow_malformed_records=False,  # type: bool
+               use_nucleus=True  # type: bool
               ):
     # type: (...) -> None
     super(_VcfSource, self).__init__(file_pattern,
@@ -197,21 +198,33 @@ class _VcfSource(filebasedsource.FileBasedSource):
     self._compression_type = compression_type
     self._buffer_size = buffer_size
     self._allow_malformed_records = allow_malformed_records
+    self._use_nucleus = use_nucleus
 
   def read_records(self,
                    file_name,  # type: str
                    range_tracker  # type: range_trackers.OffsetRangeTracker
                   ):
     # type: (...) -> Iterable[MalformedVcfRecord]
-    record_iterator = vcf_parser.PyVcfParser(
-        file_name,
-        range_tracker,
-        self._pattern,
-        self._compression_type,
-        self._allow_malformed_records,
-        self._representative_header_lines,
-        buffer_size=self._buffer_size,
-        skip_header_lines=0)
+    if self._use_nucleus:
+      record_iterator = vcf_parser.NucleusParser(
+          file_name,
+          range_tracker,
+          self._pattern,
+          self._compression_type,
+          self._allow_malformed_records,
+          self._representative_header_lines,
+          buffer_size=self._buffer_size,
+          skip_header_lines=0)
+    else:
+      record_iterator = vcf_parser.PyVcfParser(
+          file_name,
+          range_tracker,
+          self._pattern,
+          self._compression_type,
+          self._allow_malformed_records,
+          self._representative_header_lines,
+          buffer_size=self._buffer_size,
+          skip_header_lines=0)
 
     # Convert iterator to generator to abstract behavior
     for record in record_iterator:

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -213,6 +213,12 @@ def _get_sample_non_variant():
 class VcfSourceTest(unittest.TestCase):
 
   VCF_FILE_DIR_MISSING = not os.path.exists(testdata_util.get_full_dir())
+  try:
+    vcfio.vcf_parser.nucleus_vcf_reader
+  except AttributeError:
+    NUCLEUS_IMPORT_MISSING = True
+  else:
+    NUCLEUS_IMPORT_MISSING = False
 
   def _create_temp_vcf_file(
       self, lines, tempdir, compression_type=CompressionTypes.UNCOMPRESSED):
@@ -345,6 +351,7 @@ class VcfSourceTest(unittest.TestCase):
     self.assertEqual(3, len(read_data))
     self._assert_variants_equal([variant_1, variant_2, variant_3], read_data)
 
+  @unittest.skipIf(NUCLEUS_IMPORT_MISSING, 'Nucleus is not imported')
   def test_single_file_verify_details_nucleus(self):
     variant_1, vcf_line_1 = _get_sample_variant_1(is_for_nucleus=True)
     read_data = self._create_temp_file_and_read_records(
@@ -374,6 +381,7 @@ class VcfSourceTest(unittest.TestCase):
       self.assertEqual(3, len(read_data))
       self._assert_variants_equal([variant_1, variant_2, variant_3], read_data)
 
+  @unittest.skipIf(NUCLEUS_IMPORT_MISSING, 'Nucleus is not imported')
   def test_file_pattern_verify_details_nucleus(self):
     variant_1, vcf_line_1 = _get_sample_variant_1(is_for_nucleus=True)
     variant_2, vcf_line_2 = _get_sample_variant_2(is_for_nucleus=True)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ REQUIRED_PACKAGES = [
     'google-api-python-client>=1.6',
     'intervaltree>=2.1.0,<2.2.0',
     'pyvcf<0.7.0',
+    'nucleus',
     'mmh3<2.6',
     # Need to explicitly install v<=1.2.0. apache-beam requires
     # google-cloud-pubsub 0.26.0, which relies on google-cloud-core<0.26dev,
@@ -62,6 +63,10 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+    ],
+
+    dependency_links=[
+        'https://storage.googleapis.com/gcp-variant-transforms-setupfiles/nucleus/Nucleus-0.1.0-py2-none-any.whl',
     ],
 
     setup_requires=REQUIRED_SETUP_PACKAGES,

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ REQUIRED_PACKAGES = [
     'google-api-python-client>=1.6',
     'intervaltree>=2.1.0,<2.2.0',
     'pyvcf<0.7.0',
-    'nucleus',
     'mmh3<2.6',
     # Need to explicitly install v<=1.2.0. apache-beam requires
     # google-cloud-pubsub 0.26.0, which relies on google-cloud-core<0.26dev,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,9 @@
 
 """Beam pipelines for processing variants based on VCF files."""
 
+import os
 import setuptools
+from setuptools.command.build_py import build_py
 
 REQUIRED_PACKAGES = [
     'cython>=0.28.1',
@@ -43,6 +45,20 @@ REQUIRED_SETUP_PACKAGES = [
     'nose>=1.0',
 ]
 
+
+class BuildPyCommand(build_py):
+  """Custom build command for installing libraries outside of PyPi."""
+
+  _NUCLEUS_WHEEL_PATH = (
+      'https://storage.googleapis.com/gcp-variant-transforms-setupfiles/'
+      'nucleus/Nucleus-0.1.0-py2-none-any.whl')
+
+  def run(self):
+    # Temporary workaround for installing Nucleus until it's available via PyPi.
+    os.system('pip install {}'.format(BuildPyCommand._NUCLEUS_WHEEL_PATH))
+    build_py.run(self)
+
+
 setuptools.setup(
     name='gcp_variant_transforms',
     version='0.4.2',
@@ -64,10 +80,6 @@ setuptools.setup(
         'Programming Language :: Python :: 2.7',
     ],
 
-    dependency_links=[
-        'https://storage.googleapis.com/gcp-variant-transforms-setupfiles/nucleus/Nucleus-0.1.0-py2-none-any.whl',
-    ],
-
     setup_requires=REQUIRED_SETUP_PACKAGES,
     install_requires=REQUIRED_PACKAGES,
     extras_require={
@@ -77,5 +89,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     package_data={
         'gcp_variant_transforms': ['gcp_variant_transforms/testing/testdata/*']
+    },
+    cmdclass={
+        'build_py': BuildPyCommand,
     },
 )


### PR DESCRIPTION
After defining the VCFParser interface and PyVcfParser in a previous PR, here we add
NucleusParser. Following points must be highlighted:
 * This new parser is hidden behind a flag (use_nucleus=False).
 * Since we are not still able to create a Wheel file that have the
 from_string() method, we use a hack to make Nucleus work: write the whole
 file to a local temp file and send it as input to parser.
 * Currently we don't have any unit tests or integration test. We
 manually cheked the sanity of Nucleus output by comparing its output
 table with PyVcf output. This must be done in the next step.