### PR TITLE
update the temp file name for each job to be unique

### DIFF
--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -99,20 +99,21 @@ def run(argv=None):
 
   temp_folder = google_cloud_options.temp_location or tempfile.mkdtemp()
   timestamp_str = datetime.now().strftime('%Y%m%d_%H%M%S')
+  _, _, table_id = bigquery_util.parse_table_reference(known_args.input_table)
   vcf_data_temp_folder = filesystems.FileSystems.join(
       temp_folder,
-      'bq_to_vcf_data_temp_files_{}'.format(timestamp_str))
+      'bq_to_vcf_data_temp_files_{}_{}'.format(table_id, timestamp_str))
   # Create the directory manually. FileSystems cannot create a file if the
   # directory does not exist when using Direct Runner.
   filesystems.FileSystems.mkdirs(vcf_data_temp_folder)
   vcf_header_file_path = filesystems.FileSystems.join(
       temp_folder,
-      'bq_to_vcf_header_with_call_names_{}'.format(timestamp_str))
+      'bq_to_vcf_header_with_call_names_{}_{}'.format(table_id, timestamp_str))
 
   if not known_args.representative_header_file:
     known_args.representative_header_file = filesystems.FileSystems.join(
         temp_folder,
-        'bq_to_vcf_meta_info_{}'.format(timestamp_str))
+        'bq_to_vcf_meta_info_{}_{}'.format(table_id, timestamp_str))
     _write_vcf_meta_info(known_args.input_table,
                          known_args.representative_header_file,
                          known_args.allow_incompatible_schema)

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -104,24 +104,29 @@ def run(argv=None):
   # pipelines can run at the same time. Refactor it to a common lib.
   job_name = '-'.join([_BQ_TO_VCF_SHARDS_JOB_NAME,
                        datetime.now().strftime('%Y%m%d-%H%M%S')])
+  # Update the google_cloud_options.job name is necessary:
+  # - If the job_name is provided, the time stamp provides unique temp files.
+  # - Otherwise, there are no unique identifiers for the temp files, assigning
+  # the job_name stops multiple pipelines from interacting with the same temp
+  # files.
   if google_cloud_options.job_name:
     google_cloud_options.job_name += '-' + job_name
   else:
     google_cloud_options.job_name = job_name
   vcf_data_temp_folder = filesystems.FileSystems.join(
       temp_folder,
-      '{}_data_temp_files'.format(job_name))
+      '{}_data_temp_files'.format(google_cloud_options.job_name))
   # Create the directory manually. FileSystems cannot create a file if the
   # directory does not exist when using Direct Runner.
   filesystems.FileSystems.mkdirs(vcf_data_temp_folder)
   vcf_header_file_path = filesystems.FileSystems.join(
       temp_folder,
-      '{}_header_with_call_names.vcf'.format(job_name))
+      '{}_header_with_call_names.vcf'.format(google_cloud_options.job_name))
 
   if not known_args.representative_header_file:
     known_args.representative_header_file = filesystems.FileSystems.join(
         temp_folder,
-        '{}_meta_info.vcf'.format(job_name))
+        '{}_meta_info.vcf'.format(google_cloud_options.job_name))
     _write_vcf_meta_info(known_args.input_table,
                          known_args.representative_header_file,
                          known_args.allow_incompatible_schema)


### PR DESCRIPTION
When there are multiple test cases in BQ to VCF integration tests, it happens that the temp folders and some intermediate files are using the same name for different jobs. This PR
- Add the table_id to the temp folders and files that are unique for each job.

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests, manually ran bq to vcf.