### PR TITLE
allow incompatible schema

### DIFF
--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -114,7 +114,8 @@ def run(argv=None):
         temp_folder,
         'bq_to_vcf_meta_info_{}'.format(timestamp_str))
     _write_vcf_meta_info(known_args.input_table,
-                         known_args.representative_header_file)
+                         known_args.representative_header_file,
+                         known_args.allow_incompatible_schema)
 
   _bigquery_to_vcf_shards(known_args,
                           options,
@@ -131,12 +132,14 @@ def run(argv=None):
                                              known_args.output_file)
 
 
-def _write_vcf_meta_info(input_table, representative_header_file):
-  # type: (str, str) -> None
+def _write_vcf_meta_info(input_table,
+                         representative_header_file,
+                         allow_incompatible_schema):
+  # type: (str, str, bool) -> None
   """Writes the meta information generated from BigQuery schema."""
   header_fields = (
       bigquery_vcf_schema_converter.generate_header_fields_from_schema(
-          _get_schema(input_table)))
+          _get_schema(input_table), allow_incompatible_schema))
   write_header_fn = vcf_header_io.WriteVcfHeaderFn(representative_header_file)
   write_header_fn.process(header_fields)
 

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
@@ -206,15 +206,15 @@ def generate_header_fields_from_schema(schema, allow_incompatible_schema=False):
     if field.name in _NON_INFO_OR_FORMAT_CONSTANT_FIELDS:
       continue
     elif field.name == bigquery_util.ColumnKeyConstants.CALLS:
-      _add_format_fields(field, allow_incompatible_schema, formats)
+      _add_format_fields(field, formats, allow_incompatible_schema)
     else:
-      _add_info_fields(field, allow_incompatible_schema, infos)
+      _add_info_fields(field, infos, allow_incompatible_schema)
 
   return vcf_header_io.VcfHeader(infos=infos, formats=formats)
 
 
-def _add_format_fields(schema, allow_incompatible_schema, formats):
-  # type: (bigquery.TableFieldSchema, bool, Dict[str, _Format]) -> None
+def _add_format_fields(schema, formats, allow_incompatible_schema=False):
+  # type: (bigquery.TableFieldSchema, Dict[str, _Format], bool) -> None
   for field in schema.fields:
     if field.name in _CONSTANT_CALL_FIELDS:
       continue
@@ -236,12 +236,12 @@ def _add_format_fields(schema, allow_incompatible_schema, formats):
           desc=field.description)})
 
 
-def _add_info_fields(field, allow_incompatible_schema, infos):
-  # type: (bigquery.TableFieldSchema, bool, Dict[str, _Info]) -> None
+def _add_info_fields(field, infos, allow_incompatible_schema=False):
+  # type: (bigquery.TableFieldSchema, Dict[str, _Info], bool) -> None
   if field.name == bigquery_util.ColumnKeyConstants.ALTERNATE_BASES:
     _add_info_fields_from_alternate_bases(field,
-                                          allow_incompatible_schema,
-                                          infos)
+                                          infos,
+                                          allow_incompatible_schema)
   elif (field.name in vcf_reserved_fields.INFO_FIELDS.keys() and
         not allow_incompatible_schema):
     reserved_definition = vcf_reserved_fields.INFO_FIELDS.get(field.name)
@@ -265,9 +265,9 @@ def _add_info_fields(field, allow_incompatible_schema, infos):
 
 
 def _add_info_fields_from_alternate_bases(schema,
-                                          allow_incompatible_schema,
-                                          infos):
-  # type: (bigquery.TableFieldSchema, bool, Dict[str, _Info]) -> None
+                                          infos,
+                                          allow_incompatible_schema=False):
+  # type: (bigquery.TableFieldSchema, Dict[str, _Info], bool) -> None
   """Adds schema nested fields in alternate bases to `infos`.
 
   Notice that the validation of field mode is skipped for reserved fields since

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -502,3 +502,11 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
         help=('A list of call names (separated by a space). Only variants for '
               'these calls will be loaded from BigQuery. If this parameter is '
               'not specified, all calls will be kept.'))
+    parser.add_argument(
+        '--allow_incompatible_schema',
+        type='bool', default=False, nargs='?', const=True,
+        help=('If true, the incompatibilities between BigQuery schema and the '
+              'reserved fields based on VCF 4.3 spec (see '
+              'http://samtools.github.io/hts-specs/VCFv4.3.pdf for more '
+              'details.) will not raise errors. Instead, the VCF meta '
+              'information are inferred by the schema without validation.'))


### PR DESCRIPTION
In BQ to VCF pipeline, an error occurs if the schema is not compatible with the reserved  fields in VCF 4.3 spec. Currently there is no easy way to load these tables. Therefore, this PR:
- Provide an option `--allow_incompatible_schema` to disregard the reserved fields.

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: Manually ran BQ to VCF test with the option.

