### PR TITLE
load public BQ table to VCF

### DIFF
--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -45,7 +45,6 @@ from __future__ import division
 import logging
 import sys
 import tempfile
-import time
 from datetime import datetime
 from typing import Dict, Iterable, List, Tuple  # pylint: disable=unused-import
 
@@ -85,7 +84,6 @@ def run(argv=None):
   # type: (List[str]) -> None
   """Runs BigQuery to VCF pipeline."""
   logging.info('Command: %s', ' '.join(argv or sys.argv))
-  start_time = time.time()
   known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
                                                           _COMMAND_LINE_OPTIONS)
   options = pipeline_options.PipelineOptions(pipeline_args)
@@ -123,7 +121,6 @@ def run(argv=None):
                           options,
                           vcf_data_temp_folder,
                           vcf_header_file_path)
-  print ("Pipeline running time --- %s seconds ---" % (time.time() - start_time))
   if is_direct_runner:
     vcf_file_composer.compose_local_vcf_shards(vcf_header_file_path,
                                                vcf_data_temp_folder,
@@ -133,8 +130,6 @@ def run(argv=None):
                                              vcf_header_file_path,
                                              vcf_data_temp_folder,
                                              known_args.output_file)
-
-  print ("Total time --- %s seconds ---" % (time.time() - start_time))
 
 
 def _write_vcf_meta_info(input_table,

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -45,6 +45,7 @@ from __future__ import division
 import logging
 import sys
 import tempfile
+import time
 from datetime import datetime
 from typing import Dict, Iterable, List, Tuple  # pylint: disable=unused-import
 
@@ -84,6 +85,7 @@ def run(argv=None):
   # type: (List[str]) -> None
   """Runs BigQuery to VCF pipeline."""
   logging.info('Command: %s', ' '.join(argv or sys.argv))
+  start_time = time.time()
   known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
                                                           _COMMAND_LINE_OPTIONS)
   options = pipeline_options.PipelineOptions(pipeline_args)
@@ -121,6 +123,7 @@ def run(argv=None):
                           options,
                           vcf_data_temp_folder,
                           vcf_header_file_path)
+  print ("Pipeline running time --- %s seconds ---" % (time.time() - start_time))
   if is_direct_runner:
     vcf_file_composer.compose_local_vcf_shards(vcf_header_file_path,
                                                vcf_data_temp_folder,
@@ -130,6 +133,8 @@ def run(argv=None):
                                              vcf_header_file_path,
                                              vcf_data_temp_folder,
                                              known_args.output_file)
+
+  print ("Total time --- %s seconds ---" % (time.time() - start_time))
 
 
 def _write_vcf_meta_info(input_table,

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -59,11 +59,11 @@ class _SupportedTableFieldType(enum.Enum):
 
   Only schema fields with these types are interchangeable with VCF.
   """
-  TYPE_STRING = 'STRING'
-  TYPE_INTEGER = 'INTEGER'
-  TYPE_RECORD = 'RECORD'
-  TYPE_FLOAT = 'FLOAT'
-  TYPE_BOOLEAN = 'BOOLEAN'
+  TYPE_STRING = TableFieldConstants.TYPE_STRING
+  TYPE_INTEGER = TableFieldConstants.TYPE_INTEGER
+  TYPE_RECORD = TableFieldConstants.TYPE_RECORD
+  TYPE_FLOAT = TableFieldConstants.TYPE_FLOAT
+  TYPE_BOOLEAN = TableFieldConstants.TYPE_BOOLEAN
 
 
 # A map to convert from VCF types to their equivalent BigQuery types.

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -49,6 +49,7 @@ class TableFieldConstants(object):
   TYPE_RECORD = 'RECORD'
   TYPE_FLOAT = 'FLOAT'
   TYPE_BOOLEAN = 'BOOLEAN'
+  TYPE_DATE = 'DATE'
   MODE_NULLABLE = 'NULLABLE'
   MODE_REPEATED = 'REPEATED'
 
@@ -134,7 +135,7 @@ def get_vcf_type_from_bigquery_type(bigquery_type):
 def get_vcf_num_from_bigquery_schema(bigquery_mode, bigquery_type):
   # type: (str, str) -> int
   """Returns VCF num based on BigQuery mode and type."""
-  if bigquery_mode == TableFieldConstants.MODE_NULLABLE:
-    return 0 if bigquery_type == TableFieldConstants.TYPE_BOOLEAN else 1
-  else:
+  if bigquery_mode == TableFieldConstants.MODE_REPEATED:
     return parser.field_counts[vcfio.MISSING_FIELD_VALUE]
+  else:
+    return 0 if bigquery_type == TableFieldConstants.TYPE_BOOLEAN else 1

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -14,6 +14,7 @@
 
 """Constants and simple utility functions related to BigQuery."""
 
+import enum
 import re
 from typing import Tuple  # pylint: disable=unused-import
 
@@ -49,9 +50,20 @@ class TableFieldConstants(object):
   TYPE_RECORD = 'RECORD'
   TYPE_FLOAT = 'FLOAT'
   TYPE_BOOLEAN = 'BOOLEAN'
-  TYPE_DATE = 'DATE'
   MODE_NULLABLE = 'NULLABLE'
   MODE_REPEATED = 'REPEATED'
+
+
+class _SupportedTableFieldType(enum.Enum):
+  """The supported BigQuery field types.
+
+  Only schema fields with these types are interchangeable with VCF.
+  """
+  TYPE_STRING = 'STRING'
+  TYPE_INTEGER = 'INTEGER'
+  TYPE_RECORD = 'RECORD'
+  TYPE_FLOAT = 'FLOAT'
+  TYPE_BOOLEAN = 'BOOLEAN'
 
 
 # A map to convert from VCF types to their equivalent BigQuery types.
@@ -139,3 +151,8 @@ def get_vcf_num_from_bigquery_schema(bigquery_mode, bigquery_type):
     return parser.field_counts[vcfio.MISSING_FIELD_VALUE]
   else:
     return 0 if bigquery_type == TableFieldConstants.TYPE_BOOLEAN else 1
+
+
+def get_supported_bigquery_schema_types():
+  """Returns the supported BigQuery field types."""
+  return [item.value for item in _SupportedTableFieldType]

--- a/gcp_variant_transforms/libs/bigquery_util_test.py
+++ b/gcp_variant_transforms/libs/bigquery_util_test.py
@@ -82,3 +82,8 @@ class BigqueryUtilTest(unittest.TestCase):
                      bigquery_util.get_vcf_num_from_bigquery_schema(
                          bigquery_util.TableFieldConstants.MODE_NULLABLE,
                          bigquery_util.TableFieldConstants.TYPE_BOOLEAN))
+    self.assertEqual(
+        0,
+        bigquery_util.get_vcf_num_from_bigquery_schema(
+            bigquery_mode=None,
+            bigquery_type=bigquery_util.TableFieldConstants.TYPE_BOOLEAN))

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
@@ -203,8 +203,8 @@ def generate_header_fields_from_schema(schema, allow_incompatible_schema=False):
   infos = OrderedDict()  # type: OrderedDict[str, _Info]
   formats = OrderedDict()  # type: OrderedDict[str, _Format]
   for field in schema.fields:
-    if (field.type == bigquery_util.TableFieldConstants.TYPE_DATE or
-        field.name in _NON_INFO_OR_FORMAT_CONSTANT_FIELDS):
+    if (field.type not in bigquery_util.get_supported_bigquery_schema_types()
+        or field.name in _NON_INFO_OR_FORMAT_CONSTANT_FIELDS):
       continue
     elif field.name == bigquery_util.ColumnKeyConstants.CALLS:
       _add_format_fields(field, formats, allow_incompatible_schema)
@@ -325,9 +325,8 @@ def _validate_reserved_field_type(field_schema, reserved_definition):
 
 
 def _validate_reserved_field_mode(field_schema, reserved_definition):
-  schema_mode = field_schema.mode
-  if not schema_mode:
-    schema_mode = bigquery_util.TableFieldConstants.MODE_NULLABLE
+  schema_mode = (field_schema.mode or
+                 bigquery_util.TableFieldConstants.MODE_NULLABLE)
   reserved_mode = bigquery_util.get_bigquery_mode_from_vcf_num(
       reserved_definition.num)
   if schema_mode != reserved_mode:

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
@@ -203,7 +203,8 @@ def generate_header_fields_from_schema(schema, allow_incompatible_schema=False):
   infos = OrderedDict()  # type: OrderedDict[str, _Info]
   formats = OrderedDict()  # type: OrderedDict[str, _Format]
   for field in schema.fields:
-    if field.name in _NON_INFO_OR_FORMAT_CONSTANT_FIELDS:
+    if (field.type == bigquery_util.TableFieldConstants.TYPE_DATE or
+        field.name in _NON_INFO_OR_FORMAT_CONSTANT_FIELDS):
       continue
     elif field.name == bigquery_util.ColumnKeyConstants.CALLS:
       _add_format_fields(field, formats, allow_incompatible_schema)
@@ -325,6 +326,8 @@ def _validate_reserved_field_type(field_schema, reserved_definition):
 
 def _validate_reserved_field_mode(field_schema, reserved_definition):
   schema_mode = field_schema.mode
+  if not schema_mode:
+    schema_mode = bigquery_util.TableFieldConstants.MODE_NULLABLE
   reserved_mode = bigquery_util.get_bigquery_mode_from_vcf_num(
       reserved_definition.num)
   if schema_mode != reserved_mode:

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter_test.py
@@ -447,6 +447,47 @@ class GenerateHeaderFieldsFromSchemaTest(unittest.TestCase):
     expected_header = vcf_header_io.VcfHeader(infos=infos, formats=formats)
     self.assertEqual(header, expected_header)
 
+  def test_generate_header_fields_from_schema_date_type(self):
+    schema = bigquery.TableSchema()
+    schema.fields.append(bigquery.TableFieldSchema(
+        name='partition_date_please_ignore',
+        type=bigquery_util.TableFieldConstants.TYPE_DATE,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='Column required by BigQuery partitioning logic.'))
+    header = bigquery_vcf_schema_converter.generate_header_fields_from_schema(
+        schema)
+
+    expected_header = vcf_header_io.VcfHeader(infos=OrderedDict(),
+                                              formats=OrderedDict())
+    self.assertEqual(header, expected_header)
+
+  def test_generate_header_fields_from_schema_none_mode(self):
+    schema_non_reserved_fields = bigquery.TableSchema()
+    schema_non_reserved_fields.fields.append(bigquery.TableFieldSchema(
+        name='field',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        description='desc'))
+    header = bigquery_vcf_schema_converter.generate_header_fields_from_schema(
+        schema_non_reserved_fields)
+    infos = OrderedDict([
+        ('field', Info('field', 1, 'String', 'desc', None, None))])
+    formats = OrderedDict()
+    expected_header = vcf_header_io.VcfHeader(infos=infos, formats=formats)
+    self.assertEqual(header, expected_header)
+
+    schema_reserved_fields = bigquery.TableSchema()
+    schema_reserved_fields.fields.append(bigquery.TableFieldSchema(
+        name='AA',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        description='desc'))
+    header = bigquery_vcf_schema_converter.generate_header_fields_from_schema(
+        schema_reserved_fields)
+    infos = OrderedDict([
+        ('AA', Info('AA', 1, 'String', 'desc', None, None))])
+    formats = OrderedDict()
+    expected_header = vcf_header_io.VcfHeader(infos=infos, formats=formats)
+    self.assertEqual(header, expected_header)
+
   def test_generate_header_fields_from_schema_schema_compatibility(self):
     schema_conflict = bigquery.TableSchema()
     schema_conflict.fields.append(bigquery.TableFieldSchema(

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter_test.py
@@ -451,7 +451,7 @@ class GenerateHeaderFieldsFromSchemaTest(unittest.TestCase):
     schema = bigquery.TableSchema()
     schema.fields.append(bigquery.TableFieldSchema(
         name='partition_date_please_ignore',
-        type=bigquery_util.TableFieldConstants.TYPE_DATE,
+        type='Date',
         mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
         description='Column required by BigQuery partitioning logic.'))
     header = bigquery_vcf_schema_converter.generate_header_fields_from_schema(


### PR DESCRIPTION
Update the code to support the public genomic tables:
- Ignore the schema field if it has type DATE.
- Support the MODE=None fields. When trying to retrieve the mode for NULLABLE fields, it is  actually `None` instead of `NULLABLE` for the public tables (for instance, 
`bigquery-public-data:human_genome_variants.1000_genomes_phase_3_variants_20150220`).

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests & manually ran BQ to VCF.