### PR TITLE
Write VCF header generated from schema #85

### DIFF
--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -41,13 +41,13 @@ class ColumnKeyConstants(object):
 
 class TableFieldConstants(object):
   """Constants for field modes/types in the BigQuery schema."""
-  TYPE_STRING = 'string'
-  TYPE_INTEGER = 'integer'
-  TYPE_RECORD = 'record'
-  TYPE_FLOAT = 'float'
-  TYPE_BOOLEAN = 'boolean'
-  MODE_NULLABLE = 'nullable'
-  MODE_REPEATED = 'repeated'
+  TYPE_STRING = 'STRING'
+  TYPE_INTEGER = 'INTEGER'
+  TYPE_RECORD = 'RECORD'
+  TYPE_FLOAT = 'FLOAT'
+  TYPE_BOOLEAN = 'BOOLEAN'
+  MODE_NULLABLE = 'NULLABLE'
+  MODE_REPEATED = 'REPEATED'
 
 
 # A map to convert from VCF types to their equivalent BigQuery types.

--- a/gcp_variant_transforms/libs/processed_variant_test.py
+++ b/gcp_variant_transforms/libs/processed_variant_test.py
@@ -522,11 +522,11 @@ class ProcessedVariantFactoryTest(unittest.TestCase):
         annotation_fields=['CSQ'])
     schema = factory.create_alt_bases_field_schema()
     csq_field = [field for field in schema.fields if field.name == 'CSQ'][0]
-    expected_name_type_map = {'CSQ': 'record',
-                              'allele': 'string',
-                              'Consequence': 'integer',
-                              'IMPACT': 'integer',
-                              'SYMBOL': 'float',
-                              'Gene': 'string'}
+    expected_name_type_map = {'CSQ': 'RECORD',
+                              'allele': 'STRING',
+                              'Consequence': 'INTEGER',
+                              'IMPACT': 'INTEGER',
+                              'SYMBOL': 'FLOAT',
+                              'Gene': 'STRING'}
     for field in csq_field.fields:
       self.assertEqual(field.type, expected_name_type_map[field.name])

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -234,20 +234,19 @@ def _get_merged_field_schemas(
       merged_field_schemas.append(field_schema)
     else:
       existing_field_schema = existing_fields.get(field_schema.name)
-      if field_schema.mode.lower() != existing_field_schema.mode.lower():
+      if field_schema.mode != existing_field_schema.mode:
         raise ValueError(
             'The mode of field {} is not compatible. The original mode is {}, '
             'and the new mode is {}.'.format(field_schema.name,
                                              existing_field_schema.mode,
                                              field_schema.mode))
-      if field_schema.type.lower() != existing_field_schema.type.lower():
+      if field_schema.type != existing_field_schema.type:
         raise ValueError(
             'The type of field {} is not compatible. The original type is {}, '
             'and the new type is {}.'.format(field_schema.name,
                                              existing_field_schema.type,
                                              field_schema.type))
-      if (field_schema.type.lower() ==
-          bigquery_util.TableFieldConstants.TYPE_RECORD):
+      if field_schema.type == bigquery_util.TableFieldConstants.TYPE_RECORD:
         existing_field_schema.fields = _get_merged_field_schemas(
             existing_field_schema.fields, field_schema.fields)
   return merged_field_schemas


### PR DESCRIPTION
- Writes the header when `representative_header_file` is not present.
- Updated the `TableFieldConstants` to be consistent with BigQuery schema.

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests, integration tests & manually ran bq_to_vcf.