### PR TITLE
export annotations for BQ to VCF pipeline

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -1,3 +1,4 @@
+# This Python file uses the following encoding: utf-8
 # Copyright 2017 Google Inc.  All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -85,14 +86,15 @@ def _get_sample_variant_1(is_for_nucleus=False):
     multiple alternates
     not phased
     multiple names
+    utf-8 encoded
   """
   if not is_for_nucleus:
     vcf_line = ('20	1234	rs123;rs2	C	A,T	50	'
-                'PASS	AF=0.5,0.1;NS=1	GT:GQ	0/0:48	1/0:20\n')
+                'PASS	AF=0.5,0.1;NS=1;SVTYPE=BÑD	GT:GQ	0/0:48	1/0:20\n')
     variant = vcfio.Variant(
         reference_name='20', start=1233, end=1234, reference_bases='C',
         alternate_bases=['A', 'T'], names=['rs123', 'rs2'], quality=50,
-        filters=['PASS'], info={'AF': [0.5, 0.1], 'NS': 1})
+        filters=['PASS'], info={'AF': [0.5, 0.1], 'NS': 1, 'SVTYPE': ['BÑD']})
     variant.calls.append(
         vcfio.VariantCall(name='Sample1', genotype=[0, 0], info={'GQ': 48}))
     variant.calls.append(
@@ -100,15 +102,16 @@ def _get_sample_variant_1(is_for_nucleus=False):
   else:
     # 0.1 -> 0.25 float precision loss due to binary floating point conversion.
     vcf_line = ('20	1234	rs123;rs2	C	A,T	50	'
-                'PASS	AF=0.5,0.25;NS=1	GT:GQ	0/0:48	1/0:20\n')
+                'PASS	AF=0.5,0.25;NS=1;SVTYPE=BÑD	GT:GQ	0/0:48	1/0:20\n')
     variant = vcfio.Variant(
         reference_name='20', start=1233, end=1234, reference_bases='C',
         alternate_bases=['A', 'T'], names=['rs123', 'rs2'], quality=50,
-        filters=['PASS'], info={'AF': [0.5, 0.25], 'NS': 1})
+        filters=['PASS'], info={'AF': [0.5, 0.25], 'NS': 1, 'SVTYPE': ['BÑD']})
     variant.calls.append(
         vcfio.VariantCall(name='Sample1', genotype=[0, 0], info={'GQ': 48}))
     variant.calls.append(
         vcfio.VariantCall(name='Sample2', genotype=[1, 0], info={'GQ': 20}))
+
   return variant, vcf_line
 
 
@@ -840,8 +843,8 @@ class VcfSinkTest(unittest.TestCase):
       # Compare the rest of the items ignoring order
       self.assertItemsEqual(actual_split[1:], expected_split[1:])
 
-  def _get_coder(self):
-    return vcfio._ToVcfRecordCoder()
+  def _get_coder(self, annotation_fields=None):
+    return vcfio._ToVcfRecordCoder(annotation_fields)
 
   def test_to_vcf_line(self):
     coder = self._get_coder()
@@ -883,6 +886,43 @@ class VcfSinkTest(unittest.TestCase):
     expected = '.	.	.	.	.	.	.	NS=3;AF=0.333,0.667;DB	.\n'
 
     self._assert_variant_lines_equal(coder.encode(variant), expected)
+
+  def test_encode_annotation_value(self):
+    coder = self._get_coder(['allele', 'Consequence', 'AF'])
+    variant = Variant()
+    variant.info['CSQ'] = [
+        [
+            {u'allele': u'G',
+             u'Consequence': u'upstream_gene_variant',
+             u'AF': u''},
+            {u'allele': u'G',
+             u'Consequence': u'upstream_gene_variant',
+             u'AF': u''}
+        ],
+        [
+            {u'allele': u'T',
+             u'Consequence': u'upstream_gene_variant',
+             u'AF': u''},
+            {u'Consequence': u'upstream_gene_variant',
+             u'AF': u'0.1',
+             u'allele': u'T'}
+        ]
+    ]
+    expected = ['.	.	.	.	.	.	.	CSQ=G|upstream_gene_variant|,'
+                'G|upstream_gene_variant|,T|upstream_gene_variant|,'
+                'T|upstream_gene_variant|0.1	.\n']
+    self._assert_variant_lines_equal(coder.encode(variant), ''.join(expected))
+
+  def test_encode_annotation_value_missing_annotation_fields(self):
+    coder = self._get_coder()
+    variant = Variant()
+    variant.info['CSQ'] = [
+        [
+            {u'allele': u'G'}
+        ]
+    ]
+    with self.assertRaises(ValueError):
+      coder.encode(variant)
 
   def test_empty_sample_calls(self):
     coder = self._get_coder()

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -50,8 +50,11 @@ from typing import Iterable, List, Tuple  # pylint: disable=unused-import
 import apache_beam as beam
 from apache_beam.io import filesystems
 from apache_beam.io.gcp import bigquery
+from apache_beam.io.gcp.internal.clients import bigquery as bigquery_v2
 from apache_beam.options import pipeline_options
 from apache_beam.runners.direct import direct_runner
+
+from oauth2client import client
 
 from gcp_variant_transforms import vcf_to_bq_common
 from gcp_variant_transforms.beam_io import vcf_header_io
@@ -150,12 +153,14 @@ def _bigquery_to_vcf_shards(
   Also, it writes the meta info and data header with the call names to
   `vcf_header_file_path`.
   """
+
   query = _get_bigquery_query(known_args)
   logging.info('Processing BigQuery query %s:', query)
   bq_source = bigquery.BigQuerySource(query=query,
                                       validate=True,
                                       use_standard_sql=True)
-
+  schema = _get_schema(known_args.input_table)
+  annotation_fields = _extract_annotation_fields(schema)
   with beam.Pipeline(options=beam_pipeline_options) as p:
     variants = (p
                 | 'ReadFromBigQuery ' >> beam.io.Read(bq_source)
@@ -177,7 +182,30 @@ def _bigquery_to_vcf_shards(
          beam.Map(_pair_variant_with_key, known_args.number_of_bases_per_shard)
          | 'GroupVariantsByKey' >> beam.GroupByKey()
          | beam.ParDo(_get_file_path_and_sorted_variants, vcf_data_temp_folder)
-         | vcfio.WriteVcfDataLines())
+         | vcfio.WriteVcfDataLines(annotation_fields))
+
+
+def _extract_annotation_fields(schema):
+  # type: (bigquery_v2.TableSchema) -> List[str]
+  for table_field in schema.fields:
+    if table_field.name == bigquery_util.ColumnKeyConstants.ALTERNATE_BASES:
+      for sub_field in table_field.fields:
+        if (sub_field.type.lower() ==
+            bigquery_util.TableFieldConstants.TYPE_RECORD):
+          return [field.name for field in sub_field.fields]
+  return []
+
+
+def _get_schema(input_table):
+  # type: (str) -> bigqueryv2.TableSchema
+  project_id, dataset_id, table_id = bigquery_util.parse_table_reference(
+      input_table)
+  credentials = (client.GoogleCredentials.get_application_default().
+                 create_scoped(['https://www.googleapis.com/auth/bigquery']))
+  bigquery_client = bigquery_v2.BigqueryV2(credentials=credentials)
+  table = bigquery_client.tables.Get(bigquery_v2.BigqueryTablesGetRequest(
+      projectId=project_id, datasetId=dataset_id, tableId=table_id))
+  return table.schema
 
 
 def _get_bigquery_query(known_args):

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -223,10 +223,11 @@ def _extract_annotation_names(schema):
   # type: (bigquery_v2.TableSchema) -> Dict[str, List[str]]
   """Returns a mapping of annotation id to the corresponding annotation names.
 
-  The annotation names are useful for reconstructing the annotation str (e.g.,
-  'A|upstream_gene_variant|MODIFIER|PSMF1|||||'). Sample returned map:
-  {'CSQ': ['Consequence', 'IMPACT', 'SYMBOL'],
-   'CSQ_2': ['Codons', 'STRAND']}
+  Any `Record` field within alternate bases is considered as an annotation
+  field. The annotation names are useful for reconstructing the annotation str
+  (e.g., 'A|upstream_gene_variant|MODIFIER|PSMF1|||||'). Sample returned map:
+  {'CSQ': ['allele', 'Consequence', 'IMPACT', 'SYMBOL'],
+   'CSQ_2': ['allele', 'Codons', 'STRAND']}
   """
   annotation_names = {}
   for table_field in schema.fields:

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -20,6 +20,7 @@ import unittest
 from apache_beam.io import filesystems
 
 from gcp_variant_transforms import bq_to_vcf
+from gcp_variant_transforms.testing import bigquery_schema_util
 from gcp_variant_transforms.testing import temp_dir
 
 
@@ -76,3 +77,17 @@ class BqToVcfTest(unittest.TestCase):
         'end_position<=9223372036854775807)'
     )
     self.assertEqual(bq_to_vcf._get_bigquery_query(args_1), expected_query)
+
+  def test_get_annotation_fields(self):
+    schema_with_annotations = bigquery_schema_util.get_sample_table_schema(
+        with_annotation_fields=True)
+
+    self.assertEqual(
+        bq_to_vcf._extract_annotation_fields(schema_with_annotations),
+        ['allele', 'Consequence']
+    )
+    schema_with_no_annotation = bigquery_schema_util.get_sample_table_schema()
+    self.assertEqual(
+        bq_to_vcf._extract_annotation_fields(schema_with_no_annotation),
+        []
+    )

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -107,6 +107,11 @@ class BqToVcfTest(unittest.TestCase):
         mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
         description='desc')
     annotation_record_1.fields.append(bigquery.TableFieldSchema(
+        name='allele',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='desc.'))
+    annotation_record_1.fields.append(bigquery.TableFieldSchema(
         name='Consequence',
         type=bigquery_util.TableFieldConstants.TYPE_STRING,
         mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
@@ -118,6 +123,11 @@ class BqToVcfTest(unittest.TestCase):
         mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
         description='desc')
     annotation_record_2.fields.append(bigquery.TableFieldSchema(
+        name='allele',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='desc.'))
+    annotation_record_2.fields.append(bigquery.TableFieldSchema(
         name='IMPACT',
         type=bigquery_util.TableFieldConstants.TYPE_STRING,
         mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
@@ -126,5 +136,5 @@ class BqToVcfTest(unittest.TestCase):
     schema.fields.append(alternate_bases_record)
     self.assertEqual(
         bq_to_vcf._extract_annotation_names(schema),
-        {'CSQ_1': ['Consequence'], 'CSQ_2': ['IMPACT']}
+        {'CSQ_1': ['allele', 'Consequence'], 'CSQ_2': ['allele', 'IMPACT']}
     )

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -18,8 +18,10 @@ import collections
 import unittest
 
 from apache_beam.io import filesystems
+from apache_beam.io.gcp.internal.clients import bigquery
 
 from gcp_variant_transforms import bq_to_vcf
+from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.testing import bigquery_schema_util
 from gcp_variant_transforms.testing import temp_dir
 
@@ -78,16 +80,51 @@ class BqToVcfTest(unittest.TestCase):
     )
     self.assertEqual(bq_to_vcf._get_bigquery_query(args_1), expected_query)
 
-  def test_get_annotation_fields(self):
+  def test_get_annotation_names(self):
     schema_with_annotations = bigquery_schema_util.get_sample_table_schema(
         with_annotation_fields=True)
 
     self.assertEqual(
-        bq_to_vcf._extract_annotation_fields(schema_with_annotations),
-        ['allele', 'Consequence']
+        bq_to_vcf._extract_annotation_names(schema_with_annotations),
+        {'CSQ': ['Consequence', 'IMPACT']}
     )
     schema_with_no_annotation = bigquery_schema_util.get_sample_table_schema()
     self.assertEqual(
-        bq_to_vcf._extract_annotation_fields(schema_with_no_annotation),
-        []
+        bq_to_vcf._extract_annotation_names(schema_with_no_annotation),
+        {}
+    )
+
+  def test_get_annotation_names_multiple_annotations(self):
+    schema = bigquery.TableSchema()
+    alternate_bases_record = bigquery.TableFieldSchema(
+        name=bigquery_util.ColumnKeyConstants.ALTERNATE_BASES,
+        type=bigquery_util.TableFieldConstants.TYPE_RECORD,
+        mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
+        description='One record for each alternate base (if any).')
+    annotation_record_1 = bigquery.TableFieldSchema(
+        name='CSQ_1',
+        type=bigquery_util.TableFieldConstants.TYPE_RECORD,
+        mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
+        description='desc')
+    annotation_record_1.fields.append(bigquery.TableFieldSchema(
+        name='Consequence',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='desc.'))
+    alternate_bases_record.fields.append(annotation_record_1)
+    annotation_record_2 = bigquery.TableFieldSchema(
+        name='CSQ_2',
+        type=bigquery_util.TableFieldConstants.TYPE_RECORD,
+        mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
+        description='desc')
+    annotation_record_2.fields.append(bigquery.TableFieldSchema(
+        name='IMPACT',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='desc.'))
+    alternate_bases_record.fields.append(annotation_record_2)
+    schema.fields.append(alternate_bases_record)
+    self.assertEqual(
+        bq_to_vcf._extract_annotation_names(schema),
+        {'CSQ_1': ['Consequence'], 'CSQ_2': ['IMPACT']}
     )

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -86,13 +86,11 @@ class BqToVcfTest(unittest.TestCase):
 
     self.assertEqual(
         bq_to_vcf._extract_annotation_names(schema_with_annotations),
-        {'CSQ': ['Consequence', 'IMPACT']}
-    )
+        {'CSQ': ['Consequence', 'IMPACT']})
     schema_with_no_annotation = bigquery_schema_util.get_sample_table_schema()
     self.assertEqual(
         bq_to_vcf._extract_annotation_names(schema_with_no_annotation),
-        {}
-    )
+        {})
 
   def test_get_annotation_names_multiple_annotations(self):
     schema = bigquery.TableSchema()
@@ -136,5 +134,4 @@ class BqToVcfTest(unittest.TestCase):
     schema.fields.append(alternate_bases_record)
     self.assertEqual(
         bq_to_vcf._extract_annotation_names(schema),
-        {'CSQ_1': ['allele', 'Consequence'], 'CSQ_2': ['allele', 'IMPACT']}
-    )
+        {'CSQ_1': ['allele', 'Consequence'], 'CSQ_2': ['allele', 'IMPACT']})

--- a/gcp_variant_transforms/libs/annotation/annotation_parser.py
+++ b/gcp_variant_transforms/libs/annotation/annotation_parser.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 
 import re
 
-from typing import Dict, List, Tuple  # pylint: disable=unused-import
+from typing import Dict, Iterable, List, Tuple  # pylint: disable=unused-import
 
 # The key in annotation maps that keeps the original alternate allele in an
 # annotation string (and the field name in the BigQuery table that holds that
@@ -318,8 +318,8 @@ class AnnotationStrBuilder(object):
     self._annotation_id_to_annotation_names = annotation_id_to_annotation_names
 
   def reconstruct_annotation_str(self, annotation_id, annotation_maps):
-    # type: (str, List[Dict[str, Any]]) -> List[str]
-    """Returns annotation strings reconstructed from `annotation_map`.
+    # type: (str, List[Dict[str, Any]]) -> Iterable[str]
+    """Yields annotation string reconstructed from `annotation_map`.
 
     Notice that the returned value is a list of annotation string since the
     annotation record is a repeated field. The annotation str (e.g.,
@@ -340,17 +340,14 @@ class AnnotationStrBuilder(object):
           'IMPACT': ''}
         ]
 
-    Returns:
-      A list of annotation string reconstructed from `annotation_maps`.
-        Example:
-          ['G|upstream_gene_variant||MODIFIER',
-           'G|upstream_gene_variant|0.1|']
+    Yields:
+      Annotation string reconstructed from `annotation_maps`.
+        Example: 'G|upstream_gene_variant||MODIFIER'
     """
     if not self.is_valid_annotation_id(annotation_id):
       raise ValueError('No annotation names for {} are defined. The '
                        'annotation string cannot be reconstructed since the '
                        'order is not provided.'.format(annotation_id))
-    annotation_strs = []
     for annotation_map in annotation_maps:
       annotation_values = []
       for annotation_name in self._annotation_id_to_annotation_names.get(
@@ -360,8 +357,7 @@ class AnnotationStrBuilder(object):
           annotation_values.append(_MISSING_ANNOTATION_FIELD_VALUE)
         else:
           annotation_values.append(str(value))
-      annotation_strs.append('|'.join(annotation_values))
-    return annotation_strs
+      yield '|'.join(annotation_values)
 
   def is_valid_annotation_id(self, key):
     # type: (str) -> bool

--- a/gcp_variant_transforms/libs/annotation/annotation_parser_test.py
+++ b/gcp_variant_transforms/libs/annotation/annotation_parser_test.py
@@ -42,3 +42,39 @@ class AnnotationParserTest(unittest.TestCase):
     annotation_str = 'some desc-Consequence-IMPACT-SYMBOL-Gene'
     with self.assertRaisesRegexp(ValueError, 'Expected at least one.*'):
       annotation_parser.extract_annotation_names(annotation_str)
+
+
+class AnnotationStrBuilderTest(unittest.TestCase):
+  """Test cases for `AnnotationStrBuilder` class."""
+
+  def test_reconstruct_annotation_str(self):
+    str_builder = annotation_parser.AnnotationStrBuilder({
+        'CSQ': ['allele', 'Consequence', 'AF', 'IMPACT'],
+        'CSQ_2': ['allele', 'Consequence', 'IMPACT']})
+    annotation_maps = [{u'allele': u'G',
+                        u'Consequence': u'upstream_gene_variant',
+                        u'AF': u'',
+                        u'IMPACT': u'MODIFIER'},
+                       {u'allele': u'G',
+                        u'Consequence': u'upstream_gene_variant',
+                        u'AF': u'0.1',
+                        u'IMPACT': u''}]
+
+    expected_annotation_strs = ['G|upstream_gene_variant||MODIFIER',
+                                'G|upstream_gene_variant|0.1|']
+    self.assertEqual(
+        expected_annotation_strs,
+        str_builder.reconstruct_annotation_str('CSQ', annotation_maps)
+    )
+
+  def test_reconstruct_annotation_str_missing_annotation_names(self):
+    str_builder = annotation_parser.AnnotationStrBuilder(None)
+    annotation_maps = [{u'Consequence': u'upstream_gene_variant'}]
+    with self.assertRaises(ValueError):
+      str_builder.reconstruct_annotation_str('CSQ', annotation_maps)
+
+    str_builder = annotation_parser.AnnotationStrBuilder(
+        {'CSQ2': ['Consequence', 'AF']})
+    annotation_maps = [{u'Consequence': u'upstream_gene_variant'}]
+    with self.assertRaises(ValueError):
+      str_builder.reconstruct_annotation_str('CSQ', annotation_maps)

--- a/gcp_variant_transforms/libs/annotation/annotation_parser_test.py
+++ b/gcp_variant_transforms/libs/annotation/annotation_parser_test.py
@@ -64,17 +64,17 @@ class AnnotationStrBuilderTest(unittest.TestCase):
                                 'G|upstream_gene_variant|0.1|']
     self.assertEqual(
         expected_annotation_strs,
-        str_builder.reconstruct_annotation_str('CSQ', annotation_maps)
+        list(str_builder.reconstruct_annotation_str('CSQ', annotation_maps))
     )
 
   def test_reconstruct_annotation_str_missing_annotation_names(self):
     str_builder = annotation_parser.AnnotationStrBuilder(None)
     annotation_maps = [{u'Consequence': u'upstream_gene_variant'}]
     with self.assertRaises(ValueError):
-      str_builder.reconstruct_annotation_str('CSQ', annotation_maps)
+      list(str_builder.reconstruct_annotation_str('CSQ', annotation_maps))
 
     str_builder = annotation_parser.AnnotationStrBuilder(
         {'CSQ2': ['Consequence', 'AF']})
     annotation_maps = [{u'Consequence': u'upstream_gene_variant'}]
     with self.assertRaises(ValueError):
-      str_builder.reconstruct_annotation_str('CSQ', annotation_maps)
+      list(str_builder.reconstruct_annotation_str('CSQ', annotation_maps))

--- a/gcp_variant_transforms/libs/bigquery_vcf_data_converter_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_data_converter_test.py
@@ -703,33 +703,37 @@ class VariantGeneratorTest(unittest.TestCase):
 
   def test_get_variant_info_annotation(self):
     variant_generator = bigquery_vcf_data_converter.VariantGenerator({
-        'CSQ': ['Consequence', 'AF', 'IMPACT']
+        'CSQ': ['allele', 'Consequence', 'AF', 'IMPACT']
     })
     row = {
         unicode(ColumnKeyConstants.ALTERNATE_BASES): [
             {
-                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('G'),
+                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): u'G',
                 unicode('CSQ'): [
-                    {u'Consequence': u'upstream_gene_variant',
+                    {u'allele': 'G',
+                     u'Consequence': u'upstream_gene_variant',
                      u'AF': u'',
                      u'IMPACT': u'MODIFIER'},
-                    {u'Consequence': u'upstream_gene_variant',
+                    {u'allele': 'G',
+                     u'Consequence': u'upstream_gene_variant',
                      u'AF': u'0.1',
                      u'IMPACT': u''}]
             },
             {
-                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('T'),
+                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): u'T',
                 unicode('CSQ'): [
-                    {u'Consequence': u'',
+                    {u'allele': 'T',
+                     u'Consequence': u'',
                      u'AF': u'',
                      u'IMPACT': u'MODIFIER'},
-                    {u'Consequence': u'upstream_gene_variant',
+                    {u'allele': 'T',
+                     u'Consequence': u'upstream_gene_variant',
                      u'AF': u'0.6',
                      u'IMPACT': u''}]
 
             },
             {
-                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('TT'),
+                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): u'TT',
                 unicode('CSQ'): []
             }
         ]
@@ -744,14 +748,6 @@ class VariantGeneratorTest(unittest.TestCase):
     }
     self.assertEqual(expected_variant_info,
                      variant_generator._get_variant_info(row))
-
-  def test_get_variant_info_annotation_missing_annotation_names(self):
-    row = {
-        unicode(ColumnKeyConstants.ALTERNATE_BASES): [
-            {unicode('CSQ'): [{u'Consequence': u'upstream_gene_variant'}]}]
-    }
-    with self.assertRaises(ValueError):
-      self._variant_generator._get_variant_info(row)
 
   def test_get_variant_calls(self):
     variant_call_records = _get_big_query_row()[ColumnKeyConstants.CALLS]

--- a/gcp_variant_transforms/libs/bigquery_vcf_data_converter_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_data_converter_test.py
@@ -701,6 +701,58 @@ class VariantGeneratorTest(unittest.TestCase):
     self.assertEqual(expected_variant_info,
                      self._variant_generator._get_variant_info(row))
 
+  def test_get_variant_info_annotation(self):
+    variant_generator = bigquery_vcf_data_converter.VariantGenerator({
+        'CSQ': ['Consequence', 'AF', 'IMPACT']
+    })
+    row = {
+        unicode(ColumnKeyConstants.ALTERNATE_BASES): [
+            {
+                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('G'),
+                unicode('CSQ'): [
+                    {u'Consequence': u'upstream_gene_variant',
+                     u'AF': u'',
+                     u'IMPACT': u'MODIFIER'},
+                    {u'Consequence': u'upstream_gene_variant',
+                     u'AF': u'0.1',
+                     u'IMPACT': u''}]
+            },
+            {
+                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('T'),
+                unicode('CSQ'): [
+                    {u'Consequence': u'',
+                     u'AF': u'',
+                     u'IMPACT': u'MODIFIER'},
+                    {u'Consequence': u'upstream_gene_variant',
+                     u'AF': u'0.6',
+                     u'IMPACT': u''}]
+
+            },
+            {
+                unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('TT'),
+                unicode('CSQ'): []
+            }
+        ]
+    }
+
+    expected_variant_info = {
+        'CSQ': [
+            'G|upstream_gene_variant||MODIFIER',
+            'G|upstream_gene_variant|0.1|',
+            'T|||MODIFIER',
+            'T|upstream_gene_variant|0.6|']
+    }
+    self.assertEqual(expected_variant_info,
+                     variant_generator._get_variant_info(row))
+
+  def test_get_variant_info_annotation_missing_annotation_names(self):
+    row = {
+        unicode(ColumnKeyConstants.ALTERNATE_BASES): [
+            {unicode('CSQ'): [{u'Consequence': u'upstream_gene_variant'}]}]
+    }
+    with self.assertRaises(ValueError):
+      self._variant_generator._get_variant_info(row)
+
   def test_get_variant_calls(self):
     variant_call_records = _get_big_query_row()[ColumnKeyConstants.CALLS]
 

--- a/gcp_variant_transforms/testing/bigquery_schema_util.py
+++ b/gcp_variant_transforms/testing/bigquery_schema_util.py
@@ -78,12 +78,12 @@ def get_sample_table_schema(with_annotation_fields=False):
         mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
         description='desc')
     annotation_record.fields.append(bigquery.TableFieldSchema(
-        name='allele',
+        name='Consequence',
         type=bigquery_util.TableFieldConstants.TYPE_STRING,
         mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
         description='desc.'))
     annotation_record.fields.append(bigquery.TableFieldSchema(
-        name='Consequence',
+        name='IMPACT',
         type=bigquery_util.TableFieldConstants.TYPE_STRING,
         mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
         description='desc.'))
@@ -142,22 +142,20 @@ def get_sample_table_schema(with_annotation_fields=False):
       description='desc'))
   schema.fields.append(calls_record)
 
-  # Call record.
-  call_record = bigquery.TableFieldSchema(
-      name=bigquery_util.ColumnKeyConstants.CALLS,
-      type=bigquery_util.TableFieldConstants.TYPE_RECORD,
-      mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
-      description='One record for each call.')
-  call_record.fields.append(bigquery.TableFieldSchema(
-      name='FB',
-      type=bigquery_util.TableFieldConstants.TYPE_BOOLEAN,
-      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
-      description='desc'))
-  call_record.fields.append(bigquery.TableFieldSchema(
-      name='GQ',
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='II',
       type=bigquery_util.TableFieldConstants.TYPE_INTEGER,
       mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description='desc'))
-  schema.fields.append(call_record)
-  
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IFR',
+      type=bigquery_util.TableFieldConstants.TYPE_FLOAT,
+      mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
+      description='desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IS',
+      type=bigquery_util.TableFieldConstants.TYPE_STRING,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+      description='desc'))
+
   return schema

--- a/gcp_variant_transforms/testing/bigquery_schema_util.py
+++ b/gcp_variant_transforms/testing/bigquery_schema_util.py
@@ -21,7 +21,7 @@ from apache_beam.io.gcp.internal.clients import bigquery
 from gcp_variant_transforms.libs import bigquery_util
 
 
-def get_sample_table_schema():
+def get_sample_table_schema(with_annotation_fields=False):
   # type: () -> bigquery.TableSchema
   """Creates a sample BigQuery table schema.
 
@@ -70,6 +70,24 @@ def get_sample_table_schema():
       type=bigquery_util.TableFieldConstants.TYPE_FLOAT,
       mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description='desc'))
+
+  if with_annotation_fields:
+    annotation_record = bigquery.TableFieldSchema(
+        name='CSQ',
+        type=bigquery_util.TableFieldConstants.TYPE_RECORD,
+        mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
+        description='desc')
+    annotation_record.fields.append(bigquery.TableFieldSchema(
+        name='allele',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='desc.'))
+    annotation_record.fields.append(bigquery.TableFieldSchema(
+        name='Consequence',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='desc.'))
+    alternate_bases_record.fields.append(annotation_record)
 
   schema.fields.append(alternate_bases_record)
   schema.fields.append(bigquery.TableFieldSchema(
@@ -124,20 +142,22 @@ def get_sample_table_schema():
       description='desc'))
   schema.fields.append(calls_record)
 
-  schema.fields.append(bigquery.TableFieldSchema(
-      name='II',
+  # Call record.
+  call_record = bigquery.TableFieldSchema(
+      name=bigquery_util.ColumnKeyConstants.CALLS,
+      type=bigquery_util.TableFieldConstants.TYPE_RECORD,
+      mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
+      description='One record for each call.')
+  call_record.fields.append(bigquery.TableFieldSchema(
+      name='FB',
+      type=bigquery_util.TableFieldConstants.TYPE_BOOLEAN,
+      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+      description='desc'))
+  call_record.fields.append(bigquery.TableFieldSchema(
+      name='GQ',
       type=bigquery_util.TableFieldConstants.TYPE_INTEGER,
       mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description='desc'))
-  schema.fields.append(bigquery.TableFieldSchema(
-      name='IFR',
-      type=bigquery_util.TableFieldConstants.TYPE_FLOAT,
-      mode=bigquery_util.TableFieldConstants.MODE_REPEATED,
-      description='desc'))
-  schema.fields.append(bigquery.TableFieldSchema(
-      name='IS',
-      type=bigquery_util.TableFieldConstants.TYPE_STRING,
-      mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
-      description='desc'))
-
+  schema.fields.append(call_record)
+  
   return schema

--- a/gcp_variant_transforms/transforms/bigquery_to_variant.py
+++ b/gcp_variant_transforms/transforms/bigquery_to_variant.py
@@ -14,6 +14,8 @@
 
 """A PTransform to convert BigQuery table rows to a PCollection of `Variant`."""
 
+from typing import Dict, List  # pylint: disable=unused-import
+
 import apache_beam as beam
 
 from gcp_variant_transforms.libs import bigquery_vcf_data_converter
@@ -22,8 +24,19 @@ from gcp_variant_transforms.libs import bigquery_vcf_data_converter
 class BigQueryToVariant(beam.PTransform):
   """Transforms BigQuery table rows to PCollection of `Variant`."""
 
-  def __init__(self):
-    self._variant_generator = bigquery_vcf_data_converter.VariantGenerator()
+  def __init__(self, annotation_id_to_annotation_names=None):
+    # type: (Dict[str, List[str]]) -> None
+    """Initializes a `BigQueryToVariant` object.
+
+    Args:
+      annotation_id_to_annotation_names: A map where the key is the annotation
+        id (e.g., `CSQ`) and the value is a list of annotation names (e.g.,
+        ['Consequence', 'IMPACT', 'SYMBOL']). The annotation str (e.g.,
+        'A|upstream_gene_variant|MODIFIER|PSMF1|||||') is reconstructed in the
+        same order as the annotation names.
+    """
+    self._variant_generator = bigquery_vcf_data_converter.VariantGenerator(
+        annotation_id_to_annotation_names)
 
   def expand(self, pcoll):
     return (pcoll | 'BigQueryToVariant' >> beam.Map(


### PR DESCRIPTION
For BigQuery to VCF pipeline, this PR
- Support the exporting of annotations if there are annotation fields in BigQuery table. 
- Fixed on bug on utf-8 unicode.


Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests & manually ran the BQ to VCF.