### PR TITLE
Fix deletion failure in integration tests

### DIFF
--- a/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
@@ -207,15 +207,7 @@ class TestContextManager(object):
       client = bigquery.Client(project=self.project)
       dataset_ref = client.dataset(self.dataset_id)
       dataset = bigquery.Dataset(dataset_ref)
-      tables = client.list_tables(dataset)
-      # Delete tables, otherwise dataset deletion will fail because it is still
-      # "in use".
-      for table in tables:
-        # The returned tables are of type TableListItem, but delete_table
-        # needs Table or TableReference.
-        client.delete_table(
-            bigquery.TableReference(dataset_ref, table.table_id))
-      client.delete_dataset(dataset)
+      client.delete_dataset(dataset, delete_contents=True)
 
 
 def _get_args():


### PR DESCRIPTION
The deletion fails when there are more than 50 tables. The iterator can only list 50 tables. It fails to get the next page of tables since the first page of tables are deleted. Fixed it by forcing the delete_contents
to True. It can delete the whole dataset directly.