### PR TITLE
Integration tests for inferring annotation types

### DIFF
--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
@@ -6,6 +6,7 @@
     "annotation_fields": "CSQ",
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
+    "infer_annotation_types": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",
     "num_workers": 1,
     "assertion_configs": [
@@ -78,6 +79,20 @@
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
         ],
         "expected_result": {"num_symbol": 206}
+      },
+      {
+        "query": [
+          "SELECT SUM(CSQ.MOTIF_POS) AS sum_motif_pos",
+          "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ"
+        ],
+        "expected_result": {"sum_motif_pos": 485}
+      },
+      {
+        "query": [
+          "SELECT ROUND(SUM(CSQ_VT.MAX_AF), 5) AS sum_max_af",
+          "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
+        ],
+        "expected_result": {"sum_max_af": 26342.50856}
       }
     ]
   }


### PR DESCRIPTION
* The two new integration tests ensure that the MOTIF_POS and MAX_AF annotation names have been properly cast to `int` and `float`, respectively. 
* `CSQ` and `CSQ_VT` have been used to check for support of multiple annotation fields.
* Proper functionality when `infer_annotation_types=False` is still checked by the `gnomad_genomes_GRCh37_chrX_head2500_run_vep.json` tests (unchanged).

Fixes: #340
Tests: integration tests