### PR TITLE
Scalable vep annotation in VT

### DIFF
--- a/gcp_variant_transforms/libs/annotation/vep/vep_runner_test.py
+++ b/gcp_variant_transforms/libs/annotation/vep/vep_runner_test.py
@@ -156,7 +156,7 @@ class VepRunnerTest(unittest.TestCase):
     self._mock_service.projects = mock.Mock(return_value=mock_projects)
     mock_projects.operations = mock.Mock(return_value=mock_opearations)
     mock_opearations.get = mock.Mock(return_value=mock_request)
-    mock_request.execute = mock.Mock(return_value={'done': True})
+    mock_request.execute = mock.Mock(return_value={'done': True, 'error': {}})
     test_instance = self._create_test_instance()
     with patch('apache_beam.io.filesystems.FileSystems', _MockFileSystems):
       test_instance.run_on_all_files()
@@ -166,6 +166,22 @@ class VepRunnerTest(unittest.TestCase):
       test_instance.wait_until_done()
       # Since all operations are done, the next call should raise no exceptions.
       test_instance.run_on_all_files()
+
+  def test_wait_until_done_fail(self):
+    mock_projects = mock.Mock()
+    mock_opearations = mock.Mock()
+    mock_request = mock.Mock()
+    self._mock_service.projects = mock.Mock(return_value=mock_projects)
+    mock_projects.operations = mock.Mock(return_value=mock_opearations)
+    mock_opearations.get = mock.Mock(return_value=mock_request)
+    mock_request.execute = mock.Mock(return_value={
+        'done': True, 'error': {'message': 'failed'}})
+
+    test_instance = self._create_test_instance()
+    with patch('apache_beam.io.filesystems.FileSystems', _MockFileSystems):
+      test_instance.run_on_all_files()
+      with self.assertRaisesRegexp(RuntimeError, '.*failed.*retries.*'):
+        test_instance.wait_until_done()
 
 
 class PipelinesSpy(object):

--- a/gcp_variant_transforms/libs/annotation/vep/vep_runner_util_test.py
+++ b/gcp_variant_transforms/libs/annotation/vep/vep_runner_util_test.py
@@ -41,7 +41,7 @@ class VepRunnerUtilTest(unittest.TestCase):
     output_dir = 'test/out/dir'
     file_metadata_list = [file_metadata_stub.FileMetadataStub(path, size) for
                           (path, size) in _INPUT_FILES_WITH_SIZE]
-    worker_actions_list = vep_runner_util.get_vm_io_infos(
+    worker_actions_list = vep_runner_util.get_all_vm_io_info(
         file_metadata_list, output_dir, 1)
     self.assertEqual(1, len(worker_actions_list))
     single_worker_action_map = worker_actions_list[0].io_map
@@ -55,7 +55,7 @@ class VepRunnerUtilTest(unittest.TestCase):
     output_dir = 'test/out/dir'
     file_metadata_list = [file_metadata_stub.FileMetadataStub(path, size) for
                           (path, size) in _INPUT_FILES_WITH_SIZE]
-    worker_actions_list = vep_runner_util.get_vm_io_infos(
+    worker_actions_list = vep_runner_util.get_all_vm_io_info(
         file_metadata_list, output_dir, 3)
     self.assertEqual(3, len(worker_actions_list))
     total_number_of_files = sum([len(l.io_map) for l in worker_actions_list])

--- a/gcp_variant_transforms/libs/annotation/vep/vep_runner_util_test.py
+++ b/gcp_variant_transforms/libs/annotation/vep/vep_runner_util_test.py
@@ -41,7 +41,7 @@ class VepRunnerUtilTest(unittest.TestCase):
     output_dir = 'test/out/dir'
     file_metadata_list = [file_metadata_stub.FileMetadataStub(path, size) for
                           (path, size) in _INPUT_FILES_WITH_SIZE]
-    worker_actions_list = vep_runner_util.disribute_files_on_workers(
+    worker_actions_list = vep_runner_util.get_vm_io_infos(
         file_metadata_list, output_dir, 1)
     self.assertEqual(1, len(worker_actions_list))
     single_worker_action_map = worker_actions_list[0].io_map
@@ -55,7 +55,7 @@ class VepRunnerUtilTest(unittest.TestCase):
     output_dir = 'test/out/dir'
     file_metadata_list = [file_metadata_stub.FileMetadataStub(path, size) for
                           (path, size) in _INPUT_FILES_WITH_SIZE]
-    worker_actions_list = vep_runner_util.disribute_files_on_workers(
+    worker_actions_list = vep_runner_util.get_vm_io_infos(
         file_metadata_list, output_dir, 3)
     self.assertEqual(3, len(worker_actions_list))
     total_number_of_files = sum([len(l.io_map) for l in worker_actions_list])

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -289,17 +289,18 @@ class AnnotationOptions(VariantTransformsOptions):
     parser.add_argument(
         '--shard_input_files',
         type='bool', default=True, nargs='?', const=True,
-        help=('If true, shard the input files before running annotation tools. '
-              'This can improve the annotation performance for large input '
-              'files.'))
+        help=('By default, the input files are sharded into smaller temporary '
+              'VCF files before running VEP annotation. If the input files are '
+              'small, i.e., each VCF file contains less than 50,000 variants, '
+              'set this flag to false can be more time efficient.'))
     parser.add_argument(
         '--' + AnnotationOptions._OUTPUT_DIR_FLAG,
         default='',
         help=('The path on Google Cloud Storage to store annotated outputs. '
               'The output files are VCF and follow the same directory '
               'structure as input files with a suffix added to them. Note that '
-              'this is expected not to exist and is created in the process of '
-              'running VEP pipelines.'))
+              'this is expected not to exist and will be created in the '
+              'process of running VEP pipelines.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_IMAGE_FLAG,
         default='gcr.io/gcp-variant-annotation/vep_91_in_vt',
@@ -359,7 +360,10 @@ class AnnotationOptions(VariantTransformsOptions):
         '--number_of_variants_per_shard',
         type=int, default=20000,
         help=('The maximum number of variants written to each shard if '
-              '`shard_input_files` is true.'))
+              '`shard_input_files` is true. The default value should work '
+              'for most cases. You may change this flag to a smaller value if '
+              'you have a dataset with a lot of samples. Notice'
+              'that it may take a longer time to run with a smaller value.'))
 
   def validate(self, parsed_args):
     # type: (argparse.Namespace) -> None

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -287,7 +287,7 @@ class AnnotationOptions(VariantTransformsOptions):
         help=('If true, runs annotation tools (currently only VEP) on input '
               'VCFs before loading to BigQuery.'))
     parser.add_argument(
-        '--shard_input_files',
+        '--shard_variants',
         type='bool', default=True, nargs='?', const=True,
         help=('By default, the input files are sharded into smaller temporary '
               'VCF files before running VEP annotation. If the input files are '
@@ -303,7 +303,7 @@ class AnnotationOptions(VariantTransformsOptions):
               'process of running VEP pipelines.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_IMAGE_FLAG,
-        default='gcr.io/gcp-variant-annotation/vep_91_in_vt',
+        default='gcr.io/gcp-variant-annotation/vep_91',
         help=('The URI of the docker image for VEP.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_CACHE_FLAG,
@@ -360,7 +360,7 @@ class AnnotationOptions(VariantTransformsOptions):
         '--number_of_variants_per_shard',
         type=int, default=20000,
         help=('The maximum number of variants written to each shard if '
-              '`shard_input_files` is true. The default value should work '
+              '`shard_variants` is true. The default value should work '
               'for most cases. You may change this flag to a smaller value if '
               'you have a dataset with a lot of samples. Notice'
               'that it may take a longer time to run with a smaller value.'))

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -287,14 +287,22 @@ class AnnotationOptions(VariantTransformsOptions):
         help=('If true, runs annotation tools (currently only VEP) on input '
               'VCFs before loading to BigQuery.'))
     parser.add_argument(
+        '--shard_input_files',
+        type='bool', default=True, nargs='?', const=True,
+        help=('If true, shard the input files before running annotation tools. '
+              'This can improve the annotation performance for large input '
+              'files.'))
+    parser.add_argument(
         '--' + AnnotationOptions._OUTPUT_DIR_FLAG,
         default='',
         help=('The path on Google Cloud Storage to store annotated outputs. '
               'The output files are VCF and follow the same directory '
-              'structure as input files with a suffix added to them.'))
+              'structure as input files with a suffix added to them. Note that '
+              'this is expected not to exist and is created in the process of '
+              'running VEP pipelines.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_IMAGE_FLAG,
-        default='gcr.io/gcp-variant-annotation/vep_91',
+        default='gcr.io/gcp-variant-annotation/vep_91_in_vt',
         help=('The URI of the docker image for VEP.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_CACHE_FLAG,
@@ -342,6 +350,16 @@ class AnnotationOptions(VariantTransformsOptions):
               'pass over all variants. Additionally, this flag will resolve '
               'conflicts for all headers as if `allow_incompatible_types` was '
               'true.'))
+    parser.add_argument(
+        '--run_with_garbage_collection',
+        type='bool', default=True, nargs='?', const=True,
+        help=('If set, in case of failure or cancellation, the VMs running '
+              'VEP annotation will be cleaned up automatically.'))
+    parser.add_argument(
+        '--number_of_variants_per_shard',
+        type=int, default=20000,
+        help=('The maximum number of variants written to each shard if '
+              '`shard_input_files` is true.'))
 
   def validate(self, parsed_args):
     # type: (argparse.Namespace) -> None

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -87,32 +87,33 @@ def get_pipeline_mode(input_pattern, optimize_for_large_inputs=False):
   return PipelineModes.SMALL
 
 
-def read_headers(pipeline, pipeline_mode, known_args):
-  # type: (beam.Pipeline, int, argparse.Namespace) -> pvalue.PCollection
+def read_headers(pipeline, pipeline_mode, input_pattern):
+  # type: (beam.Pipeline, int, str) -> pvalue.PCollection
   """Creates an initial PCollection by reading the VCF file headers."""
   if pipeline_mode == PipelineModes.LARGE:
     headers = (pipeline
-               | beam.Create([known_args.input_pattern])
+               | beam.Create([input_pattern])
                | vcf_header_io.ReadAllVcfHeaders())
   else:
-    headers = pipeline | vcf_header_io.ReadVcfHeaders(known_args.input_pattern)
+    headers = pipeline | vcf_header_io.ReadVcfHeaders(input_pattern)
   return headers
 
 
-def add_original_headers(pipeline, known_args, pipeline_mode,
-                         merged_header,
-                         original_input_pattern):
+def add_annotation_headers(pipeline, known_args, pipeline_mode,
+                           merged_header,
+                           annotated_vcf_pattern):
   if pipeline_mode == PipelineModes.LARGE:
-    original_headers = (pipeline
-                        | 'ReadOriginalInput'
-                        >> beam.Create([original_input_pattern])
-                        | 'ReadHeaders' >> vcf_header_io.ReadAllVcfHeaders())
+    annotation_headers = (pipeline
+                          | 'ReadAnnotatedVCF'
+                          >> beam.Create([annotated_vcf_pattern])
+                          | 'ReadHeaders' >> vcf_header_io.ReadAllVcfHeaders())
   else:
-    original_headers = (
+    annotation_headers = (
         pipeline
-        | 'ReadHeaders' >> vcf_header_io.ReadVcfHeaders(original_input_pattern))
+        | 'ReadHeaders'
+        >> vcf_header_io.ReadVcfHeaders(annotated_vcf_pattern))
   merged_header = (
-      (merged_header, original_headers)
+      (merged_header, annotation_headers)
       | beam.Flatten()
       | 'MergeWithOriginalHeaders' >> merge_headers.MergeHeaders(
           known_args.split_alternate_allele_info_fields,

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
@@ -8,7 +8,7 @@
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",
-    "shard_input_files": "False",
+    "shard_variants": "False",
     "num_workers": 2,
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
@@ -8,6 +8,7 @@
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",
+    "shard_input_files": "False",
     "num_workers": 2,
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
@@ -8,7 +8,7 @@
     "run_annotation_pipeline": "True",
     "infer_annotation_types": "True",
     "run_with_garbage_collection": "False",
-    "shard_input_files": "False",
+    "shard_variants": "False",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",
     "num_workers": 1,
     "assertion_configs": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep_with_gc.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep_with_gc.json
@@ -8,7 +8,7 @@
     "run_annotation_pipeline": "True",
     "infer_annotation_types": "True",
     "run_with_garbage_collection": "True",
-    "shard_input_files": "True",
+    "shard_variants": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",
     "num_workers": 2,
     "assertion_configs": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep_with_gc.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep_with_gc.json
@@ -1,16 +1,16 @@
 [
   {
-    "test_name": "platinum-na12877-hg38-10k-lines-run-vep",
-    "table_name": "platinum_NA12877_hg38_10K_lines_run_vep",
+    "test_name": "platinum-na12877-hg38-10k-lines-run-vep-with-gc",
+    "table_name": "platinum_NA12877_hg38_10K_lines_run_vep_with_gc",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/platinum_NA12877_hg38_10K_lines_manual_vep_orig_output.vcf",
     "annotation_fields": "CSQ",
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "infer_annotation_types": "True",
-    "run_with_garbage_collection": "False",
-    "shard_input_files": "False",
+    "run_with_garbage_collection": "True",
+    "shard_input_files": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",
-    "num_workers": 1,
+    "num_workers": 2,
     "assertion_configs": [
       {
         "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/transforms/annotate_files.py
+++ b/gcp_variant_transforms/transforms/annotate_files.py
@@ -1,0 +1,54 @@
+# Copyright 2019 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import time
+import uuid
+from datetime import datetime
+from typing import List  # pylint: disable=unused-import
+
+import apache_beam as beam
+from apache_beam.io import filesystems
+
+from gcp_variant_transforms.libs.annotation.vep import vep_runner
+
+
+class AnnotateFile(beam.DoFn):
+  """A PTransform to annotate VCF files."""
+
+  def __init__(self, known_args, pipeline_args):
+    # type: (argparse.Namespace, List[str]) -> None
+    """Initializes `AnnotateFile` object."""
+    self._known_args = known_args
+    self._pipeline_args = pipeline_args
+
+  def process(self, input_pattern):
+    # type: (str) -> None
+    watchdog_file = None
+    if self._known_args.run_with_garbage_collection:
+      unique_id = '-'.join(['watchdog_file',
+                            str(uuid.uuid4()),
+                            datetime.now().strftime('%Y%m%d-%H%M%S')])
+      watchdog_file = filesystems.FileSystems.join(
+          self._known_args.annotation_output_dir, unique_id)
+      with filesystems.FileSystems.create(watchdog_file) as file_to_write:
+        file_to_write.write(str(int(time.time())))
+
+    runner = vep_runner.create_runner(self._known_args,
+                                      self._pipeline_args,
+                                      input_pattern,
+                                      watchdog_file)
+    runner.run_on_all_files()
+    runner.wait_until_done()

--- a/gcp_variant_transforms/transforms/annotate_files.py
+++ b/gcp_variant_transforms/transforms/annotate_files.py
@@ -14,7 +14,6 @@
 
 from __future__ import absolute_import
 
-import time
 import uuid
 from datetime import datetime
 from typing import List  # pylint: disable=unused-import
@@ -44,7 +43,7 @@ class AnnotateFile(beam.DoFn):
       watchdog_file = filesystems.FileSystems.join(
           self._known_args.annotation_output_dir, unique_id)
       with filesystems.FileSystems.create(watchdog_file) as file_to_write:
-        file_to_write.write(str(int(time.time())))
+        file_to_write.write('Watchdog file.')
 
     runner = vep_runner.create_runner(self._known_args,
                                       self._pipeline_args,

--- a/gcp_variant_transforms/transforms/write_variants_to_shards.py
+++ b/gcp_variant_transforms/transforms/write_variants_to_shards.py
@@ -23,12 +23,12 @@ from gcp_variant_transforms.beam_io import vcfio
 from gcp_variant_transforms.libs.annotation.vep import vep_runner_util
 
 
-class _WriteToShardsFn(beam.DoFn):
+class _WriteVariantsToVCFShards(beam.DoFn):
   """Writes variants to VCF shards."""
 
   def __init__(self, vcf_shards_output_dir, number_of_variants_per_shard):
     # type: (str, int) -> None
-    """Initializes `_WriteToShardsFn` object.
+    """Initializes `_WriteVariantsToVCFShards` object.
 
     Args:
       vcf_shards_output_dir: The location for all VCF shards.
@@ -114,6 +114,6 @@ class WriteToShards(beam.PTransform):
   def expand(self, pcoll):
     _ = (pcoll
          | 'GenerateKeys' >> beam.ParDo(
-             _WriteToShardsFn(self._vcf_shards_output_dir,
-                              self._number_of_variants_per_shard),
+             _WriteVariantsToVCFShards(self._vcf_shards_output_dir,
+                                       self._number_of_variants_per_shard),
              self._call_names))

--- a/gcp_variant_transforms/transforms/write_variants_to_shards.py
+++ b/gcp_variant_transforms/transforms/write_variants_to_shards.py
@@ -1,0 +1,119 @@
+# Copyright 2019 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import uuid
+from datetime import datetime
+from typing import List  # pylint: disable=unused-import
+
+import apache_beam as beam
+from apache_beam.io import filesystems
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.libs.annotation.vep import vep_runner_util
+
+
+class _WriteToShardsFn(beam.DoFn):
+  """Writes variants to VCF shards."""
+
+  def __init__(self, vcf_shards_output_dir, number_of_variants_per_shard):
+    # type: (str, int) -> None
+    """Initializes `_WriteToShardsFn` object.
+
+    Args:
+      vcf_shards_output_dir: The location for all VCF shards.
+      number_of_variants_per_shard: The maximum number of variants that is
+        written into one VCF shard.
+    """
+    self._vcf_shards_output_dir = vcf_shards_output_dir
+    self._number_of_variants_per_shard = number_of_variants_per_shard
+    self._coder = vcfio._ToVcfRecordCoder()
+    self._call_names = []
+    self._variant_lines = []
+    self._counter = 0
+
+  def start_bundle(self):
+    self._variant_lines[:] = []
+    self._counter = 0
+
+  def finish_bundle(self):
+    if self._variant_lines:
+      self._write_variant_lines_to_vcf_shard(self._variant_lines)
+
+  def process(self, variant, call_names):
+    # type: (vcfio.Variant, List[str]) -> None
+    self._counter += 1
+    self._call_names = call_names
+    self._variant_lines.append(self._coder.encode(variant).strip('\n'))
+    if self._counter == self._number_of_variants_per_shard:
+      self._write_variant_lines_to_vcf_shard(self._variant_lines)
+      self._counter = 0
+      self._variant_lines[:] = []
+
+  def _write_variant_lines_to_vcf_shard(self, variant_lines):
+    # type: (List[str]) -> None
+    """Writes variant lines to one VCF shard."""
+    vcf_fixed_columns = ['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER',
+                         'INFO', 'FORMAT']
+    str_call_names = [str(call_name) for call_name in self._call_names]
+    vcf_header = str('\t'.join(vcf_fixed_columns + str_call_names))
+    vcf_data_file = self._generate_unique_file_path(len(variant_lines))
+    with filesystems.FileSystems.create(vcf_data_file) as file_to_write:
+      file_to_write.write(vcf_header)
+      for v in variant_lines:
+        file_to_write.write('\n')
+        file_to_write.write(v)
+
+  def _generate_unique_file_path(self, variants_num):
+    # type: (int) -> str
+    """Generates a unique file path."""
+    unique_dir = filesystems.FileSystems.join(
+        self._vcf_shards_output_dir, self._generate_unique_key())
+    if filesystems.FileSystems.exists(unique_dir):
+      raise RuntimeError('The shard dir {} already exists.'.format(unique_dir))
+    filesystems.FileSystems.mkdirs(unique_dir)
+    return filesystems.FileSystems.join(
+        unique_dir, vep_runner_util._SHARD_PREFIX + str(variants_num))
+
+  def _generate_unique_key(self):
+    # type: () -> str
+    return '-'.join([str(uuid.uuid4()),
+                     datetime.now().strftime('%Y%m%d-%H%M%S')])
+
+
+class WriteToShards(beam.PTransform):
+  """A PTransform for writing variants to shards."""
+
+  def __init__(self,
+               vcf_shards_output_dir,
+               call_names,
+               number_of_variants_per_shard=20000):
+    # type (str, List[str], int) -> None
+    """Initializes `WriteToShards` object.
+
+     Args:
+       vcf_shards_output_dir: The location for all VCF shards.
+       call_names: Names of all calls.
+       number_of_variants_per_shard: The maximum number of variants that is
+         written into one VCF shard.
+    """
+    self._vcf_shards_output_dir = vcf_shards_output_dir
+    self._call_names = call_names
+    self._number_of_variants_per_shard = number_of_variants_per_shard
+
+  def expand(self, pcoll):
+    _ = (pcoll
+         | 'GenerateKeys' >> beam.ParDo(
+             _WriteToShardsFn(self._vcf_shards_output_dir,
+                              self._number_of_variants_per_shard),
+             self._call_names))

--- a/gcp_variant_transforms/transforms/write_variants_to_shards_test.py
+++ b/gcp_variant_transforms/transforms/write_variants_to_shards_test.py
@@ -46,7 +46,7 @@ class WriteVariantsToShardsTest(unittest.TestCase):
 
   def test_write_to_shards(self):
     with temp_dir.TempDir() as tempdir:
-      shards_writter = write_variants_to_shards._WriteToShardsFn(
+      shards_writter = write_variants_to_shards._WriteVariantsToVCFShards(
           tempdir.get_path(), 3)
       variants = self._get_variants()
       variant_lines = [shards_writter._coder.encode(v).strip('\n')

--- a/gcp_variant_transforms/transforms/write_variants_to_shards_test.py
+++ b/gcp_variant_transforms/transforms/write_variants_to_shards_test.py
@@ -1,0 +1,82 @@
+# Copyright 2019 Google Inc.  All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `write_variants_to_shards` module."""
+
+import os
+import unittest
+
+from apache_beam.io import filesystems
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.transforms import Create
+
+from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.testing import temp_dir
+from gcp_variant_transforms.transforms import write_variants_to_shards
+
+
+class WriteVariantsToShardsTest(unittest.TestCase):
+
+  def _get_variants(self):
+    variant_1 = vcfio.Variant(
+        reference_name='19', start=11, end=12, reference_bases='C',
+        alternate_bases=['A', 'TT'], names=['rs1'], quality=2,
+        filters=['PASS'],
+        info={'A1': 'some data', 'A2': ['data1', 'data2']}
+    )
+    variant_2 = vcfio.Variant(
+        reference_name='19', start=11, end=12, reference_bases='C',
+        alternate_bases=['A', 'TT'], names=['rs1'], quality=20,
+        filters=['q10'],
+        info={'A1': 'some data2', 'A3': ['data3', 'data4']}
+
+    )
+    return [variant_1, variant_2]
+
+  def test_write_to_shards(self):
+    with temp_dir.TempDir() as tempdir:
+      shards_writter = write_variants_to_shards._WriteToShardsFn(
+          tempdir.get_path(), 3)
+      variants = self._get_variants()
+      variant_lines = [shards_writter._coder.encode(v).strip('\n')
+                       for v in variants]
+      shards_writter._write_variant_lines_to_vcf_shard(variant_lines)
+
+      expected_content = [
+          '\t'.join(['#CHROM', 'POS', 'ID', 'REF', 'ALT', 'QUAL', 'FILTER',
+                     'INFO', 'FORMAT\n']),
+          '\t'.join(['19', '12', 'rs1', 'C', 'A,TT', '2', 'PASS',
+                     'A1=some data;A2=data1,data2', '.\n']),
+          '\t'.join(['19', '12', 'rs1', 'C', 'A,TT', '20', 'q10',
+                     'A1=some data2;A3=data3,data4', '.'])]
+
+      file_paths = []
+      for dirpath, _, filenames in os.walk(tempdir.get_path()):
+        for f in filenames:
+          file_paths.append(os.path.abspath(os.path.join(dirpath, f)))
+      self.assertEqual(1, len(file_paths))
+      with filesystems.FileSystems.open(file_paths[0]) as f:
+        content = f.readlines()
+        self.assertEqual(content, expected_content)
+
+  def test_write_to_shards_pipeline(self):
+    with temp_dir.TempDir() as tempdir:
+      pipeline = TestPipeline()
+      _ = (
+          pipeline
+          | Create(self._get_variants())
+          | 'WriteToShards' >> write_variants_to_shards.WriteToShards(
+              tempdir.get_path(), ['Sample 1', 'Sample 2'])
+      )
+      pipeline.run()

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -292,6 +292,8 @@ def run(argv=None):
   variant_merger = _get_variant_merge_strategy(known_args)
   # Starts a pipeline to merge VCF headers in beam if the total files that
   # match the input pattern exceeds _SMALL_DATA_THRESHOLD
+  pipeline_mode = pipeline_common.get_pipeline_mode(
+      known_args.input_pattern, known_args.optimize_for_large_inputs)
   _merge_headers(known_args, pipeline_args, pipeline_mode,
                  original_input_pattern)
 

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -97,7 +97,8 @@ def run(argv=None):
   pipeline_mode = pipeline_common.get_pipeline_mode(known_args.input_pattern)
 
   with beam.Pipeline(options=options) as p:
-    headers = pipeline_common.read_headers(p, pipeline_mode, known_args)
+    headers = pipeline_common.read_headers(p, pipeline_mode,
+                                           known_args.input_pattern)
     merged_headers = pipeline_common.get_merged_headers(headers)
     merged_definitions = (headers
                           | 'MergeDefinitions' >>


### PR DESCRIPTION
This PR improves the current annotation pipeline by:
- Add option '--shard_input_files' to shard the input files before annotations.
- Add option '--run_with_garbage_collection' to clean up the VMs in case of failure or cancellation.
- Distribute the annotation workload to VMs more evenly based on the number of variants rather than the number of files.
- Add Integration tests and published a new VEP image.

TODO: update the doc.
Tested: unit tests  & integration tests