### PR TITLE
BQ to VCF customized region

### DIFF
--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -55,6 +55,9 @@ from gcp_variant_transforms.transforms import densify_variants
 
 
 _BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`'
+_GENOMIC_REGION_TEMPLATE = ('({REFERENCE_NAME_ID}="{REFERENCE_NAME_VALUE}" AND '
+                            '{START_POSITION_ID}>={START_POSITION_VALUE} AND '
+                            '{END_POSITION_ID}<={END_POSITION_VALUE})')
 _COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
 _VCF_FIXED_COLUMNS = ['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER',
                       'INFO', 'FORMAT']
@@ -123,7 +126,9 @@ def _bigquery_to_vcf_shards(
   Also, it writes the meta info and data header with the call names to
   `vcf_header_file_path`.
   """
-  bq_source = bigquery.BigQuerySource(query=_form_customized_query(known_args),
+  query = _get_bigquery_query(known_args)
+  logging.info('Processing BigQuery query %s:', query)
+  bq_source = bigquery.BigQuerySource(query=query,
                                       validate=True,
                                       use_standard_sql=True)
 
@@ -151,23 +156,25 @@ def _bigquery_to_vcf_shards(
          | vcfio.WriteVcfDataLines())
 
 
-def _form_customized_query(known_args):
+def _get_bigquery_query(known_args):
   # type: (argparse.Namespace) -> str
-  """Returns a customized query for the interested regions."""
+  """Returns a BigQuery query for the interested regions."""
   base_query = _BASE_QUERY_TEMPLATE.format(INPUT_TABLE='.'.join(
       bigquery_util.parse_table_reference(known_args.input_table)))
-  if not known_args.genomic_regions:
-    return base_query
-
   conditions = []
-  for region in known_args.genomic_regions:
-    ref, start, end = genomic_region_parser.parse_genomic_region(region)
+  if known_args.genomic_regions:
+    for region in known_args.genomic_regions:
+      ref, start, end = genomic_region_parser.parse_genomic_region(region)
+      conditions.append(_GENOMIC_REGION_TEMPLATE.format(
+          REFERENCE_NAME_ID=bigquery_util.ColumnKeyConstants.REFERENCE_NAME,
+          REFERENCE_NAME_VALUE=ref,
+          START_POSITION_ID=bigquery_util.ColumnKeyConstants.START_POSITION,
+          START_POSITION_VALUE=start,
+          END_POSITION_ID=bigquery_util.ColumnKeyConstants.END_POSITION,
+          END_POSITION_VALUE=end))
 
-    conditions.append('{}=\'{}\' AND {}>={} AND {}<={}'.format(
-        bigquery_util.ColumnKeyConstants.REFERENCE_NAME, ref,
-        bigquery_util.ColumnKeyConstants.START_POSITION, start,
-        bigquery_util.ColumnKeyConstants.END_POSITION, end))
-
+  if not conditions:
+    return base_query
   return ' '.join([base_query, 'WHERE', ' OR '.join(conditions)])
 
 

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -53,7 +53,7 @@ from gcp_variant_transforms.transforms import combine_call_names
 from gcp_variant_transforms.transforms import densify_variants
 
 
-_BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`;'
+_BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`'
 _COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
 _VCF_FIXED_COLUMNS = ['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER',
                       'INFO', 'FORMAT']
@@ -122,12 +122,9 @@ def _bigquery_to_vcf_shards(
   Also, it writes the meta info and data header with the call names to
   `vcf_header_file_path`.
   """
-  bq_source = bigquery.BigQuerySource(
-      query=_BASE_QUERY_TEMPLATE.format(
-          INPUT_TABLE='.'.join(bigquery_util.parse_table_reference(
-              known_args.input_table))),
-      validate=True,
-      use_standard_sql=True)
+  bq_source = bigquery.BigQuerySource(query=_form_customized_query(known_args),
+                                      validate=True,
+                                      use_standard_sql=True)
 
   with beam.Pipeline(options=beam_pipeline_options) as p:
     variants = (p

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -14,6 +14,7 @@
 
 """Tests for `bq_to_vcf` module."""
 
+import collections
 import unittest
 
 from apache_beam.io import filesystems
@@ -24,6 +25,9 @@ from gcp_variant_transforms.testing import temp_dir
 
 class BqToVcfTest(unittest.TestCase):
   """Test cases for the `bq_to_vcf` module."""
+
+  def _create_mock_args(self, **args):
+    return collections.namedtuple('MockArgs', args.keys())(*args.values())
 
   def test_write_vcf_data_header(self):
     lines = [
@@ -53,3 +57,4 @@ class BqToVcfTest(unittest.TestCase):
       with filesystems.FileSystems.open(file_path) as f:
         content = f.readlines()
         self.assertEqual(content, expected_content)
+

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -58,22 +58,21 @@ class BqToVcfTest(unittest.TestCase):
         content = f.readlines()
         self.assertEqual(content, expected_content)
 
-  def test_form_customized_query_no_region(self):
+  def test_get_bigquery_query_no_region(self):
     args = self._create_mock_args(
         input_table='my_bucket:my_dataset.my_table',
         genomic_regions=None)
-    self.assertEqual(bq_to_vcf._form_customized_query(args),
+    self.assertEqual(bq_to_vcf._get_bigquery_query(args),
                      'SELECT * FROM `my_bucket.my_dataset.my_table`')
 
-  def test_form_customized_query_with_regions(self):
+  def test_get_bigquery_query_with_regions(self):
     args_1 = self._create_mock_args(
         input_table='my_bucket:my_dataset.my_table',
         genomic_regions=['c1:1,000-2,000', 'c2'])
-    self.assertEqual(
-        bq_to_vcf._form_customized_query(args_1),
+    expected_query = (
         'SELECT * FROM `my_bucket.my_dataset.my_table` WHERE '
-        'reference_name=\'c1\' AND start_position>=1000 AND end_position<=2000 '
-        'OR '
-        'reference_name=\'c2\' AND start_position>=0 AND '
-        'end_position<=9223372036854775807'
+        '(reference_name="c1" AND start_position>=1000 AND end_position<=2000) '
+        'OR (reference_name="c2" AND start_position>=0 AND '
+        'end_position<=9223372036854775807)'
     )
+    self.assertEqual(bq_to_vcf._get_bigquery_query(args_1), expected_query)

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -58,3 +58,22 @@ class BqToVcfTest(unittest.TestCase):
         content = f.readlines()
         self.assertEqual(content, expected_content)
 
+  def test_form_customized_query_no_region(self):
+    args = self._create_mock_args(
+        input_table='my_bucket:my_dataset.my_table',
+        genomic_regions=None)
+    self.assertEqual(bq_to_vcf._form_customized_query(args),
+                     'SELECT * FROM `my_bucket.my_dataset.my_table`')
+
+  def test_form_customized_query_with_regions(self):
+    args_1 = self._create_mock_args(
+        input_table='my_bucket:my_dataset.my_table',
+        genomic_regions=['c1:1,000-2,000', 'c2'])
+    self.assertEqual(
+        bq_to_vcf._form_customized_query(args_1),
+        'SELECT * FROM `my_bucket.my_dataset.my_table` WHERE '
+        'reference_name=\'c1\' AND start_position>=1000 AND end_position<=2000 '
+        'OR '
+        'reference_name=\'c2\' AND start_position>=0 AND '
+        'end_position<=9223372036854775807'
+    )

--- a/gcp_variant_transforms/libs/genomic_region_parser.py
+++ b/gcp_variant_transforms/libs/genomic_region_parser.py
@@ -23,7 +23,7 @@ from typing import Tuple  # pylint: disable=unused-import
 # Matches to regions formatted as 'chr12:10,000-20,000'.
 _REGION_LITERAL_REGEXP = re.compile(r'^(\S+):([0-9,]+)-([0-9,]+)$')
 _DEFAULT_START_POSITION = 0
-_DEFAULT_END_POSITION = sys.maxint
+_DEFAULT_END_POSITION = sys.maxsize
 
 
 def parse_genomic_region(genomic_region):
@@ -37,7 +37,7 @@ def parse_genomic_region(genomic_region):
     A tuple containing reference name, start position and end position.
   """
   def _parse_position(pos_str):
-      # type: (str) -> int
+    # type: (str) -> int
     return int(pos_str.replace(',', ''))
 
   matched = _REGION_LITERAL_REGEXP.match(genomic_region)

--- a/gcp_variant_transforms/libs/genomic_region_parser.py
+++ b/gcp_variant_transforms/libs/genomic_region_parser.py
@@ -1,0 +1,60 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Function for parsing genomic region."""
+
+from __future__ import absolute_import
+
+import re
+import sys
+from typing import Tuple  # pylint: disable=unused-import
+
+# Matches to regions formatted as 'chr12:10,000-20,000'.
+_REGION_LITERAL_REGEXP = re.compile(r'^(\S+):([0-9,]+)-([0-9,]+)$')
+_DEFAULT_START_POSITION = 0
+_DEFAULT_END_POSITION = sys.maxint
+
+
+def parse_genomic_region(genomic_region):
+  # type: (str) -> Tuple[str, int, int]
+  """Parses genomic region that formatted as 'CHROM:START-END'.
+
+  If it does not match `_REGION_LITERAL_REGEXP`, it assumes this region includes
+  a full chromosome.
+
+  Returns:
+    A tuple containing reference name, start position and end position.
+  """
+  def _parse_position(pos_str):
+      # type: (str) -> int
+    return int(pos_str.replace(',', ''))
+
+  matched = _REGION_LITERAL_REGEXP.match(genomic_region)
+  if matched:
+    ref_name, start, end = matched.groups()
+    ref_name = ref_name.strip().lower()
+    start = _parse_position(start)
+    end = _parse_position(end)
+    if start < 0:
+      raise ValueError(
+          'Start position on a region cannot be negative: {}'.format(start))
+    if end <= start:
+      raise ValueError('End position must be larger than start position: {} '
+                       'vs {}'.format(end, start))
+  else:
+    # This region includes a full chromosome
+    ref_name = genomic_region.strip().lower()
+    start = 0
+    end = _DEFAULT_END_POSITION
+  return ref_name, start, end

--- a/gcp_variant_transforms/libs/genomic_region_parser_test.py
+++ b/gcp_variant_transforms/libs/genomic_region_parser_test.py
@@ -21,7 +21,7 @@ import unittest
 from gcp_variant_transforms.libs import genomic_region_parser
 
 
-class VariantPartitionTest(unittest.TestCase):
+class GenomicRegionParserTest(unittest.TestCase):
 
   def test_parse_genomic_regions(self):
     self.assertEqual(

--- a/gcp_variant_transforms/libs/genomic_region_parser_test.py
+++ b/gcp_variant_transforms/libs/genomic_region_parser_test.py
@@ -1,0 +1,40 @@
+# Copyright 2018 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for `genomic_region_parser` module."""
+
+from __future__ import absolute_import
+
+import unittest
+
+from gcp_variant_transforms.libs import genomic_region_parser
+
+
+class VariantPartitionTest(unittest.TestCase):
+
+  def test_parse_genomic_regions(self):
+    self.assertEqual(
+        genomic_region_parser.parse_genomic_region('chr1:1,000,000-2,000,000'),
+        ('chr1', 1000000, 2000000)
+    )
+    self.assertEqual(
+        genomic_region_parser.parse_genomic_region('chr1:1000000-2000000'),
+        ('chr1', 1000000, 2000000)
+    )
+    self.assertEqual(
+        genomic_region_parser.parse_genomic_region('chr'),
+        ('chr', 0, genomic_region_parser._DEFAULT_END_POSITION)
+    )
+    with self.assertRaises(ValueError):
+      genomic_region_parser.parse_genomic_region('chr1:5-5')

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -477,3 +477,5 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
         '--representative_header_file',
         help=('If provided, meta-information from the provided file will be '
               'added into the output_file.'))
+
+

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -477,5 +477,12 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
         '--representative_header_file',
         help=('If provided, meta-information from the provided file will be '
               'added into the output_file.'))
-
-
+    parser.add_argument(
+        '--genomic_regions',
+        default=None, nargs='+',
+        help=('A list of genomic regions (separated by a space) to load from '
+              'BigQuery. The format of each genomic region should be '
+              'CHROMOSOME:START_POSITION-END_POSITION or CHROMOSOME if the full'
+              'chromosome is interested. Only variants matching at least one '
+              'of these regions will be loaded. If this parameter is not '
+              'specified, all variants will be kept.'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -483,6 +483,6 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
         help=('A list of genomic regions (separated by a space) to load from '
               'BigQuery. The format of each genomic region should be '
               'CHROMOSOME:START_POSITION-END_POSITION or CHROMOSOME if the full'
-              'chromosome is interested. Only variants matching at least one '
+              'chromosome is requested. Only variants matching at least one '
               'of these regions will be loaded. If this parameter is not '
               'specified, all variants will be kept.'))

--- a/gcp_variant_transforms/options/variant_transform_options_test.py
+++ b/gcp_variant_transforms/options/variant_transform_options_test.py
@@ -149,3 +149,37 @@ class AnnotationOptionsTest(unittest.TestCase):
                             '--vep_image_uri', 'AN_IMAGE',
                             '--vep_cache_path', 'VEP_CACHE'])
     self.assertRaises(ValueError, self._options.validate, args)
+
+
+class BigQueryToVcfOptionsTest(unittest.TestCase):
+  """Test cases for `BigQueryToVcfOptions` class."""
+
+  def setUp(self):
+    self._options = variant_transform_options.BigQueryToVcfOptions()
+
+  def _make_args(self, args):
+    # type: (List[str]) -> argparse.Namespace
+    return make_args(self._options, args)
+
+  def test_validate_okay_no_start_position(self):
+    args = self._make_args(['--output_file', 'gs://output_file',
+                            '--input_table', 'BigQuery_table',
+                            '--reference_names', '1', '2',
+                            '--end_position', '1000'])
+    self._options.validate(args)
+
+  def test_validate_okay_valid_start_end_position(self):
+    args = self._make_args(['--output_file', 'gs://output_file',
+                            '--input_table', 'BigQuery_table',
+                            '--reference_names', '1', '2',
+                            '--start_position', '1',
+                            '--end_position', '1000'])
+    self._options.validate(args)
+
+  def test_failure_for_invalid_start_end_position(self):
+    args = self._make_args(['--output_file', 'gs://output_file',
+                            '--input_table', 'BigQuery_table',
+                            '--reference_names', '1', '2',
+                            '--start_position', '1000',
+                            '--end_position', '1000'])
+    self.assertRaises(ValueError, self._options.validate, args)

--- a/gcp_variant_transforms/options/variant_transform_options_test.py
+++ b/gcp_variant_transforms/options/variant_transform_options_test.py
@@ -149,37 +149,3 @@ class AnnotationOptionsTest(unittest.TestCase):
                             '--vep_image_uri', 'AN_IMAGE',
                             '--vep_cache_path', 'VEP_CACHE'])
     self.assertRaises(ValueError, self._options.validate, args)
-
-
-class BigQueryToVcfOptionsTest(unittest.TestCase):
-  """Test cases for `BigQueryToVcfOptions` class."""
-
-  def setUp(self):
-    self._options = variant_transform_options.BigQueryToVcfOptions()
-
-  def _make_args(self, args):
-    # type: (List[str]) -> argparse.Namespace
-    return make_args(self._options, args)
-
-  def test_validate_okay_no_start_position(self):
-    args = self._make_args(['--output_file', 'gs://output_file',
-                            '--input_table', 'BigQuery_table',
-                            '--reference_names', '1', '2',
-                            '--end_position', '1000'])
-    self._options.validate(args)
-
-  def test_validate_okay_valid_start_end_position(self):
-    args = self._make_args(['--output_file', 'gs://output_file',
-                            '--input_table', 'BigQuery_table',
-                            '--reference_names', '1', '2',
-                            '--start_position', '1',
-                            '--end_position', '1000'])
-    self._options.validate(args)
-
-  def test_failure_for_invalid_start_end_position(self):
-    args = self._make_args(['--output_file', 'gs://output_file',
-                            '--input_table', 'BigQuery_table',
-                            '--reference_names', '1', '2',
-                            '--start_position', '1000',
-                            '--end_position', '1000'])
-    self.assertRaises(ValueError, self._options.validate, args)


### PR DESCRIPTION
In BigQuery to VCF pipeline, add three flags: `reference_names`, `start_position`, `end_position` to load the interested regions only. 

Tested: unit tests & manually ran BigQuery to VCF with the filters.
Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)