### PR TITLE
Fix gsutil failure in integration tests

### DIFF
--- a/gcp_variant_transforms/testing/integration/run_tests_common.py
+++ b/gcp_variant_transforms/testing/integration/run_tests_common.py
@@ -165,7 +165,7 @@ def form_pipelines_api_request(project,  # type: str
                   'commands': ['/bin/sh', '-c', ' '.join([script_path] + args)]
               },
               {
-                  'imageUri': 'google/cloud-sdk',
+                  'imageUri': 'gcr.io/cloud-genomics-pipelines/io',
                   'commands': [
                       'sh', '-c',
                       'gsutil cp /google/logs/output %s' % logging_location


### PR DESCRIPTION
The integration tests may fail randomly due to the transient gustil failure (401 Anonymous caller does not have storage.objects.list). Fixed this issue by using `gcr.io/cloud-genomics-pipelines/io` image instead, which wraps gsutil with additional retries.

Tested: integration tests.