### PR TITLE
Update integration tests.

### DIFF
--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
@@ -57,28 +57,28 @@
           "SELECT COUNT(DISTINCT CSQ.Feature) AS num_features ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ"
         ],
-        "expected_result": {"num_features": 74}
+        "expected_result": {"num_features": 73}
       },
       {
         "query": [
           "SELECT COUNT(DISTINCT CSQ_VT.Feature) AS num_features ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
         ],
-        "expected_result": {"num_features": 71}
+        "expected_result": {"num_features": 70}
       },
       {
         "query": [
           "SELECT COUNT(DISTINCT CSQ.SYMBOL) AS num_symbol ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ"
         ],
-        "expected_result": {"num_symbol": 13}
+        "expected_result": {"num_symbol": 12}
       },
       {
         "query": [
           "SELECT COUNT(DISTINCT CSQ_VT.SYMBOL) AS num_symbol ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
         ],
-        "expected_result": {"num_symbol": 13}
+        "expected_result": {"num_symbol": 12}
       }
     ]
   }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
@@ -56,28 +56,28 @@
           "SELECT COUNT(DISTINCT CSQ.Feature) AS num_features ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ"
         ],
-        "expected_result": {"num_features": 1576}
+        "expected_result": {"num_features": 1575}
       },
       {
         "query": [
           "SELECT COUNT(DISTINCT CSQ_VT.Feature) AS num_features ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
         ],
-        "expected_result": {"num_features": 1576}
+        "expected_result": {"num_features": 1575}
       },
       {
         "query": [
           "SELECT COUNT(DISTINCT CSQ.SYMBOL) AS num_symbol ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ"
         ],
-        "expected_result": {"num_symbol": 207}
+        "expected_result": {"num_symbol": 206}
       },
       {
         "query": [
           "SELECT COUNT(DISTINCT CSQ_VT.SYMBOL) AS num_symbol ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
         ],
-        "expected_result": {"num_symbol": 207}
+        "expected_result": {"num_symbol": 206}
       }
     ]
   }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_NA12877_hg38_10K_lines.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_NA12877_hg38_10K_lines.json
@@ -34,14 +34,14 @@
           "SELECT COUNT(DISTINCT CSQ.Feature) AS num_features ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ"
         ],
-        "expected_result": {"num_features": 1576}
+        "expected_result": {"num_features": 1575}
       },
       {
         "query": [
           "SELECT COUNT(DISTINCT CSQ.SYMBOL) AS num_symbol ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ"
         ],
-        "expected_result": {"num_symbol": 207}
+        "expected_result": {"num_symbol": 206}
       }
     ]
   }


### PR DESCRIPTION
The infer_annotation_types PR changed empty strings in BQ to null 
values. Several tests counting distict values needed to have `1` 
subtracted from their expected values.