### PR TITLE
remove date info from variant

### DIFF
--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -72,7 +72,7 @@ from gcp_variant_transforms.transforms import combine_call_names
 from gcp_variant_transforms.transforms import densify_variants
 
 
-_BASE_QUERY_TEMPLATE = 'SELECT * FROM `{INPUT_TABLE}`'
+_BASE_QUERY_TEMPLATE = 'SELECT {COLUMNS} FROM `{INPUT_TABLE}`'
 _GENOMIC_REGION_TEMPLATE = ('({REFERENCE_NAME_ID}="{REFERENCE_NAME_VALUE}" AND '
                             '{START_POSITION_ID}>={START_POSITION_VALUE} AND '
                             '{END_POSITION_ID}<={END_POSITION_VALUE})')
@@ -169,13 +169,14 @@ def _bigquery_to_vcf_shards(
   Also, it writes the meta info and data header with the call names to
   `vcf_header_file_path`.
   """
+  schema = _get_schema(known_args.input_table)
+  columns = _get_query_columns(schema)
   # TODO(allieychen): Modify the SQL query with the specified call_names.
-  query = _get_bigquery_query(known_args)
+  query = _get_bigquery_query(known_args, columns)
   logging.info('Processing BigQuery query %s:', query)
   bq_source = bigquery.BigQuerySource(query=query,
                                       validate=True,
                                       use_standard_sql=True)
-  schema = _get_schema(known_args.input_table)
   annotation_names = _extract_annotation_names(schema)
   with beam.Pipeline(options=beam_pipeline_options) as p:
     variants = (p
@@ -218,11 +219,13 @@ def _get_schema(input_table):
   return table.schema
 
 
-def _get_bigquery_query(known_args):
-  # type: (argparse.Namespace) -> str
+def _get_bigquery_query(known_args, columns=None):
+  # type: (argparse.Namespace, List[str]) -> str
   """Returns a BigQuery query for the interested regions."""
-  base_query = _BASE_QUERY_TEMPLATE.format(INPUT_TABLE='.'.join(
-      bigquery_util.parse_table_reference(known_args.input_table)))
+  base_query = _BASE_QUERY_TEMPLATE.format(
+      COLUMNS=', '.join(columns or ['*']),
+      INPUT_TABLE='.'.join(
+          bigquery_util.parse_table_reference(known_args.input_table)))
   conditions = []
   if known_args.genomic_regions:
     for region in known_args.genomic_regions:
@@ -259,6 +262,21 @@ def _extract_annotation_names(schema):
               sub_field.name: [field.name for field in sub_field.fields]
           })
   return annotation_names
+
+
+def _get_query_columns(schema):
+  # type: (bigquery_v2.TableSchema) -> List[str]
+  """Returns a list of columns to be selected for the query.
+
+  Only the fields with supported schema types are loaded from BigQuery. e.g.,
+  in the clustered table, the field with type DATE will be ignored. Also,
+  it assumes that all sub fields in the RECORD fields have valid types.
+  """
+  columns = []
+  for table_field in schema.fields:
+    if table_field.type in bigquery_util.get_supported_bigquery_schema_types():
+      columns.append(table_field.name)
+  return columns
 
 
 def _write_vcf_header_with_call_names(sample_names,

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -170,9 +170,8 @@ def _bigquery_to_vcf_shards(
   `vcf_header_file_path`.
   """
   schema = _get_schema(known_args.input_table)
-  columns = _get_query_columns(schema)
   # TODO(allieychen): Modify the SQL query with the specified call_names.
-  query = _get_bigquery_query(known_args, columns)
+  query = _get_bigquery_query(known_args, schema)
   logging.info('Processing BigQuery query %s:', query)
   bq_source = bigquery.BigQuerySource(query=query,
                                       validate=True,
@@ -208,7 +207,7 @@ def _bigquery_to_vcf_shards(
 
 
 def _get_schema(input_table):
-  # type: (str) -> bigqueryv2.TableSchema
+  # type: (str) -> bigquery_v2.TableSchema
   project_id, dataset_id, table_id = bigquery_util.parse_table_reference(
       input_table)
   credentials = (client.GoogleCredentials.get_application_default().
@@ -219,11 +218,12 @@ def _get_schema(input_table):
   return table.schema
 
 
-def _get_bigquery_query(known_args, columns=None):
-  # type: (argparse.Namespace, List[str]) -> str
+def _get_bigquery_query(known_args, schema):
+  # type: (argparse.Namespace, bigquery_v2.TableSchema) -> str
   """Returns a BigQuery query for the interested regions."""
+  columns = _get_query_columns(schema)
   base_query = _BASE_QUERY_TEMPLATE.format(
-      COLUMNS=', '.join(columns or ['*']),
+      COLUMNS=', '.join(columns),
       INPUT_TABLE='.'.join(
           bigquery_util.parse_table_reference(known_args.input_table)))
   conditions = []

--- a/gcp_variant_transforms/bq_to_vcf_test.py
+++ b/gcp_variant_transforms/bq_to_vcf_test.py
@@ -72,13 +72,31 @@ class BqToVcfTest(unittest.TestCase):
     args_1 = self._create_mock_args(
         input_table='my_bucket:my_dataset.my_table',
         genomic_regions=['c1:1,000-2,000', 'c2'])
+    columns = ['reference_name', 'start_position']
     expected_query = (
-        'SELECT * FROM `my_bucket.my_dataset.my_table` WHERE '
+        'SELECT reference_name, start_position FROM '
+        '`my_bucket.my_dataset.my_table` WHERE '
         '(reference_name="c1" AND start_position>=1000 AND end_position<=2000) '
         'OR (reference_name="c2" AND start_position>=0 AND '
         'end_position<=9223372036854775807)'
     )
-    self.assertEqual(bq_to_vcf._get_bigquery_query(args_1), expected_query)
+    self.assertEqual(bq_to_vcf._get_bigquery_query(args_1, columns),
+                     expected_query)
+
+  def test_get_query_columns(self):
+    schema = bigquery.TableSchema()
+    schema.fields.append(bigquery.TableFieldSchema(
+        name=bigquery_util.ColumnKeyConstants.REFERENCE_NAME,
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='Reference name.'))
+    schema.fields.append(bigquery.TableFieldSchema(
+        name='partition_date_please_ignore',
+        type='Date',
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='Column required by BigQuery partitioning logic.'))
+    expected_columns = [bigquery_util.ColumnKeyConstants.REFERENCE_NAME]
+    self.assertEqual(bq_to_vcf._get_query_columns(schema), expected_columns)
 
   def test_get_annotation_names(self):
     schema_with_annotations = bigquery_schema_util.get_sample_table_schema(


### PR DESCRIPTION
Follow up for [PR 373](https://github.com/googlegenomics/gcp-variant-transforms/pull/373), update the code to support the public genomic tables:

- remove the unsupported columns (e.g., Date column) when forming the query.

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: unit tests & manually ran BQ to VCF.