### PR TITLE
Move merge_headers logic from transforms/ to lib/.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 dist/
 .idea/
 venv/
+.vscode/
+.coverage

--- a/gcp_variant_transforms/libs/header_merger.py
+++ b/gcp_variant_transforms/libs/header_merger.py
@@ -1,0 +1,95 @@
+# Copyright 2019 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Class for merging 2 VcfHeader objects."""
+
+from collections import OrderedDict
+from typing import Dict, Any  #pylint: disable=unused-import
+
+from gcp_variant_transforms.beam_io import vcf_header_io
+from gcp_variant_transforms.libs import vcf_field_conflict_resolver #pylint: disable=unused-import
+
+class HeaderMerger(object):
+  """Class for merging two :class:`VcfHeader`s."""
+
+  def __init__(self, resolver):
+    # type: (vcf_field_conflict_resolver.FieldConflictResolver) -> None
+    """Initialize :class:`HeaderMerger` object.
+
+    Args:
+      resolver: Auxiliary class for resolving possible header value mismatches.
+    """
+    self._resolver = resolver
+
+  def merge(self, first, second):
+    # type: (vcf_header_io.VcfHeader, vcf_header_io.VcfHeader) -> None
+    """Updates `first`'s headers with values from `second`.
+
+    If a specific key does not already exist in a specific one of `first`'s
+    headers, that key and the associated value will be added. If the key does
+    already exist in the specific header of `first`, then the value of that
+    key will be updated with the value from `second`.
+
+    Args:
+      first: The VcfHeader object.
+      second: The VcfHeader object that's headers will be merged into the
+        headers of first.
+    """
+    if (not isinstance(first, vcf_header_io.VcfHeader) or
+        not isinstance(second, vcf_header_io.VcfHeader)):
+      raise NotImplementedError
+    self._merge_header_fields(first.infos, second.infos)
+    self._merge_header_fields(first.filters, second.filters)
+    self._merge_header_fields(first.alts, second.alts)
+    self._merge_header_fields(first.formats, second.formats)
+    self._merge_header_fields(first.contigs, second.contigs)
+
+  def _merge_header_fields(
+      self,
+      first,  # type: Dict[str, OrderedDict[str, Union[str, int]]]
+      second  # type: Dict[str, OrderedDict[str, Union[str, int]]]
+      ):
+    # type: (...) -> None
+    """Modifies `first` to add any keys from `second` not in `first`.
+
+    Args:
+      first: first header fields.
+      second: second header fields.
+    Raises:
+      ValueError: If the header fields are incompatible (e.g. same key with
+        different types or numbers).
+    """
+    for second_key, second_value in second.iteritems():
+      if second_key not in first:
+        first[second_key] = second_value
+        continue
+      first_value = first[second_key]
+      if first_value.keys() != second_value.keys():
+        raise ValueError('Incompatible header fields: {}, {}'.format(
+            first_value, second_value))
+      merged_value = OrderedDict()
+      for first_field_key, first_field_value in first_value.iteritems():
+        second_field_value = second_value[first_field_key]
+        try:
+          resolution_field_value = self._resolver.resolve_attribute_conflict(
+              first_field_key,
+              first_field_value,
+              second_field_value)
+          merged_value.update({first_field_key: resolution_field_value})
+        except ValueError as e:
+          raise ValueError('Incompatible number or types in header fields:'
+                           '{}, {} \n. Error: {}'.format(
+                               first_value, second_value, str(e)))
+
+      first[second_key] = merged_value

--- a/gcp_variant_transforms/libs/header_merger_test.py
+++ b/gcp_variant_transforms/libs/header_merger_test.py
@@ -49,15 +49,6 @@ class HeaderMergerTest(unittest.TestCase):
         formats=reader.formats,
         contigs=reader.contigs)
 
-  def _get_header_from_reader(self, reader):
-    """Extracts values from a pyVCF reader into a VcfHeader object."""
-    return vcf_header_io.VcfHeader(
-        infos=reader.infos,
-        filters=reader.filters,
-        alts=reader.alts,
-        formats=reader.formats,
-        contigs=reader.contigs)
-
   def _get_header_merger(self, split_alternate_allele_info_fields=True):
     resolver = vcf_field_conflict_resolver.FieldConflictResolver(
         split_alternate_allele_info_fields)

--- a/gcp_variant_transforms/libs/header_merger_test.py
+++ b/gcp_variant_transforms/libs/header_merger_test.py
@@ -1,0 +1,228 @@
+# Copyright 2019 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for header_merger module."""
+
+from collections import OrderedDict
+import unittest
+import vcf
+
+from gcp_variant_transforms.beam_io import vcf_header_io
+from gcp_variant_transforms.libs import vcf_field_conflict_resolver
+from gcp_variant_transforms.libs.header_merger import HeaderMerger
+
+FILE_1_LINES = [
+    '##fileformat=VCFv4.2\n',
+    '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+    '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
+    '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="GQ">\n',
+    '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample1	Sample2\n']
+FILE_2_LINES = [
+    '##fileformat=VCFv4.2\n',
+    '##INFO=<ID=NS2,Number=1,Type=Integer,Description="Number samples">\n',
+    '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
+    '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
+    '##FORMAT=<ID=GQ2,Number=1,Type=Integer,Description="GQ">\n',
+    '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample3\n']
+
+class HeaderMergerTest(unittest.TestCase):
+  """Test cases for HeaderMerger module."""
+
+  def _get_header_from_reader(self, reader):
+    """Extracts values from a pyVCF reader into a VcfHeader object."""
+    return vcf_header_io.VcfHeader(
+        infos=reader.infos,
+        filters=reader.filters,
+        alts=reader.alts,
+        formats=reader.formats,
+        contigs=reader.contigs)
+
+  def _get_header_from_reader(self, reader):
+    """Extracts values from a pyVCF reader into a VcfHeader object."""
+    return vcf_header_io.VcfHeader(
+        infos=reader.infos,
+        filters=reader.filters,
+        alts=reader.alts,
+        formats=reader.formats,
+        contigs=reader.contigs)
+
+  def _get_header_merger(self, split_alternate_allele_info_fields=True):
+    resolver = vcf_field_conflict_resolver.FieldConflictResolver(
+        split_alternate_allele_info_fields)
+    merger = HeaderMerger(resolver)
+    return merger
+
+  def test_merge_header_with_empty_one(self):
+    vcf_reader = vcf.Reader(fsock=iter(FILE_1_LINES))
+    merger = self._get_header_merger()
+    header_1 = self._get_header_from_reader(vcf_reader)
+    header_2 = vcf_header_io.VcfHeader()
+
+    merger.merge(header_1, header_2)
+    merger.merge(header_2, header_1)
+
+    self.assertItemsEqual(header_1.infos.keys(), ['NS', 'AF'])
+    self.assertItemsEqual(header_1.formats.keys(), ['GT', 'GQ'])
+    self.assertItemsEqual(header_2.infos.keys(), ['NS', 'AF'])
+    self.assertItemsEqual(header_2.formats.keys(), ['GT', 'GQ'])
+
+  def test_merge_two_headers(self):
+    vcf_reader_1 = vcf.Reader(fsock=iter(FILE_1_LINES))
+    vcf_reader_2 = vcf.Reader(fsock=iter(FILE_2_LINES))
+    main_header = self._get_header_from_reader(vcf_reader_1)
+    secondary_header = self._get_header_from_reader(vcf_reader_2)
+
+    merger = self._get_header_merger()
+    merger.merge(main_header, secondary_header)
+
+    self.assertItemsEqual(main_header.infos.keys(), ['NS', 'AF', 'NS2'])
+    self.assertItemsEqual(main_header.formats.keys(), ['GT', 'GQ', 'GQ2'])
+
+  def test_merge_two_type_conflicting_but_resolvable_headers(self):
+    # These two headers have type conflict (Integer vs Float), however pipeline
+    # doesn't raise error because the type conflict is resolvable.
+    lines_1 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n']
+    lines_2 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=1,Type=Float,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n']
+
+    vcf_reader_1 = vcf.Reader(fsock=iter(lines_1))
+    vcf_reader_2 = vcf.Reader(fsock=iter(lines_2))
+    main_header = self._get_header_from_reader(vcf_reader_1)
+    secondary_header = self._get_header_from_reader(vcf_reader_2)
+
+    merger = self._get_header_merger()
+
+    merger.merge(main_header, secondary_header)
+
+    self.assertItemsEqual(main_header.infos.keys(), ['NS'])
+    self.assertItemsEqual(main_header.infos['NS'],
+                          OrderedDict([('id', 'NS'),
+                                       ('num', 1),
+                                       ('type', 'Float'),
+                                       ('desc', 'Number samples'),
+                                       ('source', None),
+                                       ('version', None)]))
+
+  def test_merge_two_num_conflicting_but_resolvable_headers_1(self):
+    # These two headers have conflict in Number field (2 vs dot), however
+    # pipeline doesn't raise error because the conflict is resolvable.
+    lines_1 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=2,Type=Integer,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n']
+    lines_2 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=.,Type=Integer,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n']
+
+    vcf_reader_1 = vcf.Reader(fsock=iter(lines_1))
+    vcf_reader_2 = vcf.Reader(fsock=iter(lines_2))
+    main_header = self._get_header_from_reader(vcf_reader_1)
+    secondary_header = self._get_header_from_reader(vcf_reader_2)
+
+    merger = self._get_header_merger()
+
+    merger.merge(main_header, secondary_header)
+
+    self.assertItemsEqual(main_header.infos.keys(), ['NS'])
+    self.assertItemsEqual(main_header.infos['NS'],
+                          OrderedDict([('id', 'NS'),
+                                       ('num', '.'),
+                                       ('type', 'Integer'),
+                                       ('desc', 'Number samples'),
+                                       ('source', None),
+                                       ('version', None)]))
+
+  def test_merge_two_num_conflicting_but_resolvable_headers_2(self):
+    # These two headers have conflict in Number field (2 vs 3), however
+    # pipeline doesn't raise error because the conflict is resolvable.
+    lines_1 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=2,Type=Integer,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n']
+    lines_2 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=3,Type=Integer,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n']
+
+    vcf_reader_1 = vcf.Reader(fsock=iter(lines_1))
+    vcf_reader_2 = vcf.Reader(fsock=iter(lines_2))
+    main_header = self._get_header_from_reader(vcf_reader_1)
+    secondary_header = self._get_header_from_reader(vcf_reader_2)
+
+    merger = self._get_header_merger()
+
+    merger.merge(main_header, secondary_header)
+
+    self.assertItemsEqual(main_header.infos.keys(), ['NS'])
+    self.assertItemsEqual(main_header.infos['NS'],
+                          OrderedDict([('id', 'NS'),
+                                       ('num', '.'),
+                                       ('type', 'Integer'),
+                                       ('desc', 'Number samples'),
+                                       ('source', None),
+                                       ('version', None)]))
+
+  def test_merge_two_num_conflicting_but_not_resolvable_headers(self):
+    # Test with split_alternate_allele_info_fields=True
+    #
+    # These two headers have incompable Number field (A vs dot).
+    # `Number=A` is incompatible with dot when flag
+    # split_alternate_allele_info_fields is set.
+
+    lines_1 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=A,Type=Integer,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n']
+    lines_2 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=.,Type=Integer,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n']
+
+    vcf_reader_1 = vcf.Reader(fsock=iter(lines_1))
+    vcf_reader_2 = vcf.Reader(fsock=iter(lines_2))
+    main_header = self._get_header_from_reader(vcf_reader_1)
+    secondary_header = self._get_header_from_reader(vcf_reader_2)
+
+    merger = self._get_header_merger()
+
+    with self.assertRaises(ValueError):
+      merger.merge(main_header, secondary_header)
+
+  def test_merge_two_headers_with_bad_conflict(self):
+    # Type mistmach (String vs Float) cannot be resolved..
+    lines_1 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=1,Type=String,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n']
+    lines_2 = [
+        '##fileformat=VCFv4.2\n',
+        '##INFO=<ID=NS,Number=1,Type=Float,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n']
+
+    vcf_reader_1 = vcf.Reader(fsock=iter(lines_1))
+    vcf_reader_2 = vcf.Reader(fsock=iter(lines_2))
+    main_header = self._get_header_from_reader(vcf_reader_1)
+    secondary_header = self._get_header_from_reader(vcf_reader_2)
+
+    merger = self._get_header_merger()
+
+    with self.assertRaises(ValueError):
+      merger.merge(main_header, secondary_header)

--- a/gcp_variant_transforms/transforms/merge_headers_test.py
+++ b/gcp_variant_transforms/transforms/merge_headers_test.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Google Inc.  All Rights Reserved.
+# Copyright 2019 Google Inc.  All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Test cases for get_merged_headers module."""
+"""Test cases for merge_headers module."""
 
 from collections import OrderedDict
 import unittest
@@ -25,8 +25,8 @@ from apache_beam.transforms import Create
 
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import vcf_field_conflict_resolver
+from gcp_variant_transforms.libs.header_merger import HeaderMerger
 from gcp_variant_transforms.transforms import merge_headers
-from gcp_variant_transforms.transforms.merge_headers import _HeaderMerger as HeaderMerger
 
 FILE_1_LINES = [
     '##fileformat=VCFv4.2\n',
@@ -324,6 +324,7 @@ class MergeHeadersTest(unittest.TestCase):
       merged_headers = combiner_fn.add_input(merged_headers, headers_1)
       merged_headers = combiner_fn.add_input(merged_headers, headers_2)
       merged_headers = combiner_fn.extract_output(merged_headers)
+
 
   def test_combine_pipeline(self):
     vcf_reader_1 = vcf.Reader(fsock=iter(FILE_1_LINES))


### PR DESCRIPTION
- Migrate majority of the logic from merge_headers.py into lib/variant_merge subdir, to be commonly accessible.
- Add .vscode/ directory to gitignore, for VS Code users.
- Add .coverage to gitignore - artifact of running presubmit checks locally.

Tested via Unit Tests.

This change is part of an effort to migrate all of the complex logic from transforms/ dir to libs/. So far migrating just merge_headers, since this is my first CL and I want to know right away if what I'm doing is way off. :)