### PR TITLE
Fix issues in BQ to VCF

### DIFF
--- a/gcp_variant_transforms/libs/genomic_region_parser.py
+++ b/gcp_variant_transforms/libs/genomic_region_parser.py
@@ -43,7 +43,7 @@ def parse_genomic_region(genomic_region):
   matched = _REGION_LITERAL_REGEXP.match(genomic_region)
   if matched:
     ref_name, start, end = matched.groups()
-    ref_name = ref_name.strip().lower()
+    ref_name = ref_name.strip()
     start = _parse_position(start)
     end = _parse_position(end)
     if start < 0:
@@ -54,7 +54,7 @@ def parse_genomic_region(genomic_region):
                        'vs {}'.format(end, start))
   else:
     # This region includes a full chromosome
-    ref_name = genomic_region.strip().lower()
+    ref_name = genomic_region.strip()
     start = 0
     end = _DEFAULT_END_POSITION
   return ref_name, start, end

--- a/gcp_variant_transforms/libs/genomic_region_parser_test.py
+++ b/gcp_variant_transforms/libs/genomic_region_parser_test.py
@@ -29,8 +29,8 @@ class GenomicRegionParserTest(unittest.TestCase):
         ('chr1', 1000000, 2000000)
     )
     self.assertEqual(
-        genomic_region_parser.parse_genomic_region('chr1:1000000-2000000'),
-        ('chr1', 1000000, 2000000)
+        genomic_region_parser.parse_genomic_region('chrY:1000000-2000000'),
+        ('chrY', 1000000, 2000000)
     )
     self.assertEqual(
         genomic_region_parser.parse_genomic_region('chr'),

--- a/gcp_variant_transforms/libs/variant_partition.py
+++ b/gcp_variant_transforms/libs/variant_partition.py
@@ -189,6 +189,7 @@ class VariantPartition(object):
 
       for r in regions:
         ref_name, start, end = genomic_region_parser.parse_genomic_region(r)
+        ref_name = ref_name.lower()
         self._ref_name_to_partitions_map[ref_name].add_region(
             start, end, partition_index)
 

--- a/gcp_variant_transforms/libs/vcf_file_composer.py
+++ b/gcp_variant_transforms/libs/vcf_file_composer.py
@@ -179,6 +179,8 @@ class MultiProcessComposer(object):
     """
     blobs_to_be_composed = list(self._bucket.list_blobs(prefix=blob_prefix))
     logging.info('Total number of blobs is %d.', len(blobs_to_be_composed))
+    if not blobs_to_be_composed:
+      raise RuntimeError('No VCF shards found.')
     if len(blobs_to_be_composed) == 1:
       return blobs_to_be_composed[0]
     new_blob_prefix = filesystems.FileSystems.join(blob_prefix, 'composed_')


### PR DESCRIPTION
- Raises an error when there are no shards found.
- When parsing the genomic region filter, it should be case sensitive. For instance, chrY:1-1000, should have ref=chrY, rather than ref=chry, or the SELECT query will return the wrong results. This method is reused by partitioning, in which the matching of the reference should be case insensitive.

Issues: [447](https://github.com/googlegenomics/gcp-variant-transforms/issues/447),[446](https://github.com/googlegenomics/gcp-variant-transforms/issues/446)
Tested: unit tests