### PR TITLE
Minor fix: return empty description if null.

### DIFF
--- a/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_schema_converter.py
@@ -339,4 +339,4 @@ def _validate_reserved_field_mode(field_schema, reserved_definition):
 
 
 def _remove_special_characters(description):
-  return description.replace('\n', ' ')
+  return description.replace('\n', ' ') if description else ''


### PR DESCRIPTION
This happens when loading 1000 genomes as one of the descriptions is null.