### PR TITLE
Rollback two integration test changes.

### DIFF
--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
@@ -57,14 +57,14 @@
           "SELECT COUNT(DISTINCT CSQ.Feature) AS num_features ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ"
         ],
-        "expected_result": {"num_features": 73}
+        "expected_result": {"num_features": 74}
       },
       {
         "query": [
           "SELECT COUNT(DISTINCT CSQ_VT.Feature) AS num_features ",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
         ],
-        "expected_result": {"num_features": 70}
+        "expected_result": {"num_features": 71}
       },
       {
         "query": [


### PR DESCRIPTION
These changes should not have been made and accidentally were not 
checked. `./deploy_and_run_tests.sh --keep_table --run_presubmit_tests` now succeeds.