### PR TITLE
Update deploy_and_run_tests with httplib2 update

### DIFF
--- a/deploy_and_run_tests.sh
+++ b/deploy_and_run_tests.sh
@@ -227,6 +227,11 @@ if [[ -n "${run_unit_tests}" ]]; then
 fi
 pip install --upgrade .[int_test]
 
+# Due to the dependency issue, we have to manually upgrade httplib2 in order to
+# circumvent the CERTIFICATE_VERIFY_FAILED error. For more info, visit
+# https://github.com/googlegenomics/gcp-variant-transforms/issues/453.
+pip install --upgrade httplib2
+
 color_print "Running integration tests against ${full_image_name}" "${GREEN}"
 python gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py \
     --project "${project}" \

--- a/deploy_and_run_tests.sh
+++ b/deploy_and_run_tests.sh
@@ -227,9 +227,7 @@ if [[ -n "${run_unit_tests}" ]]; then
 fi
 pip install --upgrade .[int_test]
 
-# Due to the dependency issue, we have to manually upgrade httplib2 in order to
-# circumvent the CERTIFICATE_VERIFY_FAILED error. For more info, visit
-# https://github.com/googlegenomics/gcp-variant-transforms/issues/453.
+# Force an upgrade to avoid SSL certificate verification errors (issue #453).
 pip install --upgrade httplib2
 
 color_print "Running integration tests against ${full_image_name}" "${GREEN}"


### PR DESCRIPTION
Update deploy_and_run_tests.sh to upgrade httplib2 to newer version.
Workaround for https://github.com/googlegenomics/gcp-variant-transforms/issues/453