### PR TITLE
Extract common logic out of merge_header_definitions.py

### DIFF
--- a/gcp_variant_transforms/libs/preprocess_reporter.py
+++ b/gcp_variant_transforms/libs/preprocess_reporter.py
@@ -52,6 +52,9 @@ from gcp_variant_transforms.beam_io import vcfio  # pylint: disable=unused-impor
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import vcf_header_definitions_merger  # pylint: disable=unused-import
 
+# An alias for the header key constants to make referencing easier.
+_Definition = vcf_header_definitions_merger.Definition
+_VcfHeaderDefinitions = vcf_header_definitions_merger.VcfHeaderDefinitions
 
 _NO_SOLUTION_MESSAGE = 'Not resolved.'
 _PADDING_CHARACTER = ' '
@@ -73,8 +76,7 @@ class _HeaderLine(object):
 
 
 def generate_report(
-    # type: vcf_header_definitions_merger.VcfHeaderDefinitions
-    header_definitions,
+    header_definitions,  # type: _VcfHeaderDefinitions
     file_path,  # type: str
     resolved_headers=None,  # type: vcf_header_io.VcfHeader
     inferred_headers=None,  # type: vcf_header_io.VcfHeader
@@ -103,11 +105,9 @@ def generate_report(
 
 
 def _extract_conflicts(
-    # type: Dict[str, Dict[vcf_header_definitions_merger.Definition, List[str]]]
-    definitions
+    definitions  # type: Dict[str, Dict[_Definition, List[str]]]
     ):
-  # type: (...) ->
-  #     Dict[str, Dict[vcf_header_definitions_merger.Definition, List[str]]]
+  # type: (...) -> Dict[str, Dict[_Definition, List[str]]]
   """Extracts the fields that have conflicting definitions.
 
   Returns:
@@ -120,8 +120,7 @@ def _extract_conflicts(
 
 def _append_conflicting_headers_to_report(
     file_to_write,  # type: file
-    # type: vcf_header_definitions_merger.VcfHeaderDefinitions
-    header_definitions,
+    header_definitions,  # type: _VcfHeaderDefinitions
     resolved_headers  # type: vcf_header_io.VcfHeader
     ):
   # type: (...) -> None
@@ -187,8 +186,7 @@ def _append_malformed_records_to_report(file_to_write, malformed_records):
 
 
 def _generate_conflicting_headers_lines(
-    # type: Dict[str, Dict[vcf_header_definitions_merger.Definition, List[str]]]
-    conflicts,
+    conflicts,  # type: Dict[str, Dict[_Definition, List[str]]]
     resolved_headers,  # type: Dict[str, Dict[str, Union[str, int]]
     category  # type: str
     ):

--- a/gcp_variant_transforms/libs/preprocess_reporter_test.py
+++ b/gcp_variant_transforms/libs/preprocess_reporter_test.py
@@ -26,8 +26,8 @@ from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.beam_io.vcf_header_io import VcfHeader
 from gcp_variant_transforms.libs import preprocess_reporter
 from gcp_variant_transforms.testing import temp_dir
-from gcp_variant_transforms.transforms import merge_header_definitions
-from gcp_variant_transforms.transforms.merge_header_definitions import Definition
+from gcp_variant_transforms.libs.vcf_header_definitions_merger import Definition
+from gcp_variant_transforms.libs.vcf_header_definitions_merger import VcfHeaderDefinitions
 
 
 class PreprocessReporterTest(unittest.TestCase):
@@ -36,7 +36,7 @@ class PreprocessReporterTest(unittest.TestCase):
   def _generate_report_and_assert_contents_equal(
       self,
       expected_content,  # type: List[str]
-      header_definitions,  # type: merge_header_definitions.VcfHeaderDefinitions
+      header_definitions,  # type: VcfHeaderDefinitions
       resolved_headers=None,  # type: VcfHeader
       inferred_headers=None,  # type: VcfHeader
       malformed_records=None  # type: List[vcfio.MalformedVcfRecord]
@@ -55,7 +55,7 @@ class PreprocessReporterTest(unittest.TestCase):
         self.assertEqual(reader, expected_content)
 
   def test_report_no_conflicts(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     header_definitions._infos = {'NS': {Definition(1, 'Float'): ['file1']}}
     header_definitions._formats = {'NS': {Definition(1, 'Float'): ['file2']}}
 
@@ -70,7 +70,7 @@ class PreprocessReporterTest(unittest.TestCase):
                                                     resolved_headers)
 
   def test_report_conflicts(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     header_definitions._infos = {'NS': {Definition(1, 'Integer'): ['file1'],
                                         Definition(1, 'Float'): ['file2']}}
 
@@ -92,7 +92,7 @@ class PreprocessReporterTest(unittest.TestCase):
                                                     resolved_headers)
 
   def test_report_multiple_files(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     header_definitions._infos = {
         'NS': {Definition(1, 'Float'): ['file1', 'file2'],
                Definition(1, 'Integer'): ['file3']}
@@ -118,7 +118,7 @@ class PreprocessReporterTest(unittest.TestCase):
                                                     resolved_headers)
 
   def test_report_multiple_fields(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     header_definitions._infos = {'NS': {Definition(1, 'Float'): ['file1'],
                                         Definition(1, 'Integer'): ['file2']}}
     header_definitions._formats = {'DP': {Definition(2, 'Float'): ['file3'],
@@ -149,7 +149,7 @@ class PreprocessReporterTest(unittest.TestCase):
                                                     resolved_headers)
 
   def test_report_no_resolved_headers(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     header_definitions._infos = {'NS': {Definition(1, 'Float'): ['file1'],
                                         Definition(1, 'Integer'): ['file2']}}
 
@@ -167,7 +167,7 @@ class PreprocessReporterTest(unittest.TestCase):
                                                     header_definitions)
 
   def test_report_inferred_headers_only(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     formats = OrderedDict([('DP', Format('DP', 2, 'Float', 'Total Depth'))])
 
     inferred_headers = VcfHeader(formats=formats)
@@ -184,7 +184,7 @@ class PreprocessReporterTest(unittest.TestCase):
         expected, header_definitions, inferred_headers=inferred_headers)
 
   def test_report_conflicted_and_inferred_headers(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     header_definitions._infos = {'NS': {Definition(1, 'Float'): ['file1'],
                                         Definition(1, 'Integer'): ['file2']}}
 
@@ -214,7 +214,7 @@ class PreprocessReporterTest(unittest.TestCase):
                                                     inferred_headers)
 
   def test_report_malformed_records(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     inferred_headers = VcfHeader()
     records = [vcfio.MalformedVcfRecord('file1',
                                         'rs6054257  G  A  29  PASS',
@@ -235,7 +235,7 @@ class PreprocessReporterTest(unittest.TestCase):
         malformed_records=records)
 
   def test_report_no_inconsistencies(self):
-    header_definitions = merge_header_definitions.VcfHeaderDefinitions()
+    header_definitions = VcfHeaderDefinitions()
     inferred_headers = VcfHeader()
     expected = [
         'No Header Conflicts Found.\n',

--- a/gcp_variant_transforms/libs/vcf_header_definitions_merger.py
+++ b/gcp_variant_transforms/libs/vcf_header_definitions_merger.py
@@ -1,0 +1,94 @@
+# Copyright 2019 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VCF Header Definitions Merger class."""
+
+import collections
+from collections import namedtuple
+from typing import Dict, List  # pylint: disable=unused-import
+
+from gcp_variant_transforms.beam_io import vcf_header_io
+
+# `Definition` cherry-picks the attributes from vcf header definitions that
+# are critical for checking field compatibilities across VCF files.
+Definition = namedtuple('Definition',
+                        [vcf_header_io.VcfParserHeaderKeyConstants.NUM,
+                         vcf_header_io.VcfParserHeaderKeyConstants.TYPE])
+
+
+class VcfHeaderDefinitions(object):
+  """Container for header definitions."""
+
+  def __init__(self, vcf_header=None):
+    # type: (vcf_header_io.VcfHeader) -> None
+    """Initializes a `VcfHeaderDefinitions` object.
+
+    Creates two dictionaries (for infos and formats respectively) that map field
+    id to a dictionary which maps `Definition` to a list of file names.
+    """
+    self._infos = collections.defaultdict(dict)
+    self._formats = collections.defaultdict(dict)
+    if not vcf_header:
+      return
+    for key, val in vcf_header.infos.iteritems():
+      definition = Definition(
+          val[vcf_header_io.VcfParserHeaderKeyConstants.NUM],
+          val[vcf_header_io.VcfParserHeaderKeyConstants.TYPE])
+      self._infos[key][definition] = [vcf_header.file_name]
+    for key, val in vcf_header.formats.iteritems():
+      definition = Definition(
+          val[vcf_header_io.VcfParserHeaderKeyConstants.NUM],
+          val[vcf_header_io.VcfParserHeaderKeyConstants.TYPE])
+      self._formats[key][definition] = [vcf_header.file_name]
+
+  def __eq__(self, other):
+    return self._infos == other._infos and self._formats == other._formats
+
+  @property
+  def infos(self):
+    return self._infos
+
+  @property
+  def formats(self):
+    return self._formats
+
+
+class DefinitionsMerger(object):
+  """Class for merging two `VcfHeaderDefinitions`s."""
+
+  # For the same field definition, save at most `_MAX_NUM_FILE_NAMES` names.
+  _MAX_NUM_FILE_NAMES = 5
+
+  def merge(self, first, second):
+    # type: (VcfHeaderDefinitions, VcfHeaderDefinitions) -> None
+    """Updates `first`'s definitions with values from `second`."""
+    if (not isinstance(first, VcfHeaderDefinitions) or
+        not isinstance(second, VcfHeaderDefinitions)):
+      raise NotImplementedError
+    self._merge_definitions(first.infos, second.infos)
+    self._merge_definitions(first.formats, second.formats)
+
+  def _merge_definitions(
+      self,
+      first,  # type: Dict[str, Dict[Definition, List[str]]]
+      second  # type: Dict[str, Dict[Definition, List[str]]]
+      ):
+    # type: (...) -> None
+    """Updates `first` by merging values from `first` and `second`."""
+    for key, definitions_to_files_map in second.iteritems():
+      for definition, file_names in definitions_to_files_map.iteritems():
+        first[key].setdefault(definition, [])
+        first[key][definition].extend(str(s) for s in file_names)
+        first[key][definition] = (
+            first[key][definition][:self._MAX_NUM_FILE_NAMES])

--- a/gcp_variant_transforms/libs/vcf_header_definitions_merger_test.py
+++ b/gcp_variant_transforms/libs/vcf_header_definitions_merger_test.py
@@ -1,0 +1,229 @@
+# Copyright 2019 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test cases for definitions_merger module."""
+
+import unittest
+import vcf
+
+from gcp_variant_transforms.beam_io import vcf_header_io
+from gcp_variant_transforms.libs.vcf_header_definitions_merger import DefinitionsMerger
+from gcp_variant_transforms.libs.vcf_header_definitions_merger import Definition
+from gcp_variant_transforms.libs.vcf_header_definitions_merger import VcfHeaderDefinitions
+
+class VcfHeaderDefinitionsMergerTest(unittest.TestCase):
+
+  def _get_vcf_header_from_reader(self, reader, file_name):
+    return vcf_header_io.VcfHeader(infos=reader.infos,
+                                   filters=reader.filters,
+                                   alts=reader.alts,
+                                   formats=reader.formats,
+                                   contigs=reader.contigs,
+                                   file_name=file_name)
+
+  def _create_definitions_from_lines(self, lines, file_name):
+    vcf_reader = vcf.Reader(fsock=iter(lines))
+    header = self._get_vcf_header_from_reader(vcf_reader, file_name)
+    return VcfHeaderDefinitions(header)
+
+  def test_create_empty_header_defitions(self):
+    expected_info = {}
+    expected_format = {}
+    header_definitions = VcfHeaderDefinitions()
+
+    self.assertDictEqual(header_definitions.infos, expected_info)
+    self.assertDictEqual(header_definitions.formats, expected_format)
+
+  def test_create_definitions_with_format(self):
+    lines = [
+        '##FORMAT=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n'
+    ]
+
+    vcf_reader = vcf.Reader(fsock=iter(lines))
+    header = self._get_vcf_header_from_reader(vcf_reader, 'file1')
+
+    expected_info = {}
+    expected_format = {'NS': {Definition(1, 'Integer'): ['file1']}}
+    header_definitions = VcfHeaderDefinitions(header)
+
+    self.assertDictEqual(header_definitions.infos, expected_info)
+    self.assertDictEqual(header_definitions.formats, expected_format)
+
+  def test_create_definitions_with_info(self):
+    lines = [
+        '##INFO=<ID=NS,Number=1,Type=Float,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n'
+    ]
+
+    vcf_reader = vcf.Reader(fsock=iter(lines))
+    header = self._get_vcf_header_from_reader(vcf_reader, 'file1')
+
+    expected_info = {'NS': {Definition(1, 'Float'): ['file1']}}
+    expected_format = {}
+    header_definitions = VcfHeaderDefinitions(header)
+
+    self.assertDictEqual(header_definitions.infos, expected_info)
+    self.assertDictEqual(header_definitions.formats, expected_format)
+
+  def test_create_definitions_multi(self):
+    lines = [
+        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+        '##INFO=<ID=DP,Number=2,Type=Float,Description="Number samples">\n',
+        '##FORMAT=<ID=NS,Number=3,Type=Integer,Description="Number samples">\n',
+        '##FORMAT=<ID=DP,Number=4,Type=Float,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n'
+    ]
+
+    vcf_reader = vcf.Reader(fsock=iter(lines))
+    header = self._get_vcf_header_from_reader(vcf_reader, 'file1')
+
+    expected_info = {
+        'NS': {Definition(1, 'Integer'): ['file1']},
+        'DP': {Definition(2, 'Float'): ['file1']}
+    }
+    expected_format = {
+        'NS': {Definition(3, 'Integer'): ['file1']},
+        'DP': {Definition(4, 'Float'): ['file1']}
+    }
+    header_definitions = VcfHeaderDefinitions(header)
+
+    self.assertDictEqual(header_definitions.infos, expected_info)
+    self.assertDictEqual(header_definitions.formats, expected_format)
+
+  def test_type_check(self):
+    merger = DefinitionsMerger()
+    empty_header_definitions = VcfHeaderDefinitions()
+    with self.assertRaises(NotImplementedError):
+      merger.merge(empty_header_definitions, None)
+    with self.assertRaises(NotImplementedError):
+      merger.merge(None, empty_header_definitions)
+
+  def test_merge_same_definition(self):
+    merger = DefinitionsMerger()
+    lines_1 = [
+        '##INFO=<ID=NS,Number=1,Type=Float,Description="Number samples">\n',
+        '##FORMAT=<ID=DP,Number=3,Type=Char,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n'
+    ]
+    lines_2 = [
+        '##INFO=<ID=NS,Number=1,Type=Float,Description="Number samples2">\n',
+        '##FORMAT=<ID=DP,Number=3,Type=Char,Description="Number samples2">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n'
+    ]
+    main_definitions = self._create_definitions_from_lines(lines_1, 'file1')
+    secondary_definitions = self._create_definitions_from_lines(
+        lines_2, 'file2')
+
+    expected_infos = {'NS': {Definition(1, 'Float'): ['file1', 'file2']}}
+    expected_formats = {'DP': {Definition(3, 'Char'): ['file1', 'file2']}}
+    merger.merge(main_definitions, secondary_definitions)
+
+    self.assertDictEqual(expected_infos, main_definitions.infos)
+    self.assertDictEqual(expected_formats, main_definitions.formats)
+
+  def test_merge_different_type(self):
+    merger = DefinitionsMerger()
+    lines_1 = [
+        '##INFO=<ID=NS,Number=1,Type=Float,Description="Number samples">\n',
+        '##FORMAT=<ID=DP,Number=3,Type=Char,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n'
+    ]
+    lines_2 = [
+        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples2">\n',
+        '##FORMAT=<ID=DP,Number=3,Type=String,Description="Number samples2">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n'
+    ]
+    main_definitions = self._create_definitions_from_lines(lines_1, 'file1')
+    secondary_definitions = self._create_definitions_from_lines(
+        lines_2, 'file2')
+
+    expected_infos = {
+        'NS': {
+            Definition(1, 'Float'): ['file1'],
+            Definition(1, 'Integer'): ['file2']
+        }
+    }
+    expected_formats = {
+        'DP': {
+            Definition(3, 'Char'): ['file1'],
+            Definition(3, 'String'): ['file2']
+        }
+    }
+    merger.merge(main_definitions, secondary_definitions)
+
+    self.assertDictEqual(expected_infos, main_definitions.infos)
+    self.assertDictEqual(expected_formats, main_definitions.formats)
+
+  def test_merge_different_number(self):
+    merger = DefinitionsMerger()
+    lines_1 = [
+        '##INFO=<ID=NS,Number=1,Type=Float,Description="Number samples">\n',
+        '##FORMAT=<ID=DP,Number=3,Type=Char,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n'
+    ]
+    lines_2 = [
+        '##INFO=<ID=NS,Number=2,Type=Float,Description="Number samples2">\n',
+        '##FORMAT=<ID=DP,Number=4,Type=Char,Description="Number samples2">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n'
+    ]
+    main_definitions = self._create_definitions_from_lines(lines_1, 'file1')
+    secondary_definitions = self._create_definitions_from_lines(
+        lines_2, 'file2')
+
+    expected_infos = {
+        'NS': {
+            Definition(1, 'Float'): ['file1'],
+            Definition(2, 'Float'): ['file2']
+        }
+    }
+    expected_formats = {
+        'DP': {
+            Definition(3, 'Char'): ['file1'],
+            Definition(4, 'Char'): ['file2']
+        }
+    }
+    merger.merge(main_definitions, secondary_definitions)
+
+    self.assertDictEqual(expected_infos, main_definitions.infos)
+    self.assertDictEqual(expected_formats, main_definitions.formats)
+
+  def test_merge_different_id(self):
+    merger = DefinitionsMerger()
+    lines_1 = [
+        '##INFO=<ID=NS,Number=1,Type=Float,Description="Number samples">\n',
+        '##FORMAT=<ID=DP,Number=3,Type=Char,Description="Number samples">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample1 Sample2\n'
+    ]
+    lines_2 = [
+        '##INFO=<ID=NK,Number=1,Type=Float,Description="Number samples2">\n',
+        '##FORMAT=<ID=DL,Number=3,Type=Char,Description="Number samples2">\n',
+        '#CHROM  POS ID  REF ALT QUAL  FILTER  INFO  FORMAT  Sample3\n'
+    ]
+    main_definitions = self._create_definitions_from_lines(lines_1, 'file1')
+    secondary_definitions = self._create_definitions_from_lines(
+        lines_2, 'file2')
+
+    expected_infos = {
+        'NS': {Definition(1, 'Float'): ['file1']},
+        'NK': {Definition(1, 'Float'): ['file2']}
+    }
+    expected_formats = {
+        'DP': {Definition(3, 'Char'): ['file1']},
+        'DL': {Definition(3, 'Char'): ['file2']}
+    }
+    merger.merge(main_definitions, secondary_definitions)
+
+    self.assertDictEqual(expected_infos, main_definitions.infos)
+    self.assertDictEqual(expected_formats, main_definitions.formats)

--- a/gcp_variant_transforms/transforms/merge_header_definitions.py
+++ b/gcp_variant_transforms/transforms/merge_header_definitions.py
@@ -14,127 +14,59 @@
 
 """Beam combiner function for merging VCF file header definitions."""
 
-import collections
-from collections import namedtuple
 from typing import Dict, List  # pylint: disable=unused-import
 
 import apache_beam as beam
-from gcp_variant_transforms.beam_io import vcf_header_io
-from gcp_variant_transforms.beam_io.vcf_header_io import VcfHeader  # pylint: disable=unused-import
+from gcp_variant_transforms.beam_io import vcf_header_io # pylint: disable=unused-import
 
-# ``Definition`` cherry-picks the attributes from vcf header definitions that
-# are critical for checking field compatibilities across VCF files.
-Definition = namedtuple('Definition',
-                        [vcf_header_io.VcfParserHeaderKeyConstants.NUM,
-                         vcf_header_io.VcfParserHeaderKeyConstants.TYPE])
-
-
-class VcfHeaderDefinitions(object):
-  """Container for header definitions."""
-
-  def __init__(self, vcf_header=None):
-    # type: (VcfHeader) -> None
-    """Initializes a ``VcfHeaderDefinitions`` object.
-
-    Creates two dictionaries (for infos and formats respectively) that map field
-    id to a dictionary which maps ``Definition`` to a list of file names.
-    """
-    self._infos = collections.defaultdict(dict)
-    self._formats = collections.defaultdict(dict)
-    if not vcf_header:
-      return
-    for key, val in vcf_header.infos.iteritems():
-      definition = Definition(
-          val[vcf_header_io.VcfParserHeaderKeyConstants.NUM],
-          val[vcf_header_io.VcfParserHeaderKeyConstants.TYPE])
-      self._infos[key][definition] = [vcf_header.file_name]
-    for key, val in vcf_header.formats.iteritems():
-      definition = Definition(
-          val[vcf_header_io.VcfParserHeaderKeyConstants.NUM],
-          val[vcf_header_io.VcfParserHeaderKeyConstants.TYPE])
-      self._formats[key][definition] = [vcf_header.file_name]
-
-  def __eq__(self, other):
-    return self._infos == other._infos and self._formats == other._formats
-
-  @property
-  def infos(self):
-    return self._infos
-
-  @property
-  def formats(self):
-    return self._formats
-
-
-class _DefinitionsMerger(object):
-  """Class for merging two ``VcfHeaderDefinitions``s."""
-
-  # For the same field definition, save at most `_MAX_NUM_FILE_NAMES` names.
-  _MAX_NUM_FILE_NAMES = 5
-
-  def merge(self, first, second):
-    # type: (VcfHeaderDefinitions, VcfHeaderDefinitions) -> None
-    """Updates ``first``'s definitions with values from ``second``."""
-    if (not isinstance(first, VcfHeaderDefinitions) or
-        not isinstance(first, VcfHeaderDefinitions)):
-      raise NotImplementedError
-    self._merge_definitions(first.infos, second.infos)
-    self._merge_definitions(first.formats, second.formats)
-
-  def _merge_definitions(
-      self,
-      first,  # type: Dict[str, Dict[Definition, List[str]]]
-      second  # type: Dict[str, Dict[Definition, List[str]]]
-      ):
-    # type: (...) -> None
-    """Updates ``first`` by merging values from ``first`` and ``second``."""
-    for key, definitions_to_files_map in second.iteritems():
-      for definition, file_names in definitions_to_files_map.iteritems():
-        first[key].setdefault(definition, [])
-        first[key][definition].extend(str(s) for s in file_names)
-        first[key][definition] = (
-            first[key][definition][:self._MAX_NUM_FILE_NAMES])
+from gcp_variant_transforms.libs import vcf_header_definitions_merger
 
 
 class _MergeDefinitionsFn(beam.CombineFn):
   """Combiner function for merging definitions."""
 
   def __init__(self, definitions_merger):
-    # type: (_DefinitionsMerger) -> None
+    # type: (vcf_header_definitions_merger.DefinitionsMerger) -> None
     super(_MergeDefinitionsFn, self).__init__()
     self._definitions_merger = definitions_merger
 
   def create_accumulator(self):
-    return VcfHeaderDefinitions()
+    return vcf_header_definitions_merger.VcfHeaderDefinitions()
 
   def add_input(self, source, to_merge):
-    # type: (VcfHeaderDefinitions, VcfHeader) -> VcfHeaderDefinitions
-    return self.merge_accumulators([source,
-                                    VcfHeaderDefinitions(vcf_header=to_merge)])
+    # type: (vcf_header_definitions_merger.VcfHeaderDefinitions,
+    #        vcf_header_io.VcfHeader) ->
+    #            vcf_header_definitions_merger.VcfHeaderDefinitions
+    return self.merge_accumulators(
+        [source,
+         vcf_header_definitions_merger.VcfHeaderDefinitions(
+             vcf_header=to_merge)])
 
   def merge_accumulators(self, accumulators):
-    # type: (List[VcfHeaderDefinitions]) -> VcfHeaderDefinitions
+    # type: (List[vcf_header_definitions_merger.VcfHeaderDefinitions]) ->
+    #            vcf_header_definitions_merger.VcfHeaderDefinitions
     merged_definitions = self.create_accumulator()
     for to_merge in accumulators:
       self._definitions_merger.merge(merged_definitions, to_merge)
     return merged_definitions
 
   def extract_output(self, merged_definitions):
-    # type: (VcfHeaderDefinitions) -> VcfHeaderDefinitions
+    # type: (vcf_header_definitions_merger.VcfHeaderDefinitions) ->
+    #     vcf_header_definitions_merger.VcfHeaderDefinitions
     return merged_definitions
 
 
 class MergeDefinitions(beam.PTransform):
   """A PTransform to merge header definitions.
 
-  Reads a PCollection of ``VcfHeader`` and produces a PCollection of
-  ``VcfHeaderDefinitions``.
+  Reads a PCollection of `VcfHeader` and produces a PCollection of
+  `VcfHeaderDefinitions`.
   """
 
   def __init__(self):
-    """Initializes ``MergeDefinitions`` object."""
+    """Initializes `MergeDefinitions` object."""
     super(MergeDefinitions, self).__init__()
-    self._definitions_merger = _DefinitionsMerger()
+    self._definitions_merger = vcf_header_definitions_merger.DefinitionsMerger()
 
   def expand(self, pcoll):
     return pcoll | beam.CombineGlobally(

--- a/gcp_variant_transforms/transforms/merge_header_definitions_test.py
+++ b/gcp_variant_transforms/transforms/merge_header_definitions_test.py
@@ -23,8 +23,8 @@ from apache_beam.testing.util import equal_to
 from apache_beam.transforms import Create
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.transforms import merge_header_definitions
-from gcp_variant_transforms.transforms.merge_header_definitions import Definition
-from gcp_variant_transforms.transforms.merge_header_definitions import VcfHeaderDefinitions
+from gcp_variant_transforms.libs.vcf_header_definitions_merger import Definition
+from gcp_variant_transforms.libs.vcf_header_definitions_merger import VcfHeaderDefinitions
 
 
 class MergeHeadersTest(unittest.TestCase):


### PR DESCRIPTION
Move `VcfHeaderDefinitions` and `DefinitionsMerger` out of `merge_header_definitions.py` and into `libs/` subfolder.

Tested via running presubmit checks and unit tests locally.