### PR TITLE
Replace gcloud genomic command with pipelines tool

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,13 @@
 # To build a new docker image, run the following from the root source dir:
 # $ docker build . -f docker/Dockerfile -t $IMAGE_NAME
 
-FROM google/cloud-sdk
+FROM golang:1.11
+
+RUN go get -ldflags '-extldflags "-fno-PIC -static"' -buildmode pie -tags 'osusergo netgo static_build' github.com/googlegenomics/pipelines-tools/pipelines
+
+FROM google/cloud-sdk:slim
+
+COPY --from=0 /go/bin/pipelines /usr/bin
 
 ARG commit_sha
 ENV COMMIT_SHA=${commit_sha}

--- a/docker/pipelines_runner.sh
+++ b/docker/pipelines_runner.sh
@@ -75,16 +75,15 @@ function main {
     exit 1
   fi
 
-  operation_info=$( (`gcloud alpha genomics pipelines run \
-    --project "${google_cloud_project}" \
-    --logging "${temp_location}"/runner_logs_$(date +%Y%m%d_%H%M%S).log \
-    --service-account-scopes "https://www.googleapis.com/auth/cloud-platform" \
+  pipelines --project "${google_cloud_project}" run \
+    --command "/opt/gcp_variant_transforms/bin/${command} --project ${google_cloud_project}" \
+    --output "${temp_location}"/runner_logs_$(date +%Y%m%d_%H%M%S).log \
+    --wait \
+    --scopes "https://www.googleapis.com/auth/cloud-platform" \
     --zones "${zones}" \
-    --docker-image "${vt_docker_image}" \
-    --command-line "/opt/gcp_variant_transforms/bin/${command} --project ${google_cloud_project}"`) 2>&1)
-
-  operation_id="$(echo ${operation_info} | grep -o -P '(?<=operations/).*(?=])')"
-  gcloud alpha genomics operations wait ${operation_id}
+    --image "${vt_docker_image}" \
+    --pvm-attempts 0 \
+    --attempts 1
 }
 
 main "$@"


### PR DESCRIPTION
gcloud alpha genomic pipelines run command may fail for gsutil copy logging step.