### PR TITLE
refactor code for BigQuery row to variant

### DIFF
--- a/gcp_variant_transforms/libs/bigquery_vcf_data_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_data_converter.py
@@ -242,7 +242,7 @@ class BigQueryRowGenerator(object):
 
 
 class VariantGenerator(object):
-  """Class to generate BigQuery row from a variant."""
+  """Class to generate variant from one BigQuery row."""
 
   def convert_bq_row_to_variant(self, row):
     """Converts one BigQuery row to `Variant`."""

--- a/gcp_variant_transforms/libs/bigquery_vcf_data_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_data_converter.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Handles generating BigQuery row from variants."""
+"""Handles the conversion between BigQuery row and variant."""
 
 from __future__ import absolute_import
 
 import copy
 import json
-from typing import Any, Dict  # pylint: disable=unused-import
+from typing import Any, Dict, List  # pylint: disable=unused-import
 
 from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import bigquery_schema_descriptor  # pylint: disable=unused-import
@@ -37,6 +37,23 @@ _MAX_BIGQUERY_ROW_SIZE_BYTES = 10 * 1024 * 1024 - 10 * 1024
 # to account for ", "). We use 5 bytes to be conservative.
 _JSON_CONCATENATION_OVERHEAD_BYTES = 5
 _BigQuerySchemaSanitizer = bigquery_sanitizer.SchemaSanitizer
+
+# Reserved constants for column names in the BigQuery schema.
+RESERVED_BQ_COLUMNS = [bigquery_util.ColumnKeyConstants.REFERENCE_NAME,
+                       bigquery_util.ColumnKeyConstants.START_POSITION,
+                       bigquery_util.ColumnKeyConstants.END_POSITION,
+                       bigquery_util.ColumnKeyConstants.REFERENCE_BASES,
+                       bigquery_util.ColumnKeyConstants.ALTERNATE_BASES,
+                       bigquery_util.ColumnKeyConstants.NAMES,
+                       bigquery_util.ColumnKeyConstants.QUALITY,
+                       bigquery_util.ColumnKeyConstants.FILTER,
+                       bigquery_util.ColumnKeyConstants.CALLS]
+
+RESERVED_VARIANT_CALL_COLUMNS = [
+    bigquery_util.ColumnKeyConstants.CALLS_NAME,
+    bigquery_util.ColumnKeyConstants.CALLS_GENOTYPE,
+    bigquery_util.ColumnKeyConstants.CALLS_PHASESET
+]
 
 
 class BigQueryRowGenerator(object):
@@ -222,3 +239,70 @@ class BigQueryRowGenerator(object):
 
   def _get_json_object_size(self, obj):
     return len(json.dumps(obj))
+
+
+class VariantGenerator(object):
+  """Class to generate BigQuery row from a variant."""
+
+  def convert_bq_row_to_variant(self, row):
+    """Converts one BigQuery row to `Variant`."""
+    # type: (Dict[str, Any]) -> vcfio.Variant
+    return vcfio.Variant(
+        reference_name=row[bigquery_util.ColumnKeyConstants.REFERENCE_NAME],
+        start=row[bigquery_util.ColumnKeyConstants.START_POSITION],
+        end=row[bigquery_util.ColumnKeyConstants.END_POSITION],
+        reference_bases=row[bigquery_util.ColumnKeyConstants.REFERENCE_BASES],
+        alternate_bases=self._get_alternate_bases(
+            row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES]),
+        names=row[bigquery_util.ColumnKeyConstants.NAMES],
+        quality=row[bigquery_util.ColumnKeyConstants.QUALITY],
+        filters=row[bigquery_util.ColumnKeyConstants.FILTER],
+        info=self._get_variant_info(row),
+        calls=self._get_variant_calls(
+            row[bigquery_util.ColumnKeyConstants.CALLS])
+    )
+
+  def _get_alternate_bases(self, alternate_base_records):
+    # type: (List[Dict[str, Any]]) -> List[str]
+    return [record[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES_ALT]
+            for record in alternate_base_records]
+
+  def _get_variant_info(self, row):
+    # type: (Dict[str, Any]) -> Dict[str, Any]
+    info = {}
+    for key, value in row.iteritems():
+      if key not in RESERVED_BQ_COLUMNS and not self._is_null_or_empty(value):
+        info.update({key: value})
+    for alt_base in row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES]:
+      for key, value in alt_base.iteritems():
+        if (key != bigquery_util.ColumnKeyConstants.ALTERNATE_BASES_ALT and
+            not self._is_null_or_empty(value)):
+          if key not in info:
+            info[key] = []
+          info[key].append(value)
+    return info
+
+  def _get_variant_calls(self, variant_call_records):
+    # type: (List[Dict[str, Any]]) -> List[vcfio.VariantCall]
+    variant_calls = []
+    for call_record in variant_call_records:
+      info = {}
+      for key, value in call_record.iteritems():
+        if (key not in RESERVED_VARIANT_CALL_COLUMNS and
+            not self._is_null_or_empty(value)):
+          info.update({key: value})
+      variant_call = vcfio.VariantCall(
+          name=call_record[bigquery_util.ColumnKeyConstants.CALLS_NAME],
+          genotype=call_record[bigquery_util.ColumnKeyConstants.CALLS_GENOTYPE],
+          phaseset=call_record[bigquery_util.ColumnKeyConstants.CALLS_PHASESET],
+          info=info)
+      variant_calls.append(variant_call)
+    return variant_calls
+
+  def _is_null_or_empty(self, value):
+    # type: (Any) -> bool
+    if value is None:
+      return True
+    if isinstance(value, list) and not value:
+      return True
+    return False

--- a/gcp_variant_transforms/libs/bigquery_vcf_data_converter_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_data_converter_test.py
@@ -12,20 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for bigquery_row_generator module."""
+"""Tests for `bigquery_vcf_data_converter` module."""
 
 from __future__ import absolute_import
 
 import json
 import unittest
-import mock
+from typing import Dict  # pylint: disable=unused-import
 
 from apache_beam.io.gcp.internal.clients import bigquery
 
+import mock
+
 from gcp_variant_transforms.beam_io import vcfio
-from gcp_variant_transforms.libs import bigquery_schema_descriptor
-from gcp_variant_transforms.libs import bigquery_row_generator
 from gcp_variant_transforms.libs import bigquery_sanitizer
+from gcp_variant_transforms.libs import bigquery_schema_descriptor
+from gcp_variant_transforms.libs import bigquery_vcf_data_converter
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
 from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
@@ -49,124 +51,12 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
 
   def setUp(self):
     self._schema_descriptor = bigquery_schema_descriptor.SchemaDescriptor(
-        self._get_table_schema())
+        _get_table_schema())
     self._conflict_resolver = (
         vcf_field_conflict_resolver.FieldConflictResolver())
 
-    self._row_generator = bigquery_row_generator.BigQueryRowGenerator(
+    self._row_generator = bigquery_vcf_data_converter.BigQueryRowGenerator(
         self._schema_descriptor, self._conflict_resolver)
-
-  def _get_table_schema(self):
-    # type (None) -> bigquery.TableSchema
-    schema = bigquery.TableSchema()
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='IB',
-        type=TableFieldConstants.TYPE_BOOLEAN,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='IBR',
-        type=TableFieldConstants.TYPE_BOOLEAN,
-        mode=TableFieldConstants.MODE_REPEATED,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='II',
-        type=TableFieldConstants.TYPE_INTEGER,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='II2',
-        type=TableFieldConstants.TYPE_INTEGER,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='IIR',
-        type=TableFieldConstants.TYPE_INTEGER,
-        mode=TableFieldConstants.MODE_REPEATED,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='IF',
-        type=TableFieldConstants.TYPE_FLOAT,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='IF2',
-        type=TableFieldConstants.TYPE_FLOAT,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='IFR',
-        type=TableFieldConstants.TYPE_FLOAT,
-        mode=TableFieldConstants.MODE_REPEATED,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='IFR2',
-        type=TableFieldConstants.TYPE_FLOAT,
-        mode=TableFieldConstants.MODE_REPEATED,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='field__IS',
-        type=TableFieldConstants.TYPE_STRING,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='IS',
-        type=TableFieldConstants.TYPE_STRING,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='INFO foo desc'))
-    schema.fields.append(bigquery.TableFieldSchema(
-        name='ISR',
-        type=TableFieldConstants.TYPE_STRING,
-        mode=TableFieldConstants.MODE_REPEATED,
-        description='INFO foo desc'))
-    # Call record.
-    call_record = bigquery.TableFieldSchema(
-        name=ColumnKeyConstants.CALLS,
-        type=TableFieldConstants.TYPE_RECORD,
-        mode=TableFieldConstants.MODE_REPEATED,
-        description='One record for each call.')
-    call_record.fields.append(bigquery.TableFieldSchema(
-        name='FB',
-        type=TableFieldConstants.TYPE_BOOLEAN,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='FORMAT foo desc'))
-    call_record.fields.append(bigquery.TableFieldSchema(
-        name='FI',
-        type=TableFieldConstants.TYPE_INTEGER,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='FORMAT foo desc'))
-    call_record.fields.append(bigquery.TableFieldSchema(
-        name='GQ',
-        type=TableFieldConstants.TYPE_INTEGER,
-        mode=TableFieldConstants.MODE_NULLABLE,
-        description='FORMAT foo desc'))
-    call_record.fields.append(bigquery.TableFieldSchema(
-        name='FIR',
-        type=TableFieldConstants.TYPE_INTEGER,
-        mode=TableFieldConstants.MODE_REPEATED,
-        description='FORMAT foo desc'))
-    call_record.fields.append(bigquery.TableFieldSchema(
-        name='FSR',
-        type=TableFieldConstants.TYPE_STRING,
-        mode=TableFieldConstants.MODE_REPEATED,
-        description='FORMAT foo desc'))
-    schema.fields.append(call_record)
-    return schema
-
-  def _get_row_list_from_variant(
-      self, variant, header_num_dict=None, allow_incompatible_records=False,
-      omit_empty_sample_calls=False, **kwargs):
-    # TODO(bashir2): To make this more of a "unit" test, we should create
-    # ProcessedVariant instances directly (instead of Variant) and avoid calling
-    # create_processed_variant here. Then we should also add cases that
-    # have annotation fields.
-    header_fields = vcf_header_util.make_header(header_num_dict or {})
-    proc_var = processed_variant.ProcessedVariantFactory(
-        header_fields).create_processed_variant(variant)
-
-    return list(self._row_generator.get_rows(
-        proc_var, allow_incompatible_records,
-        omit_empty_sample_calls, **kwargs))
 
   def test_all_fields(self):
     variant = vcfio.Variant(
@@ -214,8 +104,9 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
              ColumnKeyConstants.CALLS_PHASESET: None}],
         'IS': 'some data',
         'ISR': ['data1', 'data2']}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     self.assertEqual([expected_row],
-                     self._get_row_list_from_variant(variant, header_num_dict))
+                     list(self._row_generator.get_rows(proc_variant)))
 
   def test_no_alternate_bases(self):
     variant = vcfio.Variant(
@@ -224,6 +115,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         info={'IS': 'some data',
               'ISR': ['data1', 'data2']})
     header_num_dict = {'IS': '1', 'ISR': '2'}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -234,13 +126,15 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         ColumnKeyConstants.CALLS: [],
         'IS': 'some data',
         'ISR': ['data1', 'data2']}
+
     self.assertEqual([expected_row],
-                     self._get_row_list_from_variant(variant, header_num_dict))
+                     list(self._row_generator.get_rows(proc_variant)))
 
   def test_some_fields_set(self):
     variant = vcfio.Variant(
         reference_name='chr19', start=None, end=123, reference_bases=None,
         alternate_bases=[], quality=20)
+    proc_variant = _get_processed_variant(variant)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: None,
@@ -249,11 +143,13 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         ColumnKeyConstants.ALTERNATE_BASES: [],
         ColumnKeyConstants.QUALITY: 20,
         ColumnKeyConstants.CALLS: []}
+
     self.assertEqual([expected_row],
-                     self._get_row_list_from_variant(variant))
+                     list(self._row_generator.get_rows(proc_variant)))
 
   def test_no_field_set(self):
     variant = vcfio.Variant()
+    proc_variant = _get_processed_variant(variant)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: None,
         ColumnKeyConstants.START_POSITION: None,
@@ -262,7 +158,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         ColumnKeyConstants.ALTERNATE_BASES: [],
         ColumnKeyConstants.CALLS: []}
     self.assertEqual([expected_row],
-                     self._get_row_list_from_variant(variant))
+                     list(self._row_generator.get_rows(proc_variant)))
 
   def test_null_repeated_fields(self):
     variant = vcfio.Variant(
@@ -273,6 +169,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
               'IFR': [0.1, 0.2, None, 0.4],
               'ISR': [None, 'data1', 'data2']})
     header_num_dict = {'IIR': '3', 'IBR': '3', 'IFR': '4', 'ISR': '3'}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -291,7 +188,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
                 0.4],
         'ISR': ['.', 'data1', 'data2']}
     self.assertEqual([expected_row],
-                     self._get_row_list_from_variant(variant, header_num_dict))
+                     list(self._row_generator.get_rows(proc_variant)))
 
   def test_unicode_fields(self):
     sample_unicode_str = u'\xc3\xb6'
@@ -302,6 +199,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         info={'IS': sample_utf8_str,
               'ISR': [sample_unicode_str, sample_utf8_str]})
     header_num_dict = {'IS': '1', 'ISR': '2'}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -313,7 +211,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         'IS': sample_unicode_str,
         'ISR': [sample_unicode_str, sample_unicode_str]}
     self.assertEqual([expected_row],
-                     self._get_row_list_from_variant(variant, header_num_dict))
+                     list(self._row_generator.get_rows(proc_variant)))
 
   def test_nonstandard_float_values(self):
     variant = vcfio.Variant(
@@ -327,6 +225,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
               'IF3': [float('-inf'), float('nan'), float('inf'), 1.2]},
     )
     header_num_dict = {'IF': '1', 'IFR': '3', 'IF2': '1', 'IF3': 'A'}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -353,7 +252,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         'IF2': None
     }
     self.assertEqual([expected_row],
-                     self._get_row_list_from_variant(variant, header_num_dict))
+                     list(self._row_generator.get_rows(proc_variant)))
 
   def test_nonstandard_fields_names(self):
     variant = vcfio.Variant(
@@ -362,6 +261,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         info={'IS': 'data1',
               '_IS': 'data2'})
     header_num_dict = {'IS': '1', '_IS': '2'}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -372,7 +272,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         'IS': 'data1',
         'field__IS': 'data2'}
     self.assertEqual([expected_row],
-                     self._get_row_list_from_variant(variant, header_num_dict))
+                     list(self._row_generator.get_rows(proc_variant)))
 
   def test_sharded_rows(self):
     variant = vcfio.Variant(
@@ -393,6 +293,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
                 name='Sample3', genotype=[1, 0],
                 info={'GQ': 30, 'FB': True})])
     header_num_dict = {'IFR': 'A', 'IFR2': 'A', 'IS': '1'}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     expected_rows = [
         {
             ColumnKeyConstants.REFERENCE_NAME: 'chr19',
@@ -439,12 +340,11 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
             'IS': 'some data'
         },
     ]
-    with mock.patch.object(bigquery_row_generator,
+    with mock.patch.object(bigquery_vcf_data_converter,
                            '_MAX_BIGQUERY_ROW_SIZE_BYTES',
                            len(json.dumps(expected_rows[0])) + 10):
       self.assertEqual(expected_rows,
-                       self._get_row_list_from_variant(variant,
-                                                       header_num_dict))
+                       list(self._row_generator.get_rows(proc_variant)))
 
   def test_omit_empty_sample_calls(self):
     variant = vcfio.Variant(
@@ -461,6 +361,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
             vcfio.VariantCall(
                 name='Sample3', genotype=[vcfio.MISSING_GENOTYPE_VALUE,
                                           vcfio.MISSING_GENOTYPE_VALUE])])
+    proc_variant = _get_processed_variant(variant)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -478,8 +379,8 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
 
     self.assertEqual(
         [expected_row],
-        self._get_row_list_from_variant(variant,
-                                        omit_empty_sample_calls=True))
+        list(self._row_generator.get_rows(proc_variant,
+                                          omit_empty_sample_calls=True)))
 
   def test_schema_conflict_in_info_field_type(self):
     variant = vcfio.Variant(
@@ -490,6 +391,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
               'IFR': [1, 2],
               'ISR': [1.0, 2.0]})
     header_num_dict = {'IB': '1', 'II': '1', 'IFR': '2', 'ISR': '2'}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -501,8 +403,9 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         'II': 1,
         'IFR': [1.0, 2.0],
         'ISR': ['1.0', '2.0']}
-    self.assertEqual([expected_row], self._get_row_list_from_variant(
-        variant, header_num_dict, allow_incompatible_records=True))
+    self.assertEqual([expected_row],
+                     list(self._row_generator.get_rows(
+                         proc_variant, allow_incompatible_records=True)))
 
     with self.assertRaises(ValueError):
       variant = vcfio.Variant(
@@ -511,8 +414,11 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
           # String cannot be casted to integer.
           info={'II': '1.1'})
       header_num_dict = {'II': '1'}
-      self._get_row_list_from_variant(
-          variant, header_num_dict, allow_incompatible_records=True)
+      # self._get_row_list_from_variant(
+      #     variant, header_num_dict, allow_incompatible_records=True)
+      proc_variant = _get_processed_variant(variant, header_num_dict)
+      list(self._row_generator.get_rows(proc_variant,
+                                        allow_incompatible_records=True))
       self.fail('String data for an integer schema must cause an exception')
 
   def test_schema_conflict_in_info_field_number(self):
@@ -525,6 +431,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
               'IFR': 1.1,
               'ISR': 'foo'},)
     header_num_dict = {'IB': '2', 'IBR': '1', 'II': '2', 'IFR': '1', 'ISR': '1'}
+    proc_variant = _get_processed_variant(variant, header_num_dict)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -536,9 +443,13 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
         'IBR': [True],
         'II': 10,
         'IFR': [1.1],
-        'ISR': ['foo'],}
-    self.assertEqual([expected_row], self._get_row_list_from_variant(
-        variant, header_num_dict, allow_incompatible_records=True))
+        'ISR': ['foo']
+    }
+
+    self.assertEqual(
+        [expected_row],
+        list(self._row_generator.get_rows(proc_variant,
+                                          allow_incompatible_records=True)))
 
   def test_schema_conflict_in_format_field_type(self):
     variant = vcfio.Variant(
@@ -551,6 +462,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
             vcfio.VariantCall(
                 name='Sample2', genotype=[1, 0],
                 info={'FB': 1, 'FI': True, 'FSR': [1.0, 2.0]})])
+    proc_variant = _get_processed_variant(variant)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -569,8 +481,10 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
              'FB': True, 'FI': 1, 'FSR': ['1.0', '2.0']},],
     }
 
-    self.assertEqual([expected_row], self._get_row_list_from_variant(
-        variant, allow_incompatible_records=True))
+    self.assertEqual(
+        [expected_row],
+        list(self._row_generator.get_rows(proc_variant,
+                                          allow_incompatible_records=True)))
 
     with self.assertRaises(ValueError):
       variant = vcfio.Variant(
@@ -581,8 +495,9 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
               vcfio.VariantCall(
                   name='Sample1', genotype=[0, 1], phaseset='*',
                   info={'FI': 'string_for_int_field'}),],)
-      self._get_row_list_from_variant(
-          variant, allow_incompatible_records=True)
+      proc_variant = _get_processed_variant(variant)
+      list(self._row_generator.get_rows(proc_variant,
+                                        allow_incompatible_records=True))
       self.fail('String data for an integer schema must cause an exception')
 
   def test_schema_conflict_in_format_field_number(self):
@@ -596,6 +511,7 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
             vcfio.VariantCall(
                 name='Sample2', genotype=[1, 0],
                 info={'FB': [], 'FI': [], 'FSR': ''})])
+    proc_variant = _get_processed_variant(variant)
     expected_row = {
         ColumnKeyConstants.REFERENCE_NAME: 'chr19',
         ColumnKeyConstants.START_POSITION: 11,
@@ -614,5 +530,259 @@ class BigQueryRowGeneratorTest(unittest.TestCase):
              'FB': False, 'FI': None, 'FSR': ['']},],
     }
 
-    self.assertEqual([expected_row], self._get_row_list_from_variant(
-        variant, allow_incompatible_records=True))
+    self.assertEqual(
+        [expected_row],
+        list(self._row_generator.get_rows(proc_variant,
+                                          allow_incompatible_records=True)))
+
+
+class VariantGeneratorTest(unittest.TestCase):
+  """Test cases for `VariantGenerator` class."""
+
+  def setUp(self):
+    self._variant_generator = bigquery_vcf_data_converter.VariantGenerator()
+
+  def test_alternate_bases(self):
+    alternate_base_records = _get_big_query_row()[
+        ColumnKeyConstants.ALTERNATE_BASES]
+
+    expected_alternate_bases = ['A', 'TT']
+
+    self.assertEqual(
+        expected_alternate_bases,
+        self._variant_generator._get_alternate_bases(alternate_base_records))
+
+  def test_get_variant_info(self):
+    row = _get_big_query_row()
+    expected_variant_info = {'IFR': [1, 0.2],
+                             'IFR2': [0.2, 0.3],
+                             'IS': 'some data',
+                             'ISR': ['data1', 'data2']}
+
+    self.assertEqual(expected_variant_info,
+                     self._variant_generator._get_variant_info(row))
+
+  def test_get_variant_calls(self):
+    variant_call_records = _get_big_query_row()[ColumnKeyConstants.CALLS]
+
+    expected_calls = [
+        vcfio.VariantCall(
+            name='Sample1', genotype=[0, 1], phaseset='*',
+            info={'GQ': 20, 'FIR': [10, 20]}),
+        vcfio.VariantCall(
+            name='Sample2', genotype=[1, 0],
+            info={'GQ': 10, 'FB': True}),
+    ]
+
+    self.assertEqual(
+        expected_calls,
+        self._variant_generator._get_variant_calls(variant_call_records))
+
+  def test_convert_bq_row_to_variant(self):
+    row = _get_big_query_row()
+    expected_variant = vcfio.Variant(
+        reference_name='chr19', start=11, end=12, reference_bases='C',
+        alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
+        filters=['PASS'],
+        info={'IFR': [1, 0.2], 'IFR2': [0.2, 0.3],
+              'IS': 'some data', 'ISR': ['data1', 'data2']},
+        calls=[
+            vcfio.VariantCall(
+                name='Sample1', genotype=[0, 1], phaseset='*',
+                info={'GQ': 20, 'FIR': [10, 20]}),
+            vcfio.VariantCall(
+                name='Sample2', genotype=[1, 0],
+                info={'GQ': 10, 'FB': True})
+        ]
+    )
+
+    self.assertEqual(expected_variant,
+                     self._variant_generator.convert_bq_row_to_variant(row))
+
+
+class ConverterConcatenationTest(unittest.TestCase):
+  """Test cases for concatenating the BigQuery VCF data converters."""
+
+  def setUp(self):
+    self._variant_generator = bigquery_vcf_data_converter.VariantGenerator()
+    self._schema_descriptor = bigquery_schema_descriptor.SchemaDescriptor(
+        _get_table_schema())
+    self._conflict_resolver = (
+        vcf_field_conflict_resolver.FieldConflictResolver())
+    self._row_generator = bigquery_vcf_data_converter.BigQueryRowGenerator(
+        self._schema_descriptor, self._conflict_resolver)
+
+  def test_bq_row_to_variant_to_bq_row(self):
+    row = _get_big_query_row()
+    header_num_dict = {'IFR': 'A', 'IFR2': 'A', 'IS': '1', 'ISR': '2'}
+    variant = self._variant_generator.convert_bq_row_to_variant(row)
+    proc_variant = _get_processed_variant(variant, header_num_dict)
+    converted_row = list(self._row_generator.get_rows(proc_variant))
+    self.assertEqual([row], converted_row)
+
+  def test_variant_to_bq_row_to_variant(self):
+    variant = vcfio.Variant(
+        reference_name='chr19', start=11, end=12, reference_bases='C',
+        alternate_bases=['A', 'TT'], names=['rs1', 'rs2'], quality=2,
+        filters=['PASS'],
+        info={'IFR': [0.1, 0.2],
+              'IFR2': [0.2, 0.3],
+              'IS': 'some data',
+              'ISR': ['data1', 'data2']},
+        calls=[
+            vcfio.VariantCall(
+                name='Sample1', genotype=[0, 1], phaseset='*',
+                info={'GQ': 20, 'FIR': [10, 20]}),
+            vcfio.VariantCall(
+                name='Sample2', genotype=[1, 0],
+                info={'GQ': 10, 'FB': True}),
+            vcfio.VariantCall(
+                name='Sample3', genotype=[vcfio.MISSING_GENOTYPE_VALUE])])
+    header_num_dict = {'IFR': 'A', 'IFR2': 'A', 'IS': '1', 'ISR': '2'}
+
+    proc_variant = _get_processed_variant(variant, header_num_dict)
+    row = list(self._row_generator.get_rows(proc_variant))
+    converted_variant = self._variant_generator.convert_bq_row_to_variant(
+        row[0])
+    self.assertEqual(variant, converted_variant)
+
+
+def _get_processed_variant(variant, header_num_dict=None):
+  # TODO(bashir2): To make this more of a "unit" test, we should create
+  # ProcessedVariant instances directly (instead of Variant) and avoid calling
+  # create_processed_variant here. Then we should also add cases that
+  # have annotation fields.
+  header_fields = vcf_header_util.make_header(header_num_dict or {})
+  return processed_variant.ProcessedVariantFactory(
+      header_fields).create_processed_variant(variant)
+
+
+# TODO(allieychen): Use the sample schema in script `bigquery_schema_util`.
+def _get_table_schema():
+  # type (None) -> bigquery.TableSchema
+  schema = bigquery.TableSchema()
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IB',
+      type=TableFieldConstants.TYPE_BOOLEAN,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IBR',
+      type=TableFieldConstants.TYPE_BOOLEAN,
+      mode=TableFieldConstants.MODE_REPEATED,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='II',
+      type=TableFieldConstants.TYPE_INTEGER,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='II2',
+      type=TableFieldConstants.TYPE_INTEGER,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IIR',
+      type=TableFieldConstants.TYPE_INTEGER,
+      mode=TableFieldConstants.MODE_REPEATED,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IF',
+      type=TableFieldConstants.TYPE_FLOAT,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IF2',
+      type=TableFieldConstants.TYPE_FLOAT,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IFR',
+      type=TableFieldConstants.TYPE_FLOAT,
+      mode=TableFieldConstants.MODE_REPEATED,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IFR2',
+      type=TableFieldConstants.TYPE_FLOAT,
+      mode=TableFieldConstants.MODE_REPEATED,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='field__IS',
+      type=TableFieldConstants.TYPE_STRING,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='IS',
+      type=TableFieldConstants.TYPE_STRING,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='INFO foo desc'))
+  schema.fields.append(bigquery.TableFieldSchema(
+      name='ISR',
+      type=TableFieldConstants.TYPE_STRING,
+      mode=TableFieldConstants.MODE_REPEATED,
+      description='INFO foo desc'))
+  # Call record.
+  call_record = bigquery.TableFieldSchema(
+      name=ColumnKeyConstants.CALLS,
+      type=TableFieldConstants.TYPE_RECORD,
+      mode=TableFieldConstants.MODE_REPEATED,
+      description='One record for each call.')
+  call_record.fields.append(bigquery.TableFieldSchema(
+      name='FB',
+      type=TableFieldConstants.TYPE_BOOLEAN,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='FORMAT foo desc'))
+  call_record.fields.append(bigquery.TableFieldSchema(
+      name='FI',
+      type=TableFieldConstants.TYPE_INTEGER,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='FORMAT foo desc'))
+  call_record.fields.append(bigquery.TableFieldSchema(
+      name='GQ',
+      type=TableFieldConstants.TYPE_INTEGER,
+      mode=TableFieldConstants.MODE_NULLABLE,
+      description='FORMAT foo desc'))
+  call_record.fields.append(bigquery.TableFieldSchema(
+      name='FIR',
+      type=TableFieldConstants.TYPE_INTEGER,
+      mode=TableFieldConstants.MODE_REPEATED,
+      description='FORMAT foo desc'))
+  call_record.fields.append(bigquery.TableFieldSchema(
+      name='FSR',
+      type=TableFieldConstants.TYPE_STRING,
+      mode=TableFieldConstants.MODE_REPEATED,
+      description='FORMAT foo desc'))
+  schema.fields.append(call_record)
+  return schema
+
+
+def _get_big_query_row():
+  # type: (None) -> Dict[unicode, Any]
+  """Returns one sample BigQuery row for testing."""
+  return {unicode(ColumnKeyConstants.REFERENCE_NAME): unicode('chr19'),
+          unicode(ColumnKeyConstants.START_POSITION): 11,
+          unicode(ColumnKeyConstants.END_POSITION): 12,
+          unicode(ColumnKeyConstants.REFERENCE_BASES): 'C',
+          unicode(ColumnKeyConstants.NAMES): [unicode('rs1'), unicode('rs2')],
+          unicode(ColumnKeyConstants.QUALITY): 2,
+          unicode(ColumnKeyConstants.FILTER): [unicode('PASS')],
+          unicode(ColumnKeyConstants.CALLS): [
+              {unicode(ColumnKeyConstants.CALLS_NAME): unicode('Sample1'),
+               unicode(ColumnKeyConstants.CALLS_GENOTYPE): [0, 1],
+               unicode(ColumnKeyConstants.CALLS_PHASESET): unicode('*'),
+               unicode('GQ'): 20, unicode('FIR'): [10, 20]},
+              {unicode(ColumnKeyConstants.CALLS_NAME): unicode('Sample2'),
+               unicode(ColumnKeyConstants.CALLS_GENOTYPE): [1, 0],
+               unicode(ColumnKeyConstants.CALLS_PHASESET): None,
+               unicode('GQ'): 10, unicode('FB'): True}
+          ],
+          unicode(ColumnKeyConstants.ALTERNATE_BASES): [
+              {unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('A'),
+               unicode('IFR'): 1,
+               unicode('IFR2'): 0.2},
+              {unicode(ColumnKeyConstants.ALTERNATE_BASES_ALT): unicode('TT'),
+               unicode('IFR'): 0.2,
+               unicode('IFR2'): 0.3}
+          ],
+          unicode('IS'): unicode('some data'),
+          unicode('ISR'): [unicode('data1'), unicode('data2')]}

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for bigquery_vcf_schema module."""
+"""Tests for `bigquery_vcf_schema_converter` module."""
 
 from __future__ import absolute_import
 

--- a/gcp_variant_transforms/transforms/bigquery_to_variant.py
+++ b/gcp_variant_transforms/transforms/bigquery_to_variant.py
@@ -14,97 +14,17 @@
 
 """A PTransform to convert BigQuery table rows to a PCollection of `Variant`."""
 
-from typing import Any, Dict, List  # pylint: disable=unused-import
-
 import apache_beam as beam
 
-from gcp_variant_transforms.beam_io import vcfio
-from gcp_variant_transforms.libs import bigquery_util
-
-# Reserved constants for column names in the BigQuery schema.
-RESERVED_BQ_COLUMNS = [bigquery_util.ColumnKeyConstants.REFERENCE_NAME,
-                       bigquery_util.ColumnKeyConstants.START_POSITION,
-                       bigquery_util.ColumnKeyConstants.END_POSITION,
-                       bigquery_util.ColumnKeyConstants.REFERENCE_BASES,
-                       bigquery_util.ColumnKeyConstants.ALTERNATE_BASES,
-                       bigquery_util.ColumnKeyConstants.NAMES,
-                       bigquery_util.ColumnKeyConstants.QUALITY,
-                       bigquery_util.ColumnKeyConstants.FILTER,
-                       bigquery_util.ColumnKeyConstants.CALLS]
-
-RESERVED_VARIANT_CALL_COLUMNS = [
-    bigquery_util.ColumnKeyConstants.CALLS_NAME,
-    bigquery_util.ColumnKeyConstants.CALLS_GENOTYPE,
-    bigquery_util.ColumnKeyConstants.CALLS_PHASESET
-]
+from gcp_variant_transforms.libs import bigquery_vcf_data_converter
 
 
 class BigQueryToVariant(beam.PTransform):
   """Transforms BigQuery table rows to PCollection of `Variant`."""
 
+  def __init__(self):
+    self._variant_generator = bigquery_vcf_data_converter.VariantGenerator()
+
   def expand(self, pcoll):
     return (pcoll | 'BigQueryToVariant' >> beam.Map(
-        self._convert_bq_row_to_variant))
-
-  # TODO (yifangchen): Move this to a separate module so that it can be reused.
-  def _convert_bq_row_to_variant(self, row):
-    # type: (Dict[str, Any]) -> vcfio.Variant
-    return vcfio.Variant(
-        reference_name=row[bigquery_util.ColumnKeyConstants.REFERENCE_NAME],
-        start=row[bigquery_util.ColumnKeyConstants.START_POSITION],
-        end=row[bigquery_util.ColumnKeyConstants.END_POSITION],
-        reference_bases=row[bigquery_util.ColumnKeyConstants.REFERENCE_BASES],
-        alternate_bases=self._get_alternate_bases(
-            row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES]),
-        names=row[bigquery_util.ColumnKeyConstants.NAMES],
-        quality=row[bigquery_util.ColumnKeyConstants.QUALITY],
-        filters=row[bigquery_util.ColumnKeyConstants.FILTER],
-        info=self._get_variant_info(row),
-        calls=self._get_variant_calls(
-            row[bigquery_util.ColumnKeyConstants.CALLS])
-    )
-
-  def _get_alternate_bases(self, alternate_base_records):
-    # type: (List[Dict[str, Any]]) -> List[str]
-    return [record[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES_ALT]
-            for record in alternate_base_records]
-
-  def _get_variant_info(self, row):
-    # type: (Dict[str, Any]) -> Dict[str, Any]
-    info = {}
-    for key, value in row.iteritems():
-      if key not in RESERVED_BQ_COLUMNS and not self._is_null_or_empty(value):
-        info.update({key: value})
-    for alt_base in row[bigquery_util.ColumnKeyConstants.ALTERNATE_BASES]:
-      for key, value in alt_base.iteritems():
-        if (key != bigquery_util.ColumnKeyConstants.ALTERNATE_BASES_ALT and
-            not self._is_null_or_empty(value)):
-          if key not in info:
-            info[key] = []
-          info[key].append(value)
-    return info
-
-  def _get_variant_calls(self, variant_call_records):
-    # type: (List[Dict[str, Any]]) -> List[vcfio.VariantCall]
-    variant_calls = []
-    for call_record in variant_call_records:
-      info = {}
-      for key, value in call_record.iteritems():
-        if (key not in RESERVED_VARIANT_CALL_COLUMNS and
-            not self._is_null_or_empty(value)):
-          info.update({key: value})
-      variant_call = vcfio.VariantCall(
-          name=call_record[bigquery_util.ColumnKeyConstants.CALLS_NAME],
-          genotype=call_record[bigquery_util.ColumnKeyConstants.CALLS_GENOTYPE],
-          phaseset=call_record[bigquery_util.ColumnKeyConstants.CALLS_PHASESET],
-          info=info)
-      variant_calls.append(variant_call)
-    return variant_calls
-
-  def _is_null_or_empty(self, value):
-    # type: (Any) -> bool
-    if value is None:
-      return True
-    if isinstance(value, list) and not value:
-      return True
-    return False
+        self._variant_generator.convert_bq_row_to_variant))

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -27,7 +27,7 @@ from apache_beam.transforms import Create
 
 from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import bigquery_schema_descriptor
-from gcp_variant_transforms.libs import bigquery_row_generator
+from gcp_variant_transforms.libs import bigquery_vcf_data_converter
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
 from gcp_variant_transforms.libs.bigquery_util import ColumnKeyConstants
@@ -46,7 +46,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     self._conflict_resolver = (
         vcf_field_conflict_resolver.FieldConflictResolver())
 
-    self._row_generator = bigquery_row_generator.BigQueryRowGenerator(
+    self._row_generator = bigquery_vcf_data_converter.BigQueryRowGenerator(
         self._schema_descriptor, self._conflict_resolver)
 
   def _get_table_schema(self):


### PR DESCRIPTION
- Move the conversion of BigQuery row to variant in the same module of variant to BigQuery row.
- Add the test for bq row ->variant -> bq row and variant -> bq row -> variant

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests & integration tests
