### PR TITLE
Update integration tests to use piplines v2alpha1.

### DIFF
--- a/gcp_variant_transforms/testing/integration/run_bq_to_vcf_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_bq_to_vcf_tests.py
@@ -80,7 +80,8 @@ class BqToVcfTestCase(run_tests_common.TestCaseInterface):
 
     self.pipelines_api_request = run_tests_common.form_pipelines_api_request(
         parsed_args.project,
-        '/'.join([parsed_args.logging_location, self._output_file]),
+        filesystems.FileSystems.join(parsed_args.logging_location,
+                                     '_'.join([test_name, timestamp])),
         parsed_args.image, _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
 
   def validate_result(self):

--- a/gcp_variant_transforms/testing/integration/run_bq_to_vcf_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_bq_to_vcf_tests.py
@@ -42,7 +42,6 @@ from gcp_variant_transforms.testing.integration import run_tests_common
 
 
 _PIPELINE_NAME = 'gcp-variant-transforms-bq-to-vcf-integration-test'
-_SCOPES = ['https://www.googleapis.com/auth/bigquery']
 _TEST_FOLDER = 'gcp_variant_transforms/testing/integration/bq_to_vcf_tests'
 _SCRIPT_PATH = '/opt/gcp_variant_transforms/bin/bq_to_vcf'
 
@@ -79,9 +78,10 @@ class BqToVcfTestCase(run_tests_common.TestCaseInterface):
     for k, v in kwargs.iteritems():
       args.append('--{} {}'.format(k, v))
 
-    self.pipeline_api_request = run_tests_common.form_pipeline_api_request(
-        parsed_args.project, parsed_args.logging_location, parsed_args.image,
-        _SCOPES, _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
+    self.pipelines_api_request = run_tests_common.form_pipelines_api_request(
+        parsed_args.project,
+        '/'.join([parsed_args.logging_location, self._output_file]),
+        parsed_args.image, _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
 
   def validate_result(self):
     """Validates the results.

--- a/gcp_variant_transforms/testing/integration/run_preprocessor_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_preprocessor_tests.py
@@ -44,7 +44,6 @@ from gcp_variant_transforms.testing.integration import run_tests_common
 
 _BUCKET_NAME = 'integration_test_runs'
 _PIPELINE_NAME = 'gcp-variant-transforms-preprocessor-integration-test'
-_SCOPES = []
 _SCRIPT_PATH = '/opt/gcp_variant_transforms/bin/vcf_to_bq_preprocess'
 _TEST_FOLDER = 'gcp_variant_transforms/testing/integration/preprocessor_tests'
 
@@ -89,9 +88,10 @@ class PreprocessorTestCase(run_tests_common.TestCaseInterface):
     for k, v in kwargs.iteritems():
       args.append('--{} {}'.format(k, v))
 
-    self.pipeline_api_request = run_tests_common.form_pipeline_api_request(
-        parser_args.project, parser_args.logging_location, parser_args.image,
-        _SCOPES, _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
+    self.pipelines_api_request = run_tests_common.form_pipelines_api_request(
+        parser_args.project,
+        '/'.join([parser_args.logging_location, self._report_blob_name]),
+        parser_args.image, _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
 
   def validate_result(self):
     """Validates the results.

--- a/gcp_variant_transforms/testing/integration/run_preprocessor_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_preprocessor_tests.py
@@ -38,6 +38,7 @@ import sys
 from datetime import datetime
 from typing import Dict, List  # pylint: disable=unused-import
 
+from apache_beam.io import filesystems
 from google.cloud import storage
 
 from gcp_variant_transforms.testing.integration import run_tests_common
@@ -90,7 +91,8 @@ class PreprocessorTestCase(run_tests_common.TestCaseInterface):
 
     self.pipelines_api_request = run_tests_common.form_pipelines_api_request(
         parser_args.project,
-        '/'.join([parser_args.logging_location, self._report_blob_name]),
+        filesystems.FileSystems.join(parser_args.logging_location,
+                                     self._report_blob_name),
         parser_args.image, _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
 
   def validate_result(self):

--- a/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
@@ -45,6 +45,8 @@ import sys
 from datetime import datetime
 from typing import Dict, List  # pylint: disable=unused-import
 
+from apache_beam.io import filesystems
+
 # TODO(bashir2): Figure out why pylint can't find this.
 # pylint: disable=no-name-in-module,import-error
 from google.cloud import bigquery
@@ -88,7 +90,8 @@ class VcfToBQTestCase(run_tests_common.TestCaseInterface):
         value = v.format(TABLE_NAME=self._table_name)
       args.append('--{} {}'.format(k, value))
     self.pipelines_api_request = run_tests_common.form_pipelines_api_request(
-        context.project, '/'.join([context.logging_location, output_table]),
+        context.project,
+        filesystems.FileSystems.join(context.logging_location, output_table),
         context.image, _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
 
   def validate_result(self):

--- a/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
@@ -53,7 +53,6 @@ from oauth2client.client import GoogleCredentials
 from gcp_variant_transforms.testing.integration import run_tests_common
 
 _PIPELINE_NAME = 'gcp-variant-transforms-vcf-to-bq-integration-test'
-_SCOPES = ['https://www.googleapis.com/auth/bigquery']
 _SCRIPT_PATH = '/opt/gcp_variant_transforms/bin/vcf_to_bq'
 _BASE_TEST_FOLDER = 'gcp_variant_transforms/testing/integration/vcf_to_bq_tests'
 
@@ -88,9 +87,9 @@ class VcfToBQTestCase(run_tests_common.TestCaseInterface):
       if isinstance(v, basestring):
         value = v.format(TABLE_NAME=self._table_name)
       args.append('--{} {}'.format(k, value))
-    self.pipeline_api_request = run_tests_common.form_pipeline_api_request(
-        context.project, context.logging_location, context.image, _SCOPES,
-        _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
+    self.pipelines_api_request = run_tests_common.form_pipelines_api_request(
+        context.project, '/'.join([context.logging_location, output_table]),
+        context.image, _PIPELINE_NAME, _SCRIPT_PATH, zones, args)
 
   def validate_result(self):
     """Runs queries against the output table and verifies results."""


### PR DESCRIPTION
Tested:
Manual run of `./deploy_and_run_tests.sh --run_preprocessor_tests --run_bq_to_vcf_tests --run_presubmit_tests` both with success and failure.

Fixes #296