### PR TITLE
Add support for vcf header in BQ to VCF pipeline

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_header_io.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io.py
@@ -264,7 +264,7 @@ class WriteVcfHeaderFn(beam.DoFn):
   """A DoFn for writing VCF headers to a file."""
 
   HEADER_TEMPLATE = '##{}=<{}>\n'
-  FINAL_HEADER_LINE = '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT'
+  FINAL_HEADER_LINE = '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT\n'
 
   def __init__(self, file_path):
     # type: (str) -> None

--- a/gcp_variant_transforms/beam_io/vcf_header_io.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io.py
@@ -260,11 +260,11 @@ class _HeaderFieldKeyConstants(object):
   LENGTH = 'length'
 
 
-class _WriteVcfHeaderFn(beam.DoFn):
+class WriteVcfHeaderFn(beam.DoFn):
   """A DoFn for writing VCF headers to a file."""
 
   HEADER_TEMPLATE = '##{}=<{}>\n'
-  FINAL_HEADER_LINE = '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT\n'
+  FINAL_HEADER_LINE = '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT'
 
   def __init__(self, file_path):
     # type: (str) -> None
@@ -411,4 +411,4 @@ class WriteVcfHeaders(PTransform):
     self._file_path = file_path
 
   def expand(self, pcoll):
-    return pcoll | beam.ParDo(_WriteVcfHeaderFn(self._file_path))
+    return pcoll | beam.ParDo(WriteVcfHeaderFn(self._file_path))

--- a/gcp_variant_transforms/beam_io/vcf_header_io_test.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io_test.py
@@ -29,7 +29,7 @@ from gcp_variant_transforms.beam_io.vcf_header_io import VcfHeaderSource
 from gcp_variant_transforms.beam_io.vcf_header_io import ReadAllVcfHeaders
 from gcp_variant_transforms.beam_io.vcf_header_io import ReadVcfHeaders
 from gcp_variant_transforms.beam_io.vcf_header_io import VcfHeader
-from gcp_variant_transforms.beam_io.vcf_header_io import _WriteVcfHeaderFn
+from gcp_variant_transforms.beam_io.vcf_header_io import WriteVcfHeaderFn
 from gcp_variant_transforms.beam_io.vcf_header_io import WriteVcfHeaders
 from gcp_variant_transforms.testing import asserts
 from gcp_variant_transforms.testing import temp_dir
@@ -211,7 +211,7 @@ class WriteVcfHeadersTest(unittest.TestCase):
     self.lines = testdata_util.get_sample_vcf_header_lines()
 
   def test_to_vcf_header_line(self):
-    header_fn = _WriteVcfHeaderFn('')
+    header_fn = WriteVcfHeaderFn('')
     header = collections.OrderedDict([
         ('id', 'NS'),
         ('num', 1),
@@ -225,14 +225,14 @@ class WriteVcfHeadersTest(unittest.TestCase):
                      expected)
 
   def test_raises_error_for_invalid_key(self):
-    header_fn = _WriteVcfHeaderFn('')
+    header_fn = WriteVcfHeaderFn('')
     header = collections.OrderedDict([('number', 0)])
 
     with self.assertRaises(ValueError):
       header_fn._format_header_key_value('number', header['number'])
 
   def test_raises_error_for_invalid_num(self):
-    header_fn = _WriteVcfHeaderFn('')
+    header_fn = WriteVcfHeaderFn('')
     header = collections.OrderedDict([('num', -4)])
 
     with self.assertRaises(ValueError):
@@ -245,7 +245,7 @@ class WriteVcfHeadersTest(unittest.TestCase):
         self.lines[-1]
     ]
     header = _get_vcf_header_from_lines(self.lines)
-    header_fn = _WriteVcfHeaderFn('')
+    header_fn = WriteVcfHeaderFn('')
     actual = header_fn._to_vcf_header_line('INFO', header.infos.values()[0])
     expected = self.lines[0]
     self.assertEqual(actual, expected)
@@ -256,7 +256,7 @@ class WriteVcfHeadersTest(unittest.TestCase):
         self.lines[-1],
     ]
     header = _get_vcf_header_from_lines(self.lines)
-    header_fn = _WriteVcfHeaderFn('')
+    header_fn = WriteVcfHeaderFn('')
     actual = header_fn._to_vcf_header_line('contig', header.contigs.values()[0])
     expected = '##contig=<ID=M,length=16>\n'
     self.assertEqual(actual, expected)
@@ -270,7 +270,7 @@ class WriteVcfHeadersTest(unittest.TestCase):
         self.lines[-1],
     ]
     header = _get_vcf_header_from_lines(self.lines)
-    header_fn = _WriteVcfHeaderFn('')
+    header_fn = WriteVcfHeaderFn('')
     actual = []
     for info in header.infos.values():
       actual.append(header_fn._to_vcf_header_line('INFO', info))
@@ -281,7 +281,7 @@ class WriteVcfHeadersTest(unittest.TestCase):
     header = _get_vcf_header_from_lines(self.lines)
     with temp_dir.TempDir() as tempdir:
       tempfile = tempdir.create_temp_file(suffix='.vcf')
-      header_fn = _WriteVcfHeaderFn(tempfile)
+      header_fn = WriteVcfHeaderFn(tempfile)
       header_fn.process(header)
       self._assert_file_contents_equal(tempfile, self.lines)
 

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -42,6 +42,7 @@ from apache_beam.io.gcp import bigquery
 from apache_beam.options import pipeline_options
 
 from gcp_variant_transforms import vcf_to_bq_common
+from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs import vcf_file_composer
@@ -53,8 +54,6 @@ from gcp_variant_transforms.transforms import densify_variants
 
 _BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`;'
 _COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
-_VCF_FIXED_COLUMNS = ['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER',
-                      'INFO', 'FORMAT']
 
 
 def run(argv=None):
@@ -73,28 +72,41 @@ def run(argv=None):
   vcf_data_temp_folder = filesystems.FileSystems.join(
       google_cloud_options.temp_location,
       'bq_to_vcf_data_temp_files_{}'.format(timestamp_str))
-  vcf_data_header_file_path = filesystems.FileSystems.join(
+  vcf_call_names_file_path = filesystems.FileSystems.join(
       google_cloud_options.temp_location,
-      'bq_to_vcf_data_header_{}'.format(timestamp_str))
+      'bq_to_vcf_call_names_{}'.format(timestamp_str))
+
+  if not known_args.representative_header_file:
+    known_args.representative_header_file = filesystems.FileSystems.join(
+        google_cloud_options.temp_location,
+        'bq_to_vcf_header_{}'.format(timestamp_str))
+    _write_vcf_header(known_args.representative_header_file)
 
   _bigquery_to_vcf_shards(known_args,
                           options,
                           vcf_data_temp_folder,
-                          vcf_data_header_file_path)
+                          vcf_call_names_file_path)
+
   vcf_file_composer.compose_vcf_shards(google_cloud_options.project,
-                                       vcf_data_header_file_path,
+                                       known_args.representative_header_file,
+                                       vcf_call_names_file_path,
                                        vcf_data_temp_folder,
                                        known_args.output_file)
 
-  # TODO(allieychen): Eventually, it further consolidates the meta information
-  # into the `output_file`.
+
+def _write_vcf_header(representative_header_file):
+  # TODO(allieychen): infer the meta information from the schema and replace the
+  # empty `VcfHeader` below.
+  header_fields = vcf_header_io.VcfHeader()
+  write_header_fn = vcf_header_io.WriteVcfHeaderFn(representative_header_file)
+  write_header_fn.process(header_fields)
 
 
 def _bigquery_to_vcf_shards(
     known_args,  # type: argparse.Namespace
     beam_pipeline_options,  # type: pipeline_options.PipelineOptions
     vcf_data_temp_folder,  # type: str
-    vcf_data_header_file_path,  # type: str
+    call_names_file_path,  # type: str
     ):
   # type: (...) -> None
   """Runs BigQuery to VCF shards pipelines.
@@ -105,8 +117,7 @@ def _bigquery_to_vcf_shards(
   writes to one VCF file. All VCF data files are saved in
   `vcf_data_temp_folder`.
 
-  Also, it writes the data header to `vcf_data_header_file_path`.
-  TODO(allieychen): Eventually, it also generates the meta information file.
+  Also, it writes the call names to `call_names_file_path`.
   """
   bq_source = bigquery.BigQuerySource(
       query=_BASE_QUERY_TEMPLATE.format(
@@ -125,9 +136,7 @@ def _bigquery_to_vcf_shards(
 
     _ = (call_names
          | 'GenerateVcfDataHeader' >>
-         beam.ParDo(_write_vcf_data_header,
-                    _VCF_FIXED_COLUMNS,
-                    vcf_data_header_file_path))
+         beam.ParDo(_write_call_names, call_names_file_path))
 
     _ = (variants
          | densify_variants.DensifyVariants(beam.pvalue.AsSingleton(call_names))
@@ -138,24 +147,22 @@ def _bigquery_to_vcf_shards(
          | vcfio.WriteVcfDataLines())
 
 
-def _write_vcf_data_header(sample_names, vcf_fixed_columns, file_path):
-  # type: (List[str], List[str], str) -> None
-  """Writes VCF data header.
+def _write_call_names(call_names, file_path):
+  # type: (List[str], str) -> None
+  """Writes call names.
 
-  It writes the header line with ` vcf_fixed_columns`, followed by sample
-  names in `sample_names`. Example:
-  #CHROM  POS  ID  REF  ALT  QUAL  FILTER  INFO  SAMPLE1  SAMPLE2
+  It writes the call names in `call_names`. Example:
+    SAMPLE1  SAMPLE2  SAMPLE3
 
   Args:
-    sample_names: The sample names appended to `vcf_fixed_columns`.
-    vcf_fixed_columns: The VCF fixed columns.
-    file_path: The location where the data header line is saved.
+    call_names: The call names in the header line.
+    file_path: The location where the call names is saved.
   """
   # pylint: disable=redefined-outer-name,reimported
   from apache_beam.io import filesystems
   with filesystems.FileSystems.create(file_path) as file_to_write:
     file_to_write.write(
-        str('\t'.join(vcf_fixed_columns + sample_names)))
+        str(''.join(['\t' + call_name for call_name in call_names])))
     file_to_write.write('\n')
 
 

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -26,12 +26,30 @@ class BqToVcfTest(unittest.TestCase):
   """Test cases for the `bq_to_vcf` module."""
 
   def test_write_vcf_data_header(self):
+    lines = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+        '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
+        '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="GQ">\n',
+        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	\n']
     with temp_dir.TempDir() as tempdir:
+      representative_header = tempdir.create_temp_file(lines=lines)
       file_path = filesystems.FileSystems.join(tempdir.get_path(),
                                                'data_header')
-      bq_to_vcf._write_call_names(['Sample 1', 'Sample 2'],
-                                  file_path)
-      expected_content = '\tSample 1\tSample 2\n'
+      bq_to_vcf._write_vcf_header_with_call_names(
+          ['Sample 1', 'Sample 2'],
+          ['#CHROM', 'POS', 'ID', 'REF', 'ALT'],
+          representative_header,
+          file_path)
+      expected_content = [
+          '##fileformat=VCFv4.2\n',
+          '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+          '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
+          '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
+          '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="GQ">\n',
+          '#CHROM\tPOS\tID\tREF\tALT\tSample 1\tSample 2\n'
+      ]
       with filesystems.FileSystems.open(file_path) as f:
         content = f.readlines()
-        self.assertEqual(content, [expected_content])
+        self.assertEqual(content, expected_content)

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -29,10 +29,9 @@ class BqToVcfTest(unittest.TestCase):
     with temp_dir.TempDir() as tempdir:
       file_path = filesystems.FileSystems.join(tempdir.get_path(),
                                                'data_header')
-      bq_to_vcf._write_vcf_data_header(['Sample 1', 'Sample 2'],
-                                       ['#CHROM', 'POS', 'ID', 'REF', 'ALT'],
-                                       file_path)
-      expected_content = '#CHROM\tPOS\tID\tREF\tALT\tSample 1\tSample 2\n'
+      bq_to_vcf._write_call_names(['Sample 1', 'Sample 2'],
+                                  file_path)
+      expected_content = '\tSample 1\tSample 2\n'
       with filesystems.FileSystems.open(file_path) as f:
         content = f.readlines()
         self.assertEqual(content, [expected_content])

--- a/gcp_variant_transforms/libs/vcf_file_composer.py
+++ b/gcp_variant_transforms/libs/vcf_file_composer.py
@@ -27,7 +27,8 @@ _MAX_NUM_OF_BLOBS_PER_COMPOSE = 32
 
 
 def compose_vcf_shards(project,  # type: str
-                       vcf_data_header_file_path,  # type: str
+                       vcf_header_file,  # type: str
+                       call_names_file_path,  # type: str
                        vcf_data_files_folder,  # type: str
                        output_file,  # type: str
                        delete=True,  # type: bool
@@ -35,37 +36,42 @@ def compose_vcf_shards(project,  # type: str
   # type: (...) -> None
   """Composes VCF shards to one VCF file.
 
-  It composes VCF data header and VCF data files to one VCF file, and deletes
-  the original VCF shards if `delete` is True.
-  TODO(allieychen): Eventually, it further consolidates the meta information,
-  into the `output_file`.
+  It composes VCF header, call names, and VCF data files to one VCF file, and
+  deletes the original VCF shards if `delete` is True.
+
 
   Args:
     project: The project name.
-    vcf_data_header_file_path: The path of the VCF data header file.
+    vcf_header_file: The path of the VCF header file.
+    call_names_file_path: The file path that contains the call names.
     vcf_data_files_folder: The folder that contains all VCF data files.
     output_file: The final VCF file path.
     delete: If true, delete the original VCF shards.
   """
+  header_bucket_name, header_blob = gcsio.parse_gcs_path(vcf_header_file)
   vcf_data_bucket_name, vcf_data_blob_prefix = gcsio.parse_gcs_path(
       vcf_data_files_folder)
-  vcf_data_header_bucket_name, vcf_data_header_blob_name = gcsio.parse_gcs_path(
-      vcf_data_header_file_path)
-  if vcf_data_bucket_name != vcf_data_header_bucket_name:
-    raise ValueError('The VCF data files {} and data header file {} are in '
-                     'different buckets. '.format(vcf_data_files_folder,
-                                                  vcf_data_header_file_path))
+  call_names_bucket_name, call_names_blob_name = gcsio.parse_gcs_path(
+      call_names_file_path)
+  if (vcf_data_bucket_name != call_names_bucket_name or
+      vcf_data_bucket_name != header_bucket_name):
+    raise ValueError(
+        'The VCF header file {}, VCF data files {}, call names file {} '
+        'must be in the same bucket. '.format(vcf_header_file,
+                                              vcf_data_files_folder,
+                                              call_names_file_path))
 
   composed_vcf_data_blob = _compose_vcf_data_files(project,
                                                    vcf_data_files_folder)
   client = storage.Client(project)
   bucket = client.get_bucket(vcf_data_bucket_name)
   output_file_blob = _create_blob(client, output_file)
-  output_file_blob.compose([bucket.get_blob(vcf_data_header_blob_name),
+  output_file_blob.compose([bucket.get_blob(header_blob),
+                            bucket.get_blob(call_names_blob_name),
                             composed_vcf_data_blob])
   if delete:
     bucket.delete_blobs(bucket.list_blobs(prefix=vcf_data_blob_prefix))
-    bucket.delete_blobs(bucket.list_blobs(prefix=vcf_data_header_blob_name))
+    bucket.delete_blobs(bucket.list_blobs(prefix=call_names_blob_name))
 
 
 def _compose_vcf_data_files(project, vcf_data_files_folder):

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -473,3 +473,7 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
               'within a contiguous region of the genome. This parameter will '
               'have an impact on memory requirements since the data in a '
               'single shard must be sorted.'))
+    parser.add_argument(
+        '--representative_header_file',
+        help='If provided, header values from the provided file will be added '
+             'into the output_file. ')

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -475,5 +475,5 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
               'single shard must be sorted.'))
     parser.add_argument(
         '--representative_header_file',
-        help='If provided, header values from the provided file will be added '
-             'into the output_file. ')
+        help=('If provided, meta-information from the provided file will be '
+              'added into the output_file. '))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -476,4 +476,4 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
     parser.add_argument(
         '--representative_header_file',
         help=('If provided, meta-information from the provided file will be '
-              'added into the output_file. '))
+              'added into the output_file.'))


### PR DESCRIPTION
In BQ to VCF pipeline
- Add one flag for the header.
- Write the meta-information and the data header (include the fixed VCF columns ( '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT), and the call names) to VCF header file. A complete VCF will be the composition of VCF header file and VCF data file.

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests.