### PR TITLE
move common funs to common file

### DIFF
--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -56,7 +56,7 @@ from apache_beam.options import pipeline_options
 
 from oauth2client import client
 
-from gcp_variant_transforms import vcf_to_bq_common
+from gcp_variant_transforms import pipeline_common
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import bigquery_util
@@ -84,10 +84,10 @@ def run(argv=None):
   # type: (List[str]) -> None
   """Runs BigQuery to VCF pipeline."""
   logging.info('Command: %s', ' '.join(argv or sys.argv))
-  known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
-                                                          _COMMAND_LINE_OPTIONS)
+  known_args, pipeline_args = pipeline_common.parse_args(argv,
+                                                         _COMMAND_LINE_OPTIONS)
   options = pipeline_options.PipelineOptions(pipeline_args)
-  is_direct_runner = vcf_to_bq_common.is_pipeline_direct_runner(
+  is_direct_runner = pipeline_common.is_pipeline_direct_runner(
       beam.Pipeline(options=options))
   google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)
   if not google_cloud_options.project:
@@ -99,7 +99,7 @@ def run(argv=None):
     known_args.number_of_bases_per_shard = sys.maxsize
 
   temp_folder = google_cloud_options.temp_location or tempfile.mkdtemp()
-  unique_temp_id = vcf_to_bq_common.generate_unique_name(
+  unique_temp_id = pipeline_common.generate_unique_name(
       google_cloud_options.job_name or _BQ_TO_VCF_SHARDS_JOB_NAME)
   vcf_data_temp_folder = filesystems.FileSystems.join(
       temp_folder,

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Common functions that are used by both vcf_to_bq and vcf_to_bq_preprocessor.
+"""Common functions used by vcf_to_bq, bq_to_vcf and vcf_to_bq_preprocessor.
 
 It includes parsing the command line arguments, reading the input, applying the
 PTransforms and writing the output.

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for vcf_to_bq_common script."""
+"""Tests for pipeline_common script."""
 
 import collections
 import unittest
@@ -20,19 +20,19 @@ import unittest
 from apache_beam.io.filesystems import FileSystems
 import mock
 
-from gcp_variant_transforms import vcf_to_bq_common
-from gcp_variant_transforms.vcf_to_bq_common import PipelineModes
+from gcp_variant_transforms import pipeline_common
+from gcp_variant_transforms.pipeline_common import PipelineModes
 
 
 class VcfToBqCommonTest(unittest.TestCase):
-  """Tests cases for the ``vcf_to_bq_common`` script."""
+  """Tests cases for the `pipeline_common` script."""
 
   def _create_mock_args(self, **args):
     return collections.namedtuple('MockArgs', args.keys())(*args.values())
 
   def _get_pipeline_mode(self, args):
-    return vcf_to_bq_common.get_pipeline_mode(args.input_pattern,
-                                              args.optimize_for_large_inputs)
+    return pipeline_common.get_pipeline_mode(args.input_pattern,
+                                             args.optimize_for_large_inputs)
 
   def test_get_mode_raises_error_for_no_match(self):
     args = self._create_mock_args(
@@ -85,7 +85,7 @@ class VcfToBqCommonTest(unittest.TestCase):
 
     match = match_result(range(101))
     with mock.patch.object(FileSystems, 'match', return_value=[match]):
-      self.assertEqual(vcf_to_bq_common.get_pipeline_mode(args.input_pattern),
+      self.assertEqual(pipeline_common.get_pipeline_mode(args.input_pattern),
                        PipelineModes.MEDIUM)
 
   def test_fail_on_invalid_flags(self):
@@ -94,18 +94,18 @@ class VcfToBqCommonTest(unittest.TestCase):
                      'gcp-variant-transforms-test',
                      '--staging_location',
                      'gs://integration_test_runs/staging']
-    vcf_to_bq_common._raise_error_on_invalid_flags(pipeline_args)
+    pipeline_common._raise_error_on_invalid_flags(pipeline_args)
 
     # Add Dataflow runner (requires --setup_file).
     pipeline_args.extend(['--runner', 'DataflowRunner'])
     with self.assertRaisesRegexp(ValueError, 'setup_file'):
-      vcf_to_bq_common._raise_error_on_invalid_flags(pipeline_args)
+      pipeline_common._raise_error_on_invalid_flags(pipeline_args)
 
     # Add setup.py (required for Variant Transforms run). This is now valid.
     pipeline_args.extend(['--setup_file', 'setup.py'])
-    vcf_to_bq_common._raise_error_on_invalid_flags(pipeline_args)
+    pipeline_common._raise_error_on_invalid_flags(pipeline_args)
 
     # Add an unknown flag.
     pipeline_args.extend(['--unknown_flag', 'somevalue'])
     with self.assertRaisesRegexp(ValueError, 'Unrecognized.*unknown_flag'):
-      vcf_to_bq_common._raise_error_on_invalid_flags(pipeline_args)
+      pipeline_common._raise_error_on_invalid_flags(pipeline_args)

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -34,7 +34,6 @@ python -m gcp_variant_transforms.vcf_to_bq \
 from __future__ import absolute_import
 
 import argparse  # pylint: disable=unused-import
-import datetime
 import logging
 import sys
 import tempfile
@@ -102,7 +101,7 @@ def _read_variants(pipeline, known_args):
 
 def _get_variant_merge_strategy(known_args  # type: argparse.Namespace
                                ):
-  # type: (...) -> Optional(variant_merge_strategy.VariantMergeStrategy)
+  # type: (...) -> Optional[variant_merge_strategy.VariantMergeStrategy]
   merge_options = variant_transform_options.MergeOptions
   if (not known_args.variant_merge_strategy or
       known_args.variant_merge_strategy == merge_options.NONE):
@@ -161,11 +160,8 @@ def _merge_headers(known_args, pipeline_args, pipeline_mode):
     options.view_as(pipeline_options.StandardOptions).runner = 'DirectRunner'
 
   google_cloud_options = options.view_as(pipeline_options.GoogleCloudOptions)
-  # Add a time suffix to ensure the job names and the merged headers files are
-  # unique in case multiple pipelines are run at the same time.
-  merge_headers_job_name = '-'.join([
-      _MERGE_HEADERS_JOB_NAME,
-      datetime.datetime.now().strftime('%Y%m%d-%H%M%S')])
+  merge_headers_job_name = vcf_to_bq_common.generate_unique_name(
+      _MERGE_HEADERS_JOB_NAME)
   if google_cloud_options.job_name:
     google_cloud_options.job_name += '-' + merge_headers_job_name
   else:

--- a/gcp_variant_transforms/vcf_to_bq_common.py
+++ b/gcp_variant_transforms/vcf_to_bq_common.py
@@ -21,11 +21,14 @@ PTransforms and writing the output.
 from typing import List  # pylint: disable=unused-import
 import argparse
 import enum
+import uuid
+from datetime import datetime
 
 import apache_beam as beam
 from apache_beam import pvalue  # pylint: disable=unused-import
 from apache_beam.io import filesystems
 from apache_beam.options import pipeline_options
+from apache_beam.runners.direct import direct_runner
 
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.transforms import merge_headers
@@ -135,3 +138,17 @@ def _raise_error_on_invalid_flags(pipeline_args):
       not known_pipeline_args.setup_file):
     raise ValueError('The --setup_file flag is required for DataflowRunner. '
                      'Please provide a path to the setup.py file.')
+
+
+def is_pipeline_direct_runner(pipeline):
+  # type: (beam.Pipeline) -> bool
+  """Returns True if the pipeline's runner is DirectRunner."""
+  return isinstance(pipeline.runner, direct_runner.DirectRunner)
+
+
+def generate_unique_name(job_name):
+  # type: (str) -> str
+  """Returns a unique name with time suffix and random UUID."""
+  return '-'.join([job_name,
+                   datetime.now().strftime('%Y%m%d-%H%M%S'),
+                   str(uuid.uuid4())])

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -55,7 +55,7 @@ import apache_beam as beam
 from apache_beam import pvalue
 from apache_beam.options import pipeline_options
 
-from gcp_variant_transforms import vcf_to_bq_common
+from gcp_variant_transforms import pipeline_common
 from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs import preprocess_reporter
 from gcp_variant_transforms.options import variant_transform_options
@@ -91,14 +91,14 @@ def run(argv=None):
   # type: (List[str]) -> (str, str)
   """Runs preprocess pipeline."""
   logging.info('Command: %s', ' '.join(argv or sys.argv))
-  known_args, pipeline_args = vcf_to_bq_common.parse_args(argv,
-                                                          _COMMAND_LINE_OPTIONS)
+  known_args, pipeline_args = pipeline_common.parse_args(argv,
+                                                         _COMMAND_LINE_OPTIONS)
   options = pipeline_options.PipelineOptions(pipeline_args)
-  pipeline_mode = vcf_to_bq_common.get_pipeline_mode(known_args.input_pattern)
+  pipeline_mode = pipeline_common.get_pipeline_mode(known_args.input_pattern)
 
   with beam.Pipeline(options=options) as p:
-    headers = vcf_to_bq_common.read_headers(p, pipeline_mode, known_args)
-    merged_headers = vcf_to_bq_common.get_merged_headers(headers)
+    headers = pipeline_common.read_headers(p, pipeline_mode, known_args)
+    merged_headers = pipeline_common.get_merged_headers(headers)
     merged_definitions = (headers
                           | 'MergeDefinitions' >>
                           merge_header_definitions.MergeDefinitions())
@@ -123,8 +123,8 @@ def run(argv=None):
                       beam.pvalue.AsSingleton(merged_headers)))
 
     if known_args.resolved_headers_path:
-      vcf_to_bq_common.write_headers(merged_headers,
-                                     known_args.resolved_headers_path)
+      pipeline_common.write_headers(merged_headers,
+                                    known_args.resolved_headers_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Moved some common functions into a common file.
- generate a unique job name/file name.
- check whether a pipeline is using direct runner.

Tested: integration tests.