### PR TITLE
Modify entry script to execute command as is, if supplied to pipelines API directly.

### DIFF
--- a/docker/pipelines_runner.sh
+++ b/docker/pipelines_runner.sh
@@ -51,6 +51,9 @@ function parse_args {
 }
 
 function main {
+  if [[ $1 == /opt/gcp_variant_transforms/bin/* ]]; then
+    exec $@
+  fi
   parse_args "$@"
 
   google_cloud_project="${google_cloud_project:-$(gcloud config get-value project)}"


### PR DESCRIPTION
Fixes the issue in #475 

Tested via docker, gcloud and pipelines run.
Got the same error as customer with following command on older image, but passed with new image:
pipelines run action_input.json --scopes https://www.googleapis.com/auth/genomics,https://www.googleapis.com/auth/cloud-platform --zones us-west1-b

with action_input.json:
[
  {
    "imageUri": "gcr.io/tural-test-runner/gcp-variant-transforms:a53a8fa653d5110ac3da0d5ed71f1147dde3fd33",
    "commands": ["/opt/gcp_variant_transforms/bin/vcf_to_bq", "--project", "tural-test-runner", "--input_pattern", "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf", "--output_table", "tural-test-runner:turalds.test1800", "--runner", "DataflowRunner", "--job_name", "vcf-to-bigquery", "--temp_location", "gs://tural-test-runner/temp", "--staging_location", "gs://tural-test-runner/staging"],
  }
]