### PR TITLE
Minor fix to the release script.

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -66,7 +66,7 @@ The process is as follows:
    virtualenv "${temp_dir}"
    source ${temp_dir}/bin/activate
    pip install --upgrade .[int_test]
-   python gcp_variant_transforms/testing/integration/run_tests.py \
+   python gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py \
        --project gcp-variant-transforms-test \
        --staging_location "gs://integration_test_runs/staging" \
        --temp_location "gs://integration_test_runs/temp" \


### PR DESCRIPTION
We should ultimately work on #395 to make this easier and have a single point of entry for all integration tests. It's now up to the person doing the release about whether to also sanity check other binaries.