### PR TITLE
Update BQ row limit to 100MB and make it more efficient.

### DIFF
--- a/docs/bigquery_schema.md
+++ b/docs/bigquery_schema.md
@@ -3,27 +3,10 @@
 See [this page](https://cloud.google.com/genomics/v1/bigquery-variants-schema)
 for a general explanation of the schema.
 
-**Note:** the schema used in Variant Transforms has the following changes
-compared to the linked page:
-
-* `start` and `end` have been renamed to `start_position` and `end_position`.
-  This is because `end` is a reserved keyword in SQL.
-* `alternate_bases` has been changed to a record, which also contains any
-  INFO field with `Number=A`. This is to make querying easier because it avoids
-  having to map each field with the corresponding alternate record. If you
-  prefer to use the old schema where `Number=A` fields appear independent of
-  alternate bases, then set `--split_alternate_allele_info_fields False` when
-  running the pipeline.
-* `call_set_name` has been renamed to `name`.
-* `call_set_id` and `variant_set_id` columns have been removed. These fields
-  are no longer applicable in this pipeline.
-* Explicit transform of `call.GL` to `call.genotype_likelihood` has been
-  removed, so any `GL` field will be loaded to BigQuery 'as is'.
-
 In addition, the schema from Variant Transforms has the following properties:
 * If a record has a large number of calls such that the resulting BigQuery
-  row is more than 10MB, then that record will be automatically split into
-  multiple rows such that each row is less than 10MB. This is needed to
+  row is more than 100MB, then that record will be automatically split into
+  multiple rows such that each row is less than 100MB. This is needed to
   accommodate BigQuery's
   [10MB per row limit](https://cloud.google.com/bigquery/quotas#import).
 * _Only for float/integer repeated fields containing a null value:_ BigQuery

--- a/gcp_variant_transforms/libs/bigquery_vcf_data_converter.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_data_converter.py
@@ -55,8 +55,8 @@ RESERVED_VARIANT_CALL_COLUMNS = [
 # We set it to 90MB to leave some room for error as our row estimate is based
 # on sampling rather than exact byte size.
 _MAX_BIGQUERY_ROW_SIZE_BYTES = 90 * 1024 * 1024
-# Maximum number of calls to sample for BigQuery row size estimate.
-_MAX_NUM_CALL_SAMPLES = 5
+# Number of calls to sample for BigQuery row size estimation.
+_NUM_CALL_SAMPLES = 5
 # Row size estimation based on sampling calls can be expensive and unnecessary
 # when there are not enough calls, so it's only enabled when there are at least
 # this many calls.
@@ -266,7 +266,7 @@ class BigQueryRowGenerator(object):
     call_record_schema_descriptor = (
         self._schema_descriptor.get_record_schema_descriptor(
             bigquery_util.ColumnKeyConstants.CALLS))
-    for call in calls[::len(calls) // _MAX_NUM_CALL_SAMPLES]:
+    for call in calls[::len(calls) // _NUM_CALL_SAMPLES]:
       call_record, _ = self._get_call_record(
           call, call_record_schema_descriptor, allow_incompatible_records=True)
       sum_sampled_call_size_bytes += self._get_json_object_size(call_record)

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
@@ -13,15 +13,15 @@
     "assertion_configs": [
       {
         "query": ["NUM_ROWS_QUERY"],
-        "expected_result": {"num_rows": 26}
+        "expected_result": {"num_rows": 13}
       },
       {
         "query": ["SUM_START_QUERY"],
-        "expected_result": {"sum_start": 46063858}
+        "expected_result": {"sum_start": 23031929}
       },
       {
         "query": ["SUM_END_QUERY"],
-        "expected_result": {"sum_end": 46066104}
+        "expected_result": {"sum_end": 23033052}
       },
       {
         "query": [


### PR DESCRIPTION
BQ row limit has changed from 10MB to 100MB. I also made this method more efficient as it turns out jsonifying every single call/variant is a very expensive operation! This PTransform is now **50% faster!** The sampling logic can be improved (e.g. randomizing the samples rather than picking particular locations, or dynamically choosing sample size based on input), but I realistically don't think anyone is going to hit the 100MB limit anytime soon and this method can be good enough even then.

Tested:
- unit + integration tests
- Also ran on a synthetic dataset with 500k+ files to force row split. Can consider creating this dataset as part of `huge_tests` later.