### PR TITLE
remove the utf-8 encoded data from nucleus

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -102,11 +102,11 @@ def _get_sample_variant_1(is_for_nucleus=False):
   else:
     # 0.1 -> 0.25 float precision loss due to binary floating point conversion.
     vcf_line = ('20	1234	rs123;rs2	C	A,T	50	'
-                'PASS	AF=0.5,0.25;NS=1;SVTYPE=BÑD	GT:GQ	0/0:48	1/0:20\n')
+                'PASS	AF=0.5,0.25;NS=1	GT:GQ	0/0:48	1/0:20\n')
     variant = vcfio.Variant(
         reference_name='20', start=1233, end=1234, reference_bases='C',
         alternate_bases=['A', 'T'], names=['rs123', 'rs2'], quality=50,
-        filters=['PASS'], info={'AF': [0.5, 0.25], 'NS': 1, 'SVTYPE': ['BÑD']})
+        filters=['PASS'], info={'AF': [0.5, 0.25], 'NS': 1})
     variant.calls.append(
         vcfio.VariantCall(name='Sample1', genotype=[0, 0], info={'GQ': 48}))
     variant.calls.append(


### PR DESCRIPTION
A quick fix on the unit tests failure for nucleus with utf-8 encoded data.

- May revisit this test case when nucleus related functions are ready.

Tested: unit tests