### PR TITLE
update the watchdog file

### DIFF
--- a/gcp_variant_transforms/libs/annotation/vep/vep_runner_test.py
+++ b/gcp_variant_transforms/libs/annotation/vep/vep_runner_test.py
@@ -81,7 +81,7 @@ class VepRunnerTest(unittest.TestCase):
         self._mock_service, _ASSEMBLY, _SPECIES,
         _INPUT_PATTERN, _OUTPUT_DIR,
         _VEP_INFO_FIELD, _IMAGE, _CACHE, _NUM_FORK,
-        pipeline_args or self._get_pipeline_args())
+        pipeline_args or self._get_pipeline_args(), None, 30)
     return test_object
 
   def _get_pipeline_args(self, num_workers=1):
@@ -105,13 +105,15 @@ class VepRunnerTest(unittest.TestCase):
     self.assertEqual(test_instance._vep_cache_path, _CACHE)
     test_instance = vep_runner.VepRunner(
         self._mock_service, _SPECIES, _ASSEMBLY, _INPUT_PATTERN, _OUTPUT_DIR,
-        _VEP_INFO_FIELD, _IMAGE, '', _NUM_FORK, self._get_pipeline_args())
+        _VEP_INFO_FIELD, _IMAGE, '', _NUM_FORK, self._get_pipeline_args(),
+        None, 30)
     self.assertEqual(test_instance._vep_cache_path,
                      ('gs://gcp-variant-annotation-vep-cache/'
                       'vep_cache_homo_sapiens_GRCh38_91.tar.gz'))
     test_instance = vep_runner.VepRunner(
         self._mock_service, 'mouse', 'mm9', _INPUT_PATTERN, _OUTPUT_DIR,
-        _VEP_INFO_FIELD, _IMAGE, '', _NUM_FORK, self._get_pipeline_args())
+        _VEP_INFO_FIELD, _IMAGE, '', _NUM_FORK, self._get_pipeline_args(),
+        None, 30)
     self.assertEqual(test_instance._vep_cache_path,
                      ('gs://gcp-variant-annotation-vep-cache/'
                       'vep_cache_mouse_mm9_91.tar.gz'))


### PR DESCRIPTION
Fix one bug for annotation. The operations could get killed because of the watchdog file is stale even though no cancellation is made. The watchdog file was updated only when waiting for one operation to be done. This fix handles the following two failing cases:
- If there are a lot of PAPI calls, some operations might already start running VEP (after loading cache) while we are still submitting other operations, the stale watchdog file will get this operation to be killed.
- If there are a lot of consecutive done operations, the watchdog file won't be updated in time.

Tested: unit tests & integration tests & manually ran one annotation test.