### PR TITLE
Annotation fields with no data default to strings.

### DIFF
--- a/gcp_variant_transforms/libs/vcf_field_conflict_resolver.py
+++ b/gcp_variant_transforms/libs/vcf_field_conflict_resolver.py
@@ -30,9 +30,8 @@ class FieldConflictResolver(object):
 
   def __init__(self,
                split_alternate_allele_info_fields=True,
-               resolve_always=False,
-               allow_none_type=False):
-    # type: (bool, bool, bool) -> None
+               resolve_always=False):
+    # type: (bool, bool) -> None
     """Initialize the class.
 
     Args:
@@ -41,13 +40,10 @@ class FieldConflictResolver(object):
       resolve_always: Always find a solution for the conflicts. When the
         conflicts are incompatible, convert all type conflicts to `String` and
         number conflicts to `.`.
-      allow_none_type: If true, resolve type conflicts when one value is `None`
-        by returning the type of the second value, otherwise, raise ValueError.
     """
     self._split_alternate_allele_info_fields = (
         split_alternate_allele_info_fields)
     self._resolve_always = resolve_always
-    self._allow_none_type = allow_none_type
 
   def resolve_schema_conflict(self,
                               schema_field_descriptor,
@@ -123,7 +119,7 @@ class FieldConflictResolver(object):
     numeric_types = (type_constants.INTEGER, type_constants.FLOAT)
     if first == second:
       return first
-    elif (first is None or second is None) and self._allow_none_type:
+    elif first is None or second is None:
       return first if second is None else second
     elif first in numeric_types and second in numeric_types:
       return type_constants.FLOAT

--- a/gcp_variant_transforms/libs/vcf_field_conflict_resolver.py
+++ b/gcp_variant_transforms/libs/vcf_field_conflict_resolver.py
@@ -30,8 +30,9 @@ class FieldConflictResolver(object):
 
   def __init__(self,
                split_alternate_allele_info_fields=True,
-               resolve_always=False):
-    # type: (bool, bool) -> None
+               resolve_always=False,
+               allow_none_type=False):
+    # type: (bool, bool, bool) -> None
     """Initialize the class.
 
     Args:
@@ -40,10 +41,13 @@ class FieldConflictResolver(object):
       resolve_always: Always find a solution for the conflicts. When the
         conflicts are incompatible, convert all type conflicts to `String` and
         number conflicts to `.`.
+      allow_none_type: If true, resolve type conflicts when one value is `None`
+        by returning the type of the second value, otherwise, raise ValueError.
     """
     self._split_alternate_allele_info_fields = (
         split_alternate_allele_info_fields)
     self._resolve_always = resolve_always
+    self._allow_none_type = allow_none_type
 
   def resolve_schema_conflict(self,
                               schema_field_descriptor,
@@ -119,6 +123,8 @@ class FieldConflictResolver(object):
     numeric_types = (type_constants.INTEGER, type_constants.FLOAT)
     if first == second:
       return first
+    elif (first is None or second is None) and self._allow_none_type:
+      return first if second is None else second
     elif first in numeric_types and second in numeric_types:
       return type_constants.FLOAT
     elif self._resolve_always:

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_VEP.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_VEP.json
@@ -4,6 +4,7 @@
     "table_name": "valid_4_2_VEP",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2_VEP.vcf",
     "annotation_fields": "CSQ",
+    "infer_annotation_types": "True",
     "runner": "DirectRunner",
     "zones": ["us-west1-b"],
     "assertion_configs": [
@@ -26,6 +27,13 @@
           "WHERE start_position = 1110695 AND alts.alt = 'G'"
         ],
         "expected_result": {"num_features": 3}
+      },
+      {
+        "query": [
+          "select 'valid' as length_total from(SELECT SUM(LENGTH(CSQ.HGVSc))",
+          "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ)"
+          ],
+        "expected_result": {"length_total": "valid"}
       }
     ]
   }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_VEP.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_VEP.json
@@ -30,7 +30,7 @@
       },
       {
         "query": [
-          "select 'valid' as length_total from(SELECT SUM(LENGTH(CSQ.HGVSc))",
+          "SELECT 'valid' AS length_total FROM(SELECT SUM(LENGTH(CSQ.HGVSc))",
           "FROM {TABLE_NAME} AS T, T.alternate_bases AS A, A.CSQ AS CSQ)"
           ],
         "expected_result": {"length_total": "valid"}

--- a/gcp_variant_transforms/transforms/infer_headers.py
+++ b/gcp_variant_transforms/transforms/infer_headers.py
@@ -289,7 +289,7 @@ class _InferHeaderFields(beam.DoFn):
         raise ValueError(error)
 
     resolver = vcf_field_conflict_resolver.FieldConflictResolver(
-        resolve_always=True)
+        resolve_always=True, allow_none_type=True)
     for field in self._annotation_fields_to_infer:
       if field not in variant.info:
         continue
@@ -301,7 +301,7 @@ class _InferHeaderFields(beam.DoFn):
       _check_annotation_lists_lengths(annotation_names, annotation_values)
       annotation_values = zip(*annotation_values)
       for name, values in zip(annotation_names, annotation_values):
-        variant_merged_type = _HeaderTypeConstants.INTEGER
+        variant_merged_type = None
         for v in values:
           if not v:
             continue
@@ -457,4 +457,5 @@ class InferHeaderFields(beam.PTransform):
                 split_alternate_allele_info_fields=True,
                 allow_incompatible_records=(
                     self._allow_incompatible_records or
-                    bool(self._annotation_fields_to_infer))))
+                    bool(self._annotation_fields_to_infer)),
+                allow_none_type=bool(self._annotation_fields_to_infer)))

--- a/gcp_variant_transforms/transforms/infer_headers.py
+++ b/gcp_variant_transforms/transforms/infer_headers.py
@@ -289,7 +289,7 @@ class _InferHeaderFields(beam.DoFn):
         raise ValueError(error)
 
     resolver = vcf_field_conflict_resolver.FieldConflictResolver(
-        resolve_always=True, allow_none_type=True)
+        resolve_always=True)
     for field in self._annotation_fields_to_infer:
       if field not in variant.info:
         continue
@@ -457,5 +457,4 @@ class InferHeaderFields(beam.PTransform):
                 split_alternate_allele_info_fields=True,
                 allow_incompatible_records=(
                     self._allow_incompatible_records or
-                    bool(self._annotation_fields_to_infer)),
-                allow_none_type=bool(self._annotation_fields_to_infer)))
+                    bool(self._annotation_fields_to_infer))))

--- a/gcp_variant_transforms/transforms/infer_headers_test.py
+++ b/gcp_variant_transforms/transforms/infer_headers_test.py
@@ -466,7 +466,7 @@ class InferHeaderFieldsTest(unittest.TestCase):
                            'TT|||']
     infer_header_fields = infer_headers._InferHeaderFields(False, anno_fields)
     inferred_headers = next(infer_header_fields.process(variant, header))
-    expected_types = {'CSQ_Gene_TYPE': 'Integer',
+    expected_types = {'CSQ_Gene_TYPE': None,
                       'CSQ_Position_TYPE': 'Integer',
                       'CSQ_Score_TYPE': 'Float'}
     for key, item in inferred_headers.infos.iteritems():

--- a/gcp_variant_transforms/transforms/merge_headers.py
+++ b/gcp_variant_transforms/transforms/merge_headers.py
@@ -139,9 +139,8 @@ class MergeHeaders(beam.PTransform):
 
   def __init__(self,
                split_alternate_allele_info_fields=True,
-               allow_incompatible_records=False,
-               allow_none_type=False):
-    # type: (bool, bool, bool) -> None
+               allow_incompatible_records=False):
+    # type: (bool, bool) -> None
     """Initializes :class:`MergeHeaders` object.
 
     Args:
@@ -150,8 +149,6 @@ class MergeHeaders(beam.PTransform):
         as it changes the header compatibility rules as it changes the schema.
       allow_incompatible_records: If true, header definition with type mismatch
         (e.g., string vs float) are always resolved.
-      allow_none_type: If true, resolve type conflicts when one value is `None`
-        by returning the type of the second value, otherwise, raise ValueError.
     """
     super(MergeHeaders, self).__init__()
     # Resolver makes extra efforts to resolve conflict in header definitions
@@ -160,8 +157,7 @@ class MergeHeaders(beam.PTransform):
     self._header_merger = _HeaderMerger(
         vcf_field_conflict_resolver.FieldConflictResolver(
             split_alternate_allele_info_fields,
-            resolve_always=allow_incompatible_records,
-            allow_none_type=allow_none_type))
+            resolve_always=allow_incompatible_records))
 
   def expand(self, pcoll):
     return pcoll | 'MergeHeaders' >> beam.CombineGlobally(_MergeHeadersFn(


### PR DESCRIPTION
When inferring annotation types, the default will be string instead of 
integer.

Fixes: #342
Tests: unit tests and integration test