### PR TITLE
Update integration test

### DIFF
--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/combine_from_multiple_inputs.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/combine_from_multiple_inputs.json
@@ -9,15 +9,15 @@
     "assertion_configs": [
       {
         "query": ["NUM_ROWS_QUERY"],
-        "expected_result": {"num_rows": 19790}
+        "expected_result": {"num_rows": 9895}
       },
       {
         "query": ["SELECT SUM(DP) AS sum FROM {TABLE_NAME}"],
-        "expected_result": {"sum": 262}
+        "expected_result": {"sum": 131}
       },
       {
         "query": ["SELECT COUNT(DB) AS cnt FROM {TABLE_NAME}"],
-        "expected_result": {"cnt": 4}
+        "expected_result": {"cnt": 2}
       }
     ]
   }


### PR DESCRIPTION
The test file combine_input includes both vcf file and gz file, which is unlikely to happen in real use case. Modified the combine_input to cover only the VCF files. Or an error arises for #484, which requires
the input to have the same format.

Tested: manually ran test case combine_from_multiple_inputs.