### PR TITLE
Remove the new lines in description

### DIFF
--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
@@ -227,14 +227,15 @@ def _add_format_fields(schema, formats, allow_incompatible_schema=False):
           id=field.name,
           num=reserved_definition.num,
           type=reserved_definition.type,
-          desc=field.description or reserved_definition.desc)})
+          desc=(_remove_new_line_character(field.description) or
+                reserved_definition.desc))})
     else:
       formats.update({field.name: _Format(
           id=field.name,
           num=bigquery_util.get_vcf_num_from_bigquery_schema(field.mode,
                                                              field.type),
           type=bigquery_util.get_vcf_type_from_bigquery_type(field.type),
-          desc=field.description)})
+          desc=_remove_new_line_character(field.description))})
 
 
 def _add_info_fields(field, infos, allow_incompatible_schema=False):
@@ -251,7 +252,8 @@ def _add_info_fields(field, infos, allow_incompatible_schema=False):
         id=field.name,
         num=reserved_definition.num,
         type=reserved_definition.type,
-        desc=field.description or reserved_definition.desc,
+        desc=(_remove_new_line_character(field.description) or
+              reserved_definition.desc),
         source=None,
         version=None)})
   else:
@@ -260,7 +262,7 @@ def _add_info_fields(field, infos, allow_incompatible_schema=False):
         num=bigquery_util.get_vcf_num_from_bigquery_schema(field.mode,
                                                            field.type),
         type=bigquery_util.get_vcf_type_from_bigquery_type(field.type),
-        desc=field.description,
+        desc=_remove_new_line_character(field.description),
         source=None,
         version=None)})
 
@@ -290,7 +292,8 @@ def _add_info_fields_from_alternate_bases(schema,
           id=field.name,
           num=reserved_definition.num,
           type=reserved_definition.type,
-          desc=field.description or reserved_definition.desc,
+          desc=(_remove_new_line_character(field.description) or
+                reserved_definition.desc),
           source=None,
           version=None)})
     else:
@@ -298,7 +301,7 @@ def _add_info_fields_from_alternate_bases(schema,
           id=field.name,
           num=parser.field_counts[vcfio.FIELD_COUNT_ALTERNATE_ALLELE],
           type=bigquery_util.get_vcf_type_from_bigquery_type(field.type),
-          desc=field.description,
+          desc=_remove_new_line_character(field.description),
           source=None,
           version=None)})
 
@@ -333,3 +336,7 @@ def _validate_reserved_field_mode(field_schema, reserved_definition):
     raise ValueError(
         'The mode of field {} is different from the VCF spec: {} vs {}.'
         .format(field_schema.name, schema_mode, reserved_mode))
+
+
+def _remove_new_line_character(description):
+  return description.replace('\n', ' ')

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
@@ -227,15 +227,15 @@ def _add_format_fields(schema, formats, allow_incompatible_schema=False):
           id=field.name,
           num=reserved_definition.num,
           type=reserved_definition.type,
-          desc=(_remove_new_line_character(field.description) or
-                reserved_definition.desc))})
+          desc=_remove_special_characters(field.description or
+                                          reserved_definition.desc))})
     else:
       formats.update({field.name: _Format(
           id=field.name,
           num=bigquery_util.get_vcf_num_from_bigquery_schema(field.mode,
                                                              field.type),
           type=bigquery_util.get_vcf_type_from_bigquery_type(field.type),
-          desc=_remove_new_line_character(field.description))})
+          desc=_remove_special_characters(field.description))})
 
 
 def _add_info_fields(field, infos, allow_incompatible_schema=False):
@@ -252,8 +252,8 @@ def _add_info_fields(field, infos, allow_incompatible_schema=False):
         id=field.name,
         num=reserved_definition.num,
         type=reserved_definition.type,
-        desc=(_remove_new_line_character(field.description) or
-              reserved_definition.desc),
+        desc=_remove_special_characters(field.description or
+                                        reserved_definition.desc),
         source=None,
         version=None)})
   else:
@@ -262,7 +262,7 @@ def _add_info_fields(field, infos, allow_incompatible_schema=False):
         num=bigquery_util.get_vcf_num_from_bigquery_schema(field.mode,
                                                            field.type),
         type=bigquery_util.get_vcf_type_from_bigquery_type(field.type),
-        desc=_remove_new_line_character(field.description),
+        desc=_remove_special_characters(field.description),
         source=None,
         version=None)})
 
@@ -292,8 +292,8 @@ def _add_info_fields_from_alternate_bases(schema,
           id=field.name,
           num=reserved_definition.num,
           type=reserved_definition.type,
-          desc=(_remove_new_line_character(field.description) or
-                reserved_definition.desc),
+          desc=_remove_special_characters(field.description or
+                                          reserved_definition.desc),
           source=None,
           version=None)})
     else:
@@ -301,7 +301,7 @@ def _add_info_fields_from_alternate_bases(schema,
           id=field.name,
           num=parser.field_counts[vcfio.FIELD_COUNT_ALTERNATE_ALLELE],
           type=bigquery_util.get_vcf_type_from_bigquery_type(field.type),
-          desc=_remove_new_line_character(field.description),
+          desc=_remove_special_characters(field.description),
           source=None,
           version=None)})
 
@@ -338,5 +338,5 @@ def _validate_reserved_field_mode(field_schema, reserved_definition):
         .format(field_schema.name, schema_mode, reserved_mode))
 
 
-def _remove_new_line_character(description):
+def _remove_special_characters(description):
   return description.replace('\n', ' ')

--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter_test.py
@@ -508,6 +508,24 @@ class GenerateHeaderFieldsFromSchemaTest(unittest.TestCase):
                                               formats=OrderedDict())
     self.assertEqual(header, expected_header)
 
+  def test_generate_header_fields_from_schema_invalid_description(self):
+    schema = bigquery.TableSchema()
+    schema.fields.append(bigquery.TableFieldSchema(
+        name='invalid_description',
+        type=bigquery_util.TableFieldConstants.TYPE_STRING,
+        mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
+        description='Desc\nThis is added intentionally.'))
+    header = bigquery_vcf_schema_converter.generate_header_fields_from_schema(
+        schema)
+
+    infos = OrderedDict([
+        ('invalid_description', Info('invalid_description', 1, 'String',
+                                     'Desc This is added intentionally.',
+                                     None, None))])
+    expected_header = vcf_header_io.VcfHeader(infos=infos,
+                                              formats=OrderedDict())
+    self.assertEqual(header, expected_header)
+
 
 class VcfHeaderAndSchemaConverterCombinationTest(unittest.TestCase):
   """Test cases for concatenating VCF header and schema converters."""


### PR DESCRIPTION
In BigQuery public datasets, there are some field descriptions contain `\n` (For instance, in `call.quality` of `bigquery-public-data:human_genome_variants.platinum_genomes_deepvariant_variants_20180823` ).  If adding those descriptions with `\n` into the VCF header, loading it back to BQ will raise an error. This PR:
- replacing all `\n` to ` `.

Issues: [85](https://github.com/googlegenomics/gcp-variant-transforms/issues/85)
Tested: manually tested bq to vcf.