### PR TITLE
Add version in VCF loaded from BQ

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_header_io.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io.py
@@ -271,9 +271,11 @@ class WriteVcfHeaderFn(beam.DoFn):
     self._file_path = file_path
     self._file_to_write = None
 
-  def process(self, header):
-    # type: (VcfHeader) -> None
+  def process(self, header, vcf_version_line=None):
+    # type: (VcfHeader, str) -> None
     with FileSystems.create(self._file_path) as self._file_to_write:
+      if vcf_version_line:
+        self._file_to_write.write(vcf_version_line)
       self._write_headers_by_type(HeaderTypeConstants.INFO, header.infos)
       self._write_headers_by_type(HeaderTypeConstants.FILTER, header.filters)
       self._write_headers_by_type(HeaderTypeConstants.ALT, header.alts)

--- a/gcp_variant_transforms/beam_io/vcf_header_io_test.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io_test.py
@@ -285,6 +285,29 @@ class WriteVcfHeadersTest(unittest.TestCase):
       header_fn.process(header)
       self._assert_file_contents_equal(tempfile, self.lines)
 
+  def test_write_headers_with_vcf_version_line(self):
+    header = _get_vcf_header_from_lines(self.lines)
+    vcf_version_line = '##fileformat=VCFv4.3\n'
+    expected_results = [
+        vcf_version_line,
+        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+        '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
+        '##INFO=<ID=HG,Number=G,Type=Integer,Description="IntInfo_G">\n',
+        '##INFO=<ID=HR,Number=R,Type=Character,Description="ChrInfo_R">\n',
+        '##FILTER=<ID=MPCBT,Description="Mate pair count below 10">\n',
+        '##ALT=<ID=INS:ME:MER,Description="Insertion of MER element">\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
+        '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="GQ">\n',
+        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT\n'
+    ]
+    with temp_dir.TempDir() as tempdir:
+      tempfile = tempdir.create_temp_file(suffix='.vcf')
+      header_fn = WriteVcfHeaderFn(tempfile)
+      header_fn.process(header, vcf_version_line)
+      with open(tempfile, 'rb') as f:
+        actual = f.readlines()
+        self.assertItemsEqual(actual, expected_results)
+
   def _remove_sample_names(self, line):
     # Return line with all columns except sample names.
     return '\t'.join(line.split('\t')[:9])

--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -73,13 +73,14 @@ from gcp_variant_transforms.transforms import densify_variants
 
 
 _BASE_QUERY_TEMPLATE = 'SELECT {COLUMNS} FROM `{INPUT_TABLE}`'
+_BQ_TO_VCF_SHARDS_JOB_NAME = 'bq-to-vcf-shards'
+_COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
 _GENOMIC_REGION_TEMPLATE = ('({REFERENCE_NAME_ID}="{REFERENCE_NAME_VALUE}" AND '
                             '{START_POSITION_ID}>={START_POSITION_VALUE} AND '
                             '{END_POSITION_ID}<={END_POSITION_VALUE})')
-_COMMAND_LINE_OPTIONS = [variant_transform_options.BigQueryToVcfOptions]
 _VCF_FIXED_COLUMNS = ['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER',
                       'INFO', 'FORMAT']
-_BQ_TO_VCF_SHARDS_JOB_NAME = 'bq-to-vcf-shards'
+_VCF_VERSION_LINE = '##fileformat=VCFv4.3\n'
 
 
 def run(argv=None):
@@ -148,7 +149,7 @@ def _write_vcf_meta_info(input_table,
       bigquery_vcf_schema_converter.generate_header_fields_from_schema(
           _get_schema(input_table), allow_incompatible_schema))
   write_header_fn = vcf_header_io.WriteVcfHeaderFn(representative_header_file)
-  write_header_fn.process(header_fields)
+  write_header_fn.process(header_fields, _VCF_VERSION_LINE)
 
 
 def _bigquery_to_vcf_shards(

--- a/gcp_variant_transforms/testing/data/vcf/bq_to_vcf/expected_output/4_0.vcf
+++ b/gcp_variant_transforms/testing/data/vcf/bq_to_vcf/expected_output/4_0.vcf
@@ -1,3 +1,4 @@
+##fileformat=VCFv4.3
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">

--- a/gcp_variant_transforms/testing/data/vcf/bq_to_vcf/expected_output/4_0_option_customized_export.vcf
+++ b/gcp_variant_transforms/testing/data/vcf/bq_to_vcf/expected_output/4_0_option_customized_export.vcf
@@ -1,3 +1,4 @@
+##fileformat=VCFv4.3
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">

--- a/gcp_variant_transforms/testing/data/vcf/bq_to_vcf/expected_output/4_2_option_allow_incompatible_schema.vcf
+++ b/gcp_variant_transforms/testing/data/vcf/bq_to_vcf/expected_output/4_2_option_allow_incompatible_schema.vcf
@@ -1,3 +1,4 @@
+##fileformat=VCFv4.3
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">

--- a/gcp_variant_transforms/testing/data/vcf/bq_to_vcf/expected_output/densify_samples.vcf
+++ b/gcp_variant_transforms/testing/data/vcf/bq_to_vcf/expected_output/densify_samples.vcf
@@ -1,3 +1,4 @@
+##fileformat=VCFv4.3
 ##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">
 ##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
 ##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">


### PR DESCRIPTION
In the BQ to VCF pipeline, add the version `##fileformat=VCFv4.3\n` in the VCF file if the meta info is inferred from the BigQuery schema.

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: integration tests.