### PR TITLE
update the default value for number of bases per shard

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -477,7 +477,7 @@ class BigQueryToVcfOptions(VariantTransformsOptions):
               'format of (PROJECT:DATASET.TABLE).'))
     parser.add_argument(
         '--number_of_bases_per_shard',
-        type=int, default=10000,
+        type=int, default=1000000,
         help=('The maximum number of base pairs per chromosome to include in a '
               'single VCF file (one shard). A shard is a collection of data '
               'within a contiguous region of the genome. This parameter will '


### PR DESCRIPTION
Change the default value of `number_of_bases_per_shard` from 10,000 to 1,000,000.
- For large datasets (tested with `bigquery-public-data:human_genome_variants.platinum_genomes_deepvariant_variants_20180823`), the run time for BigQuery to VCF shards are almost the same (45min), while the time for composing the shards are significantly dropped (from 1.8h to 1 min).

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: manually ran BQ to VCF.