### PR TITLE
small fixes

### DIFF
--- a/gcp_variant_transforms/testing/integration/run_tests_common.py
+++ b/gcp_variant_transforms/testing/integration/run_tests_common.py
@@ -70,6 +70,7 @@ class TestRunner(object):
         credentials=GoogleCredentials.get_application_default())
     self._revalidate = revalidate
     self._operation_names_to_test_states = {}  # type: Dict[str, TestCaseState]
+    self._operation_names_to_test_case_names = {}  # type: Dict[str, str]
 
   def run(self):
     """Runs all tests."""
@@ -101,6 +102,8 @@ class TestRunner(object):
     operation_name = request.execute()['name']
     self._operation_names_to_test_states.update(
         {operation_name: TestCaseState(test_cases[0], test_cases[1:])})
+    self._operation_names_to_test_case_names.update(
+        {operation_name: test_cases[0]._name})
 
   def _wait_for_all_operations_done(self):
     """Waits until all operations are done."""
@@ -113,7 +116,9 @@ class TestRunner(object):
         request = operations.get(name=operation_name)
         response = request.execute()
         if response['done']:
-          self._handle_failure(operation_name, response)
+          self._handle_failure(
+              self._operation_names_to_test_case_names[operation_name],
+              response)
           test_case_state = self._operation_names_to_test_states.get(
               operation_name)
           del self._operation_names_to_test_states[operation_name]

--- a/gcp_variant_transforms/testing/integration/run_tests_common.py
+++ b/gcp_variant_transforms/testing/integration/run_tests_common.py
@@ -116,9 +116,7 @@ class TestRunner(object):
         request = operations.get(name=operation_name)
         response = request.execute()
         if response['done']:
-          self._handle_failure(
-              self._operation_names_to_test_case_names[operation_name],
-              response)
+          self._handle_failure(operation_name, response)
           test_case_state = self._operation_names_to_test_states.get(
               operation_name)
           del self._operation_names_to_test_states[operation_name]
@@ -130,13 +128,17 @@ class TestRunner(object):
     if 'error' in response:
       if 'message' in response['error']:
         raise TestCaseFailure(
-            'Operation {} failed: {}'.format(operation_name,
-                                             response['error']['message']))
+            'Test case {} (Operation {}) failed: {}'.format(
+                self._operation_names_to_test_case_names[operation_name],
+                operation_name,
+                response['error']['message']))
       else:
         # This case should never happen.
         raise TestCaseFailure(
-            'Operation {} failed: No traceback. '
-            'See logs for more information on error.'.format(operation_name))
+            'Test case {} (Operation {}) failed: No traceback. '
+            'See logs for more information on error.'.format(
+                self._operation_names_to_test_case_names[operation_name],
+                operation_name))
 
   def print_results(self):
     """Prints results of test cases."""

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -157,7 +157,7 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
 
   # Always run pipeline locally if data is small.
   if (pipeline_mode == vcf_to_bq_common.PipelineModes.SMALL and
-      not known_args.infer_headers):
+      not known_args.infer_headers and not known_args.infer_annotation_types):
     options.view_as(pipeline_options.StandardOptions).runner = 'DirectRunner'
 
   google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)


### PR DESCRIPTION
- Use test name in integration tests error message instead of the operation name to be more informative.
- When the data is small we always run pipeline locally, unless `--infer_headers` is provided. Add `--infer_annotation_types` as well since it also needs to read the variants. (The `valid_4_2_VEP.json` test case now runs correctly when using `BundleBasedDirectRunner` with a higher version of apache beam).

Related issues: https://github.com/googlegenomics/gcp-variant-transforms/issues/291