### PR TITLE
automate release

### DIFF
--- a/cloudbuild_CI.yaml
+++ b/cloudbuild_CI.yaml
@@ -50,7 +50,7 @@ steps:
       - '--run_unit_tests'
       - '--run_preprocessor_tests'
       - '--run_bq_to_vcf_tests'
-      - '--run_presubmit_tests'
+      - '--run_all_tests'
       - '--test_name_prefix cloud-ci-'
     id: 'test-gcp-variant-transforms-docker'
       # By default the script uses a GS bucket of gcp-variant-transforms-test

--- a/cloudbuild_release.yaml
+++ b/cloudbuild_release.yaml
@@ -13,50 +13,16 @@
 # limitations under the License.
 
 # This is meant to be used by the Build Trigger set in Cloud Build for auto
-# release. This is what it does:
-# - Builds an image using the last GitHub commit hash as the tag.
-# - Pushes that image to the test project's Container Registry.
-# - Runs all integration test from that very image.
-# - Pushes the verified image to the main project (gcp-variant-transforms).
+# release. It pushes the verified image to the main project
+# (gcp-variant-transforms) and tags it with `TAG_NAME` and `latest`.
 
 steps:
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      - 'build'
-      - '-t'
-      - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-      - '-f'
-      - 'docker/Dockerfile'
-      - '.'
-    id: 'build-image'
-
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      - 'push'
-      - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-    id: 'deploy-to-test-project'
-
-  - name: 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-    args:
-      - 'bash'
-      - './deploy_and_run_tests.sh'
-      - '--keep_image'
-      - '--skip_build'
-      - '--project ${PROJECT_ID}'
-      - '--image_tag ${COMMIT_SHA}'
-      - '--run_unit_tests'
-      - '--run_preprocessor_tests'
-      - '--run_bq_to_vcf_tests'
-      - '--run_all_tests'
-      - '--test_name_prefix cloud-ci-'
-    id: 'test-image'
-
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'tag'
       - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
       - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
-    id: 'tag-image'
+    id: 'tag-image-commit-sha'
 
   - name: 'gcr.io/cloud-builders/docker'
     args:
@@ -64,4 +30,18 @@ steps:
       - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
     id: 'deploy-to-serving-project'
 
-timeout: 150m
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'tag'
+      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
+      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${TAG_NAME}'
+    id: 'tag-image-release-version'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'tag'
+      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
+      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:latest'
+    id: 'tag-image-latest'
+
+timeout: 10m

--- a/cloudbuild_release.yaml
+++ b/cloudbuild_release.yaml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # This is meant to be used by the Build Trigger set in Cloud Build for auto
-# release. It pushes the verified image to the main project
-# (gcp-variant-transforms) and tags it with `TAG_NAME` and `latest`.
+# release. It tags the verified image and pushes to the main project
+# (gcp-variant-transforms).
 
 steps:
   - name: 'gcr.io/cloud-builders/docker'
@@ -23,12 +23,6 @@ steps:
       - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
       - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
     id: 'tag-image-commit-sha'
-
-  - name: 'gcr.io/cloud-builders/docker'
-    args:
-      - 'push'
-      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
-    id: 'deploy-to-serving-project'
 
   - name: 'gcr.io/cloud-builders/docker'
     args:
@@ -44,4 +38,7 @@ steps:
       - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:latest'
     id: 'tag-image-latest'
 
-timeout: 10m
+images:
+  - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
+  - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${TAG_NAME}'
+  - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:latest'

--- a/docs/release.md
+++ b/docs/release.md
@@ -12,35 +12,10 @@ The process is as follows:
    https://semver.org/. See the **Summary** section for a quick overview.
 1. Update the version number in
    [setup.py](https://github.com/googlegenomics/gcp-variant-transforms/blob/master/setup.py)
-   by submitting a change. Please include `[skip ci]` in the commit message, so
-   the auto build will not be triggered and we will run the release build
-   trigger manually instead in the next step.
-1. Go to
-   [Cloud Build](https://pantheon.corp.google.com/cloud-build/triggers?project=gcp-variant-transforms-test),
-   find the trigger `Release (disabled)`, and click `Run trigger`. It will start
-   running all tests and publish the verified image to the main project at the
-   end.
-1. Wait until it is done. It will take about 2 hours. Ensure that there
-   are no failures. In case of failures, rollback the version change in
-   `setup.py` and continue from Step #1 once the errors are fixed.
-1. Navigate to the
-   [Container registry](https://console.cloud.google.com/gcr/images/gcp-variant-transforms/GLOBAL/gcp-variant-transforms?project=gcp-variant-transforms)
-   page and update the published image to have the labels `latest` and `X.X.X`
-   for the version number. You may optionally run a "sanity" test on the newly
-   released image by running:
-
-   ```bash
-   temp_dir="$(mktemp -d)"
-   virtualenv "${temp_dir}"
-   source ${temp_dir}/bin/activate
-   pip install --upgrade .[int_test]
-   python gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py \
-       --project gcp-variant-transforms-test \
-       --staging_location "gs://integration_test_runs/staging" \
-       --temp_location "gs://integration_test_runs/temp" \
-       --logging_location "gs://integration_test_runs/temp/logs" \
-       --image gcr.io/gcp-variant-transforms/gcp-variant-transforms
-   ```
+   by submitting a change.
+1. Wait until the integration tests are done. It will take about 2 hours. Ensure
+   that there are no failures. In case of failures, rollback the version change
+   in `setup.py` and continue from Step #1 once the errors are fixed.
 1. Navigate to the
    [releases tab](https://github.com/googlegenomics/gcp-variant-transforms/releases)
    and click on **Draft a new release**.
@@ -51,5 +26,7 @@ The process is as follows:
    1. Enter a description of the main features and/or bug fixes going into the
       release.
    1. Click on **Publish release**.
+   1. This will kick off a trigger to copy the verified image to the main
+      project.
 1. Congratulations! The release process is now complete!
 


### PR DESCRIPTION
- modify the auto integration tests to cover all tests
- update the cloudbuild_release.yaml to be triggered by TAG. It also tags the image after publish.