### PR TITLE
Introduce PySam as an alternative parsing library.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,18 @@ ADD / /opt/gcp_variant_transforms/src/
 # Needed for installing mmh3 (one of the required packages in setup.py).
 RUN apt install -y g++
 
+# Install Pysam dependencies.
+RUN apt-get update && apt-get install -y autoconf \
+    automake \
+    make \
+    gcc \
+    perl \
+    zlib1g-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libcurl4-openssl-dev \
+    libssl-dev
+
 # Install dependencies.
 RUN python -m pip install --upgrade pip && \
     python -m pip install --upgrade virtualenv && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,17 +32,19 @@ ADD / /opt/gcp_variant_transforms/src/
 # Needed for installing mmh3 (one of the required packages in setup.py).
 RUN apt install -y g++
 
-# Install Pysam dependencies.
-RUN apt-get update && apt-get install -y autoconf \
+# Install Pysam dependencies. These dependencies are only required becuase we
+# have a monolithic binary - they primarily have to be installed on the workers.
+RUN apt-get update && apt-get install -y \
+    autoconf \
     automake \
-    make \
     gcc \
-    perl \
-    zlib1g-dev \
     libbz2-dev \
-    liblzma-dev \
     libcurl4-openssl-dev \
-    libssl-dev
+    liblzma-dev \
+    libssl-dev \
+    make \
+    perl \
+    zlib1g-dev
 
 # Install dependencies.
 RUN python -m pip install --upgrade pip && \

--- a/gcp_variant_transforms/beam_io/vcf_header_io.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io.py
@@ -16,10 +16,12 @@
 
 from __future__ import absolute_import
 
-from collections import OrderedDict
+import collections
 from functools import partial
 from typing import Dict, Iterable, List  # pylint: disable=unused-import
+from pysam import libcbcf
 import vcf
+
 
 import apache_beam as beam
 from apache_beam.io import filebasedsource
@@ -31,6 +33,8 @@ from apache_beam.transforms import PTransform
 
 from gcp_variant_transforms.beam_io import bgzf
 from gcp_variant_transforms.beam_io import vcfio
+
+LAST_HEADER_LINE_PREFIX = '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO'
 
 
 class VcfHeaderFieldTypeConstants(object):
@@ -52,18 +56,34 @@ class VcfParserHeaderKeyConstants(object):
   VERSION = 'version'
   LENGTH = 'length'
 
+VcfHeaderInfoField = collections.namedtuple(
+    'Info', ['id', 'num', 'type', 'desc', 'source', 'version'])
+
+VcfHeaderFormatField = collections.namedtuple(
+    'Format', ['id', 'num', 'type', 'desc'])
+
+VCF_HEADER_INFO_NUM_FIELD_CONVERSION = {
+    None: '.',
+    -1: 'A', # PyVCF value when number of alternate alleles dictates the count
+    -2: 'G', # PyVCF value when number of genotypes dictates the count
+    -3: 'R', # PyVCF value when number of alleles and ref dictates the count
+    'A': 'A', # PySam value when number of alternate alleles dictates the count
+    'G': 'G', # PySam value when number of genotypes dictates the count
+    'R': 'R', # PySam value when number of alleles and ref dictates the count
+}
 
 class VcfHeader(object):
   """Container for header data."""
 
   def __init__(self,
-               infos=None,  # type: OrderedDict[str, vcf.parser._Info]
-               filters=None,  # type: OrderedDict[str, vcf.parser._Filter]
-               alts=None,  # type: OrderedDict[str, vcf.parser._Alt]
-               formats=None,  # type: OrderedDict[str, vcf.parser._Format]
-               contigs=None,  # type: OrderedDict[str, vcf.parser._Contig]
-               samples=None,  # type: List[str]
-               file_path=None  # type: str
+               infos=None,  # type: Any
+               filters=None,  # type: Any
+               alts=None,  # type: Any
+               formats=None,  # type: Any
+               contigs=None,  # type: Any
+               samples=None,  # type: Any
+               file_path=None,  # type: str
+               vcf_parser=vcfio.VcfParserType.PYVCF  # type: vcfio.VcfParserType
               ):
     # type: (...) -> None
     """Initializes a VcfHeader object.
@@ -81,13 +101,21 @@ class VcfHeader(object):
       samples: A list of sample names.
       file_path: The full file path of the vcf file.
     """
-    # type: OrderedDict[str, OrderedDict]
-    self.infos = self._values_asdict(infos or {})
-    self.filters = self._values_asdict(filters or {})
-    self.alts = self._values_asdict(alts or {})
-    self.formats = self._values_asdict(formats or {})
-    self.contigs = self._values_asdict(contigs or {})
-    self.samples = samples
+    # type: collections.OrderedDict[str, collections.OrderedDict]
+    if vcf_parser == vcfio.VcfParserType.PYSAM:
+      self.infos = self._get_infos_pysam(infos)
+      self.filters = self._get_filters_pysam(filters)
+      self.alts = self._get_alts_pysam(alts)
+      self.formats = self._get_formats_pysam(formats)
+      self.contigs = self._get_contigs_pysam(contigs)
+      self.samples = self._get_samples_pysam(samples)
+    else:
+      self.infos = self._values_asdict(infos or {})
+      self.filters = self._values_asdict(filters or {})
+      self.alts = self._values_asdict(alts or {})
+      self.formats = self._values_asdict(formats or {})
+      self.contigs = self._values_asdict(contigs or {})
+      self.samples = samples
     self.file_path = file_path
 
   def __eq__(self, other):
@@ -106,13 +134,74 @@ class VcfHeader(object):
 
   def _values_asdict(self, header):
     """Converts PyVCF header values to ordered dictionaries."""
-    ordered_dict = OrderedDict()
+    ordered_dict = collections.OrderedDict()
     for key in header:
       # These methods were not designed to be protected. They start with an
       # underscore to avoid conflicts with field names. For more info, see
       # https://docs.python.org/2/library/collections.html#collections.namedtuple
       ordered_dict[key] = header[key]._asdict()  # pylint: disable=W0212
     return ordered_dict
+
+  def _get_infos_pysam(self, infos):
+    results = collections.OrderedDict()
+    for item in infos.items():
+      result = collections.OrderedDict()
+      result['id'] = item[0]
+      result['num'] = item[1].number if item[1].number != '.' else None
+      result['type'] = item[1].type
+      result['desc'] = item[1].description
+      # Pysam doesn't return these fields in info
+      result['source'] = None
+      result['version'] = None
+      results[item[0]] = result
+    return dict(results.items())
+
+  def _get_filters_pysam(self, filters):
+    results = collections.OrderedDict()
+    for item in filters.items():
+      result = collections.OrderedDict()
+      result['id'] = item[0]
+      result['desc'] = item[1].description
+      results[item[0]] = result
+    # PySAM adds default PASS value to its filters
+    del results['PASS']
+    return dict(results.items())
+
+  def _get_alts_pysam(self, alts):
+    results = collections.OrderedDict()
+    for item in alts.items():
+      result = collections.OrderedDict()
+      result['id'] = item[0]
+      result['desc'] = item[1]['Description'].strip("\"")
+      results[item[0]] = result
+    return dict(results.items())
+
+  def _get_formats_pysam(self, formats):
+    results = collections.OrderedDict()
+    for item in formats.items():
+      result = collections.OrderedDict()
+      result['id'] = item[0]
+      result['num'] = item[1].number if item[1].number != '.' else None
+      result['type'] = item[1].type
+      result['desc'] = item[1].description
+      results[item[0]] = result
+    return dict(results.items())
+
+  def _get_contigs_pysam(self, contigs):
+    results = collections.OrderedDict()
+    for item in contigs.items():
+      result = collections.OrderedDict()
+      result['id'] = item[0]
+      result['length'] = item[1].length
+      results[item[0]] = result
+    return dict(results.items())
+
+  def _get_samples_pysam(self, sample_line):
+    sample_tags = sample_line.split('\t')
+    if len(sample_tags) > 9:
+      return sample_tags[9:]
+    else:
+      return []
 
 
 class VcfHeaderSource(filebasedsource.FileBasedSource):
@@ -124,15 +213,28 @@ class VcfHeaderSource(filebasedsource.FileBasedSource):
   def __init__(self,
                file_pattern,
                compression_type=CompressionTypes.AUTO,
-               validate=True):
-    # type: (str, str, bool) -> None
+               validate=True,
+               vcf_parser=vcfio.VcfParserType.PYVCF):
+    # type: (str, str, bool, vcfio.VcfParserType) -> None
     super(VcfHeaderSource, self).__init__(file_pattern,
                                           compression_type=compression_type,
                                           validate=validate,
                                           splittable=False)
     self._compression_type = compression_type
+    self._vcf_parser = vcf_parser
 
   def read_records(
+      self,
+      file_path,  # type: str
+      unused_range_tracker,  # type: range_trackers.UnsplittableRangeTracker
+      ):
+    # type: (...) -> Iterable[VcfHeader]
+    if self._vcf_parser == vcfio.VcfParserType.PYSAM:
+      return self._read_records_pysam(file_path, unused_range_tracker)
+    else:
+      return self._read_records_pyvcf(file_path, unused_range_tracker)
+
+  def _read_records_pyvcf(
       self,
       file_path,  # type: str
       unused_range_tracker  # type: range_trackers.UnsplittableRangeTracker
@@ -142,25 +244,53 @@ class VcfHeaderSource(filebasedsource.FileBasedSource):
       vcf_reader = vcf.Reader(fsock=self._read_headers(file_path))
     except StopIteration:
       raise ValueError('{} has no header.'.format(file_path))
-
     yield VcfHeader(infos=vcf_reader.infos,
                     filters=vcf_reader.filters,
                     alts=vcf_reader.alts,
                     formats=vcf_reader.formats,
                     contigs=vcf_reader.contigs,
                     samples=vcf_reader.samples,
-                    file_path=file_path)
+                    file_path=file_path,
+                    vcf_parser=vcfio.VcfParserType.PYVCF)
 
   def _read_headers(self, file_path):
     with self.open_file(file_path) as file_to_read:
       while True:
         record = file_to_read.readline()
-        while not record or not record.strip():  # Skip empty lines.
+        while record and not record.strip():  # Skip empty lines.
           record = file_to_read.readline()
         if record and record.startswith('#'):
-          yield record
+          yield record.strip()
         else:
           break
+
+  def _read_records_pysam(
+      self,
+      file_path,  # type: str
+      unused_range_tracker  # type: range_trackers.UnsplittableRangeTracker
+      ):
+    # type: (...) -> Iterable[VcfHeader]
+    header = libcbcf.VariantHeader()
+    lines = self._read_headers(file_path)
+    sample_line = LAST_HEADER_LINE_PREFIX
+    header.add_line('##fileformat=VCFv4.0')
+    for line in lines:
+      if line.startswith('#'):
+        if line.startswith(LAST_HEADER_LINE_PREFIX):
+          sample_line = line.strip()
+          break
+        else:
+          header.add_line(line.strip())
+      else:
+        break
+    yield VcfHeader(infos=header.info,
+                    filters=header.filters,
+                    alts=header.alts,
+                    formats=header.formats,
+                    contigs=header.contigs,
+                    samples=sample_line,
+                    file_path=file_path,
+                    vcf_parser=vcfio.VcfParserType.PYSAM)
 
   def open_file(self, file_path):
     if self._compression_type == CompressionTypes.GZIP:
@@ -181,6 +311,7 @@ class ReadVcfHeaders(PTransform):
       file_pattern,  # type: str
       compression_type=CompressionTypes.AUTO,  # type: str
       validate=True,  # type: bool
+      vcf_parser=vcfio.VcfParserType.PYVCF,  # type: vcfio.VcfParserType
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -198,15 +329,22 @@ class ReadVcfHeaders(PTransform):
     """
     super(ReadVcfHeaders, self).__init__(**kwargs)
     self._source = VcfHeaderSource(
-        file_pattern, compression_type, validate=validate)
+        file_pattern,
+        compression_type,
+        validate=validate,
+        vcf_parser=vcf_parser)
 
   def expand(self, pvalue):
     return pvalue.pipeline | Read(self._source)
 
 
-def _create_vcf_header_source(file_pattern=None, compression_type=None):
+def _create_vcf_header_source(
+    file_pattern=None,
+    compression_type=None,
+    vcf_parser=vcfio.VcfParserType.PYVCF):
   return VcfHeaderSource(file_pattern=file_pattern,
-                         compression_type=compression_type)
+                         compression_type=compression_type,
+                         vcf_parser=vcf_parser)
 
 
 class ReadAllVcfHeaders(PTransform):
@@ -226,8 +364,9 @@ class ReadAllVcfHeaders(PTransform):
       self,
       desired_bundle_size=DEFAULT_DESIRED_BUNDLE_SIZE,
       compression_type=CompressionTypes.AUTO,
+      vcf_parser=vcfio.VcfParserType.PYVCF,
       **kwargs):
-    # type: (int, str, **str) -> None
+    # type: (int, str, **str, vcfio.VcfParserType) -> None
     """Initialize the :class:`ReadAllVcfHeaders` transform.
 
     Args:
@@ -242,7 +381,9 @@ class ReadAllVcfHeaders(PTransform):
     """
     super(ReadAllVcfHeaders, self).__init__(**kwargs)
     source_from_file = partial(
-        _create_vcf_header_source, compression_type=compression_type)
+        _create_vcf_header_source,
+        compression_type=compression_type,
+        vcf_parser=vcf_parser)
     self._read_all_files = filebasedsource.ReadAllFiles(
         False,  # splittable (we are just reading the headers)
         CompressionTypes.AUTO, desired_bundle_size,
@@ -406,9 +547,8 @@ class WriteVcfHeaderFn(beam.DoFn):
       return None
     elif number >= 0:
       return str(number)
-    number_to_string = {v: k for k, v in vcf.parser.field_counts.items()}
-    if number in number_to_string:
-      return number_to_string[number]
+    if number in VCF_HEADER_INFO_NUM_FIELD_CONVERSION:
+      return VCF_HEADER_INFO_NUM_FIELD_CONVERSION[number]
     else:
       raise ValueError('Invalid value for number: {}'.format(number))
 

--- a/gcp_variant_transforms/beam_io/vcf_header_io_test.py
+++ b/gcp_variant_transforms/beam_io/vcf_header_io_test.py
@@ -31,6 +31,7 @@ from gcp_variant_transforms.beam_io.vcf_header_io import ReadVcfHeaders
 from gcp_variant_transforms.beam_io.vcf_header_io import VcfHeader
 from gcp_variant_transforms.beam_io.vcf_header_io import WriteVcfHeaderFn
 from gcp_variant_transforms.beam_io.vcf_header_io import WriteVcfHeaders
+from gcp_variant_transforms.beam_io.vcfio import VcfParserType
 from gcp_variant_transforms.testing import asserts
 from gcp_variant_transforms.testing import temp_dir
 from gcp_variant_transforms.testing import testdata_util
@@ -59,10 +60,11 @@ class VcfHeaderSourceTest(unittest.TestCase):
   def setUp(self):
     self.lines = testdata_util.get_sample_vcf_header_lines()
 
-  def _create_file_and_read_headers(self):
+  def _create_file_and_read_headers(self, vcf_parser=VcfParserType.PYVCF):
     with temp_dir.TempDir() as tempdir:
       filename = tempdir.create_temp_file(suffix='.vcf', lines=self.lines)
-      headers = source_test_utils.read_from_source(VcfHeaderSource(filename))
+      headers = source_test_utils.read_from_source(
+          VcfHeaderSource(filename, vcf_parser=vcf_parser))
       return headers[0]
 
   def test_vcf_header_eq(self):
@@ -80,6 +82,7 @@ class VcfHeaderSourceTest(unittest.TestCase):
     self.lines = [
         '##contig=<ID=M,length=16,assembly=B37,md5=c6,species="Homosapiens">\n',
         '##contig=<ID=P,length=16,assembly=B37,md5=c6,species="Homosapiens">\n',
+        '\n',
         '##ALT=<ID=CGA_CNVWIN,Description="Copy number analysis window">\n',
         '##ALT=<ID=INS:ME:MER,Description="Insertion of MER element">\n',
         '##FILTER=<ID=MPCBT,Description="Mate pair count below 10">\n',
@@ -88,6 +91,25 @@ class VcfHeaderSourceTest(unittest.TestCase):
         '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	GS000016676-ASM\n',
     ]
     header = self._create_file_and_read_headers()
+    self.assertItemsEqual(header.contigs.keys(), ['M', 'P'])
+    self.assertItemsEqual(header.alts.keys(), ['CGA_CNVWIN', 'INS:ME:MER'])
+    self.assertItemsEqual(header.filters.keys(), ['MPCBT'])
+    self.assertItemsEqual(header.infos.keys(), ['CGA_MIRB'])
+    self.assertItemsEqual(header.formats.keys(), ['FT'])
+
+  def test_all_fields_pysam(self):
+    self.lines = [
+        '##contig=<ID=M,length=16,assembly=B37,md5=c6,species="Homosapiens">\n',
+        '##contig=<ID=P,length=16,assembly=B37,md5=c6,species="Homosapiens">\n',
+        '\n',
+        '##ALT=<ID=CGA_CNVWIN,Description="Copy number analysis window">\n',
+        '##ALT=<ID=INS:ME:MER,Description="Insertion of MER element">\n',
+        '##FILTER=<ID=MPCBT,Description="Mate pair count below 10">\n',
+        '##INFO=<ID=CGA_MIRB,Number=.,Type=String,Description="miRBaseId">\n',
+        '##FORMAT=<ID=FT,Number=1,Type=String,Description="Genotype filter">\n',
+        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	GS000016676-ASM\n',
+    ]
+    header = self._create_file_and_read_headers(vcf_parser=VcfParserType.PYSAM)
     self.assertItemsEqual(header.contigs.keys(), ['M', 'P'])
     self.assertItemsEqual(header.alts.keys(), ['CGA_CNVWIN', 'INS:ME:MER'])
     self.assertItemsEqual(header.filters.keys(), ['MPCBT'])
@@ -295,6 +317,46 @@ class WriteVcfHeadersTest(unittest.TestCase):
         '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
         '##INFO=<ID=HG,Number=G,Type=Integer,Description="IntInfo_G">\n',
         '##INFO=<ID=HR,Number=R,Type=Character,Description="ChrInfo_R">\n',
+        '##FILTER=<ID=MPCBT,Description="Mate pair count below 10">\n',
+        '##ALT=<ID=INS:ME:MER,Description="Insertion of MER element">\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
+        '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="GQ">\n',
+        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT\n'
+    ]
+    with temp_dir.TempDir() as tempdir:
+      tempfile = tempdir.create_temp_file(suffix='.vcf')
+      header_fn = WriteVcfHeaderFn(tempfile)
+      header_fn.process(header, vcf_version_line)
+      with open(tempfile, 'rb') as f:
+        actual = f.readlines()
+        self.assertItemsEqual(actual, expected_results)
+
+  def test_write_headers_with_vcf_version_line_pysam(self):
+    lines = [
+        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+        '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
+        '##INFO=<ID=HG,Number=G,Type=Integer,Description="IntInfo_G">\n',
+        '##INFO=<ID=HR,Number=R,Type=Character,Description="ChrInfo_R">\n',
+        '##FILTER=<ID=MPCBT,Description="Mate pair count below 10">\n',
+        '##ALT=<ID=INS:ME:MER,Description="Insertion of MER element">\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',
+        '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="GQ">\n',
+        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT\n',
+    ]
+    header = None
+    with temp_dir.TempDir() as tempdir:
+      filename = tempdir.create_temp_file(suffix='.vcf', lines=lines)
+      headers = source_test_utils.read_from_source(
+          VcfHeaderSource(filename, vcf_parser=VcfParserType.PYSAM))
+      header = headers[0]
+    vcf_version_line = '##fileformat=VCFv4.3\n'
+    expected_results = [
+        vcf_version_line,
+        '##INFO=<ID=NS,Number=1,Type=Integer,Description="Number samples">\n',
+        '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
+        '##INFO=<ID=HG,Number=G,Type=Integer,Description="IntInfo_G">\n',
+        # Pysam does not recognize Character type, and converts to String.
+        '##INFO=<ID=HR,Number=R,Type=String,Description="ChrInfo_R">\n',
         '##FILTER=<ID=MPCBT,Description="Mate pair count below 10">\n',
         '##ALT=<ID=INS:ME:MER,Description="Insertion of MER element">\n',
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\n',

--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -21,10 +21,10 @@ from __future__ import absolute_import
 
 from collections import namedtuple
 from copy import copy
+from typing import Iterable # pylint: disable=unused-import
 import logging
 import os
 import tempfile
-import typing  # pylint: disable=unused-import
 
 from apache_beam.coders import coders
 from apache_beam.io import filesystems
@@ -234,6 +234,7 @@ class VariantCall(object):
     return ', '.join(
         [str(s) for s in [self.name, self.genotype, self.phaseset, self.info]])
 
+
 class VcfParser(object):
   """Base abstract class for defining a VCF file parser.
 
@@ -320,8 +321,8 @@ class VcfParser(object):
     return
 
   def _next_non_empty_line(self, iterator):
+    # type: (Iterable[str]) -> str
     # Get next non-empty stripped record from iterator.
-    # type: (typing.Iterable[str]) -> str
     text_line = next(iterator).strip()
     while not text_line:  # skip empty lines.
       text_line = next(iterator).strip()
@@ -742,8 +743,8 @@ class PySamParser(VcfParser):
     return info
 
   def _parse_to_numeric(self, value):
-    # Attempt to parse a value to int, then float or return as string.
     # type: (Any) -> Any
+    # Attempt to parse a value to int, then float or return as string.
     if isinstance(value, str) and value.isdigit():
       return int(value)
     else:

--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -652,7 +652,13 @@ class PySamParser(VcfParser):
       info = {}
       for (key, value) in sample.iteritems():
         if key == GENOTYPE_FORMAT_KEY:
-          genotype = list(value) if isinstance(value, tuple) else value
+          if isinstance(value, tuple):
+            genotype = []
+            for elem in value:
+              genotype.append(elem if elem else MISSING_GENOTYPE_VALUE)
+          else:
+            genotype = value if value else MISSING_GENOTYPE_VALUE
+
         elif key == PHASESET_FORMAT_KEY:
           phaseset = list(value) if isinstance(value, tuple) else value
         else:

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -246,7 +246,8 @@ class ReadFromBGZF(beam.PTransform):
   def __init__(self,
                input_files,
                representative_header_lines,
-               allow_malformed_records):
+               allow_malformed_records,
+               vcf_parser_type=VcfParserType.PYVCF):
     # type: (List[str], List[str], bool) -> None
     """Initializes the transform.
 
@@ -260,11 +261,22 @@ class ReadFromBGZF(beam.PTransform):
     self._input_files = input_files
     self._representative_header_lines = representative_header_lines
     self._allow_malformed_records = allow_malformed_records
+    self._vcf_parser_type = vcf_parser_type
 
   def _read_records(self, (file_path, block)):
     # type: (Tuple[str, Block]) -> Iterable(Variant)
     """Reads records from `file_path` in `block`."""
-    record_iterator = vcf_parser.PyVcfParser(
+
+    vcf_parser_class = None
+    if self._vcf_parser_type == VcfParserType.PYVCF:
+      vcf_parser_class = vcf_parser.PyVcfParser
+    elif self._vcf_parser_type == VcfParserType.PYSAM:
+      vcf_parser_class = vcf_parser.PySamParser
+    else:
+      raise ValueError(
+          'Unrecognized _vcf_parser_type: %s.' % str(self._vcf_parser_type))
+
+    record_iterator = vcf_parser_class(
         file_path,
         block,
         filesystems.CompressionTypes.GZIP,
@@ -333,11 +345,12 @@ class ReadFromVcf(PTransform):
 
 def _create_vcf_source(
     file_pattern=None, representative_header_lines=None, compression_type=None,
-    allow_malformed_records=None):
+    allow_malformed_records=None, vcf_parser_type=VcfParserType.PYVCF):
   return _VcfSource(file_pattern=file_pattern,
                     representative_header_lines=representative_header_lines,
                     compression_type=compression_type,
-                    allow_malformed_records=allow_malformed_records)
+                    allow_malformed_records=allow_malformed_records,
+                    vcf_parser_type=vcf_parser_type)
 
 
 class ReadAllFromVcf(PTransform):
@@ -360,6 +373,7 @@ class ReadAllFromVcf(PTransform):
       desired_bundle_size=DEFAULT_DESIRED_BUNDLE_SIZE,  # type: int
       compression_type=CompressionTypes.AUTO,  # type: str
       allow_malformed_records=False,  # type: bool
+      vcf_parser_type=VcfParserType.PYVCF,
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -384,7 +398,8 @@ class ReadAllFromVcf(PTransform):
         _create_vcf_source,
         representative_header_lines=representative_header_lines,
         compression_type=compression_type,
-        allow_malformed_records=allow_malformed_records)
+        allow_malformed_records=allow_malformed_records,
+        vcf_parser_type=vcf_parser_type)
     self._read_all_files = filebasedsource.ReadAllFiles(
         True,  # splittable
         CompressionTypes.AUTO, desired_bundle_size,

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -55,6 +55,7 @@ class VcfParserType(enum.Enum):
   """An Enum specifying the parser used for reading VCF files."""
   PYVCF = 0
   NUCLEUS = 1
+  PYSAM = 2
 
 
 class _ToVcfRecordCoder(coders.Coder):
@@ -219,6 +220,8 @@ class _VcfSource(filebasedsource.FileBasedSource):
       vcf_parser_class = vcf_parser.PyVcfParser
     elif self._vcf_parser_type == VcfParserType.NUCLEUS:
       vcf_parser_class = vcf_parser.NucleusParser
+    elif self._vcf_parser_type == VcfParserType.PYSAM:
+      vcf_parser_class = vcf_parser.PySamParser
     else:
       raise ValueError(
           'Unrecognized _vcf_parser_type: %s.' % str(self._vcf_parser_type))

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -273,7 +273,6 @@ class ReadFromBGZF(beam.PTransform):
   def _read_records(self, (file_path, block)):
     # type: (Tuple[str, Block]) -> Iterable(Variant)
     """Reads records from `file_path` in `block`."""
-
     record_iterator = self._vcf_parser_class(
         file_path,
         block,
@@ -371,7 +370,7 @@ class ReadAllFromVcf(PTransform):
       desired_bundle_size=DEFAULT_DESIRED_BUNDLE_SIZE,  # type: int
       compression_type=CompressionTypes.AUTO,  # type: str
       allow_malformed_records=False,  # type: bool
-      vcf_parser_type=VcfParserType.PYVCF, # int
+      vcf_parser_type=VcfParserType.PYVCF,  # type: int
       **kwargs  # type: **str
       ):
     # type: (...) -> None

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -49,7 +49,8 @@ _SAMPLE_HEADER_LINES = [
     '##INFO=<ID=AF,Number=A,Type=Float,Description="Allele Frequency">\n',
     '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\r\n',
     '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">\n',
-    '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample1	Sample2\r\n',
+    '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSample1\tSample2\r'
+    '\n',
 ]
 
 # Note: Nucleus cannot tolarate missing fields in the header and needs contig.
@@ -66,14 +67,14 @@ _NUCLEUS_HEADER_LINES = [
 ]
 
 _SAMPLE_TEXT_LINES = [
-    '20	14370	.	G	A	29	PASS	AF=0.5	GT:GQ	0|0:48 1|0:48\n',
-    '20	17330	.	T	A	3	q10	AF=0.017	GT:GQ	0|0:49	0|1:3\n',
-    '20	1110696	.	A	G,T	67	PASS	AF=0.3,0.7	GT:GQ	1|2:21	2|1:2\n',
-    '20	1230237	.	T	.	47	PASS	.	GT:GQ	0|0:54	0|0:48\n',
-    '19	1234567	.	GTCT	G,GTACT	50	PASS	.	GT:GQ	0/1:35	0/2:17\n',
-    '20	1234	rs123	C	A,T	50	PASS	AF=0.5	GT:GQ	0/0:48	1/0:20\n',
-    '19	123	rs1234	GTC	.	40	q10;s50	NS=2	GT:GQ	1|0:48	0/1:.\n',
-    '19	12	.	C	<SYMBOLIC>	49	q10	AF=0.5	GT:GQ	0|1:45 .:.\n'
+    '20\t14370\t.\tG\tA\t29\tPASS\tAF=0.5\tGT:GQ\t0|0:48\t1|0:48\n',
+    '20\t17330\t.\tT\tA\t3\tq10\tAF=0.017\tGT:GQ\t0|0:49\t0|1:3\n',
+    '20\t1110696\t.\tA\tG,T\t67\tPASS\tAF=0.3,0.7\tGT:GQ\t1|2:21\t2|1:2\n',
+    '20\t1230237\t.\tT\t.\t47\tPASS\t.\tGT:GQ\t0|0:54\t0|0:48\n',
+    '19\t1234567\t.\tGTCT\tG,GTACT\t50\tPASS\t.\tGT:GQ\t0/1:35\t0/2:17\n',
+    '20\t1234\trs123\tC\tA,T\t50\tPASS\tAF=0.5\tGT:GQ\t0/0:48\t1/0:20\n',
+    '19\t123\trs1234\tGTC\t.\t40\tq10;s50\tNS=2\tGT:GQ\t1|0:48\t0/1:.\n',
+    '19\t12\t.\tC\t<SYMBOLIC>\t49\tq10\tAF=0.5\tGT:GQ\t0|1:45\t.:.\n'
 ]
 
 
@@ -118,7 +119,7 @@ def _get_sample_variant_1(is_for_nucleus=False):
   return variant, vcf_line
 
 
-def _get_sample_variant_2(is_for_nucleus=False):
+def _get_sample_variant_2(vcf_parser_type=VcfParserType.PYVCF):
   """Get second sample variant.
 
   Features:
@@ -128,7 +129,7 @@ def _get_sample_variant_2(is_for_nucleus=False):
     multiple filters
     missing format field
   """
-  if not is_for_nucleus:
+  if vcf_parser_type == VcfParserType.PYSAM:
     vcf_line = (
         '19	123	rs1234	GTC	.	40	q10;s50	NS=2	'
         'GT:GQ	1|0:48	0/1:.\n')
@@ -137,12 +138,12 @@ def _get_sample_variant_2(is_for_nucleus=False):
         alternate_bases=[], names=['rs1234'], quality=40,
         filters=['q10', 's50'], info={'NS': 2})
     variant.calls.append(
-        vcfio.VariantCall(name='Sample1', genotype=[1, 0],
+        vcfio.VariantCall(name='Sample1', genotype=[-1, 0],
                           phaseset=vcfio.DEFAULT_PHASESET_VALUE,
                           info={'GQ': 48}))
     variant.calls.append(
-        vcfio.VariantCall(name='Sample2', genotype=[0, 1], info={'GQ': None}))
-  else:
+        vcfio.VariantCall(name='Sample2', genotype=[0, -1], info={'GQ': None}))
+  elif vcf_parser_type == VcfParserType.NUCLEUS:
     # 'q10;s50' -> 'PASS' due to missing header fields.
     vcf_line = (
         '19	123	rs1234	GTC	.	40	PASS	NS=2	'
@@ -157,6 +158,20 @@ def _get_sample_variant_2(is_for_nucleus=False):
                           info={'GQ': 48}))
     variant.calls.append(
         vcfio.VariantCall(name='Sample2', genotype=[0, 1], info={}))
+  else:
+    vcf_line = (
+        '19	123	rs1234	GTC	.	40	q10;s50	NS=2	'
+        'GT:GQ	1|0:48	0/1:.\n')
+    variant = vcfio.Variant(
+        reference_name='19', start=122, end=125, reference_bases='GTC',
+        alternate_bases=[], names=['rs1234'], quality=40,
+        filters=['q10', 's50'], info={'NS': 2})
+    variant.calls.append(
+        vcfio.VariantCall(name='Sample1', genotype=[1, 0],
+                          phaseset=vcfio.DEFAULT_PHASESET_VALUE,
+                          info={'GQ': 48}))
+    variant.calls.append(
+        vcfio.VariantCall(name='Sample2', genotype=[0, 1], info={'GQ': None}))
   return variant, vcf_line
 
 
@@ -262,7 +277,7 @@ class VcfSourceTest(unittest.TestCase):
         sorted(expected),
         sorted(actual))
 
-  def _get_invalid_file_contents(self):
+  def _get_invalid_file_contents(self, is_pysam=False):
     """Gets sample invalid files contents.
 
     Returns:
@@ -271,18 +286,6 @@ class VcfSourceTest(unittest.TestCase):
        because of header errors.
     """
     malformed_vcf_records = [
-        # Malfromed record.
-        [
-            '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample\n',
-            '1    1  '
-        ],
-        # Depending on whether pyvcf uses cython this case fails, this is a
-        # known problem: https://github.com/apache/beam/pull/4221
-        # Missing "GT:GQ" format, but GQ is provided.
-        #[
-        #    '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSample\n',
-        #    '19\t123\trs12345\tT\tC\t50\tq10\tAF=0.2;NS=2\tGT\t1|0:48'
-        #],
         # GT is not an integer.
         [
             '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample\n',
@@ -296,6 +299,26 @@ class VcfSourceTest(unittest.TestCase):
             '19	abc	rs12345	T	C	9	q10	AF=0.2;NS=2	GT:GQ	1|0:48\n',
         ]
     ]
+    if not is_pysam:
+      malformed_vcf_records.extend(
+          [
+              # Malfromed record.
+              # Causes segmentation fault with PYSAM due to memory allocation
+              # issue with the id field.
+              [
+                  '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample\n',
+                  '1    1  '
+              ],
+              # Depending on whether pyvcf uses cython this case fails, this is
+              # a known problem: https://github.com/apache/beam/pull/4221
+              # Missing "GT:GQ" format, but GQ is provided.
+              # HTSLib throws "exit(1)" when encountering this error.
+              [
+                  '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t'
+                  'Sample\n',
+                  '19\t123\trs12345\tT\tC\t50\tq10\tAF=0.2;NS=2\tGT\t1|0:48'
+              ],
+          ])
     malformed_header_lines = [
         # Malformed FILTER.
         [
@@ -366,7 +389,8 @@ class VcfSourceTest(unittest.TestCase):
     self.assertEqual(1, len(read_data))
     self.assertEqual(variant_1, read_data[0])
 
-    variant_2, vcf_line_2 = _get_sample_variant_2(is_for_nucleus=True)
+    variant_2, vcf_line_2 = _get_sample_variant_2(
+        vcf_parser_type=VcfParserType.NUCLEUS)
     variant_3, vcf_line_3 = _get_sample_variant_3(is_for_nucleus=True)
     read_data = self._create_temp_file_and_read_records(
         _NUCLEUS_HEADER_LINES + [vcf_line_1, vcf_line_2, vcf_line_3],
@@ -390,7 +414,8 @@ class VcfSourceTest(unittest.TestCase):
   @unittest.skipIf(NUCLEUS_IMPORT_MISSING, 'Nucleus is not imported')
   def test_file_pattern_verify_details_nucleus(self):
     variant_1, vcf_line_1 = _get_sample_variant_1(is_for_nucleus=True)
-    variant_2, vcf_line_2 = _get_sample_variant_2(is_for_nucleus=True)
+    variant_2, vcf_line_2 = _get_sample_variant_2(
+        vcf_parser_type=VcfParserType.NUCLEUS)
     variant_3, vcf_line_3 = _get_sample_variant_3(is_for_nucleus=True)
     with TempDir() as tempdir:
       self._create_temp_vcf_file(_NUCLEUS_HEADER_LINES + [vcf_line_1], tempdir)
@@ -443,7 +468,6 @@ class VcfSourceTest(unittest.TestCase):
       with TempDir() as tempdir, self.assertRaises(ValueError):
         self._read_records(self._create_temp_vcf_file(content, tempdir),
                            allow_malformed_records=True)
-
 
   def test_no_samples(self):
     header_line = '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO\n'
@@ -663,7 +687,8 @@ class VcfSourceTest(unittest.TestCase):
     self.assertEqual(expected_variant, read_data[0])
 
   def _assert_pipeline_read_files_record_count_equal(
-      self, input_pattern, expected_count, use_read_all=False):
+      self, input_pattern, expected_count, use_read_all=False,
+      vcf_parser_type=VcfParserType.PYVCF):
     """Helper method for verifying total records read.
 
     Args:
@@ -676,9 +701,10 @@ class VcfSourceTest(unittest.TestCase):
     if use_read_all:
       pcoll = (pipeline
                | 'Create' >> beam.Create([input_pattern])
-               | 'Read' >> ReadAllFromVcf())
+               | 'Read' >> ReadAllFromVcf(vcf_parser_type=vcf_parser_type))
     else:
-      pcoll = pipeline | 'Read' >> ReadFromVcf(input_pattern)
+      pcoll = pipeline | 'Read' >> ReadFromVcf(input_pattern,
+                                               vcf_parser_type=vcf_parser_type)
     assert_that(pcoll, asserts.count_equals_to(expected_count))
     pipeline.run()
 
@@ -797,6 +823,496 @@ class VcfSourceTest(unittest.TestCase):
           (splits[0].source, splits[0].start_position, splits[0].stop_position))
 
   def test_dynamic_work_rebalancing(self):
+    with TempDir() as tempdir:
+      file_name = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir)
+      source = VcfSource(file_name)
+      splits = [split for split in source.split(desired_bundle_size=100000)]
+      assert len(splits) == 1
+      source_test_utils.assert_split_at_fraction_exhaustive(
+          splits[0].source, splits[0].start_position, splits[0].stop_position)
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_read_single_file_large_pysam(self):
+    test_data_conifgs = [
+        {'file': 'valid-4.0.vcf', 'num_records': 5},
+        {'file': 'valid-4.0.vcf.gz', 'num_records': 5},
+        {'file': 'valid-4.0.vcf.bz2', 'num_records': 5},
+        {'file': 'valid-4.1-large.vcf', 'num_records': 9882},
+        {'file': 'valid-4.2.vcf', 'num_records': 13},
+    ]
+    for config in test_data_conifgs:
+      read_data = self._read_records(
+          testdata_util.get_full_file_path(config['file']),
+          vcf_parser_type=VcfParserType.PYSAM)
+      self.assertEqual(config['num_records'], len(read_data))
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_read_file_pattern_large_pysam(self):
+    read_data = self._read_records(
+        os.path.join(testdata_util.get_full_dir(), 'valid-*.vcf'),
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(9900, len(read_data))
+    read_data_gz = self._read_records(
+        os.path.join(testdata_util.get_full_dir(), 'valid-*.vcf.gz'),
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(9900, len(read_data_gz))
+
+  def test_single_file_no_records_pysam(self):
+    for content in [[''], [' '], ['', ' ', '\n'], ['\n', '\r\n', '\n']]:
+      self.assertEqual([], self._create_temp_file_and_read_records(
+          content, vcf_parser_type=VcfParserType.PYSAM))
+      self.assertEqual([], self._create_temp_file_and_read_records(
+          content, _SAMPLE_HEADER_LINES, vcf_parser_type=VcfParserType.PYSAM))
+
+  def test_single_file_verify_details_pysam(self):
+    variant_1, vcf_line_1 = _get_sample_variant_1()
+    read_data = self._create_temp_file_and_read_records(
+        _SAMPLE_HEADER_LINES + [vcf_line_1],
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(1, len(read_data))
+    self.assertEqual(variant_1, read_data[0])
+
+    variant_2, vcf_line_2 = _get_sample_variant_2(
+        vcf_parser_type=VcfParserType.PYSAM)
+    variant_3, vcf_line_3 = _get_sample_variant_3()
+    read_data = self._create_temp_file_and_read_records(
+        _SAMPLE_HEADER_LINES + [vcf_line_1, vcf_line_2, vcf_line_3],
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(3, len(read_data))
+    self._assert_variants_equal([variant_1, variant_2, variant_3], read_data)
+
+  def test_file_pattern_verify_details_pysam(self):
+    variant_1, vcf_line_1 = _get_sample_variant_1()
+    variant_2, vcf_line_2 = _get_sample_variant_2(
+        vcf_parser_type=VcfParserType.PYSAM)
+    variant_3, vcf_line_3 = _get_sample_variant_3()
+    with TempDir() as tempdir:
+      self._create_temp_vcf_file(_SAMPLE_HEADER_LINES + [vcf_line_1], tempdir)
+      self._create_temp_vcf_file((_SAMPLE_HEADER_LINES +
+                                  [vcf_line_2, vcf_line_3]),
+                                 tempdir)
+      read_data = self._read_records(os.path.join(tempdir.get_path(), '*.vcf'),
+                                     vcf_parser_type=VcfParserType.PYSAM)
+      self.assertEqual(3, len(read_data))
+      self._assert_variants_equal([variant_1, variant_2, variant_3], read_data)
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_read_after_splitting_pysam(self):
+    file_name = testdata_util.get_full_file_path('valid-4.1-large.vcf')
+    source = VcfSource(file_name, vcf_parser_type=VcfParserType.PYSAM)
+    splits = [p for p in source.split(desired_bundle_size=500)]
+    self.assertGreater(len(splits), 1)
+    sources_info = ([
+        (split.source, split.start_position, split.stop_position) for
+        split in splits])
+    self.assertGreater(len(sources_info), 1)
+    split_records = []
+    for source_info in sources_info:
+      split_records.extend(source_test_utils.read_from_source(*source_info))
+    self.assertEqual(9882, len(split_records))
+
+  def test_invalid_file_pysam(self):
+    invalid_file_contents = self._get_invalid_file_contents(is_pysam=True)
+
+    for content in chain(*invalid_file_contents):
+      with TempDir() as tempdir, self.assertRaises(ValueError):
+        self._read_records(self._create_temp_vcf_file(content, tempdir))
+        self.fail('Invalid VCF file must throw an exception')
+    # Try with multiple files (any one of them will throw an exception).
+    with TempDir() as tempdir, self.assertRaises(ValueError):
+      for content in chain(*invalid_file_contents):
+        self._create_temp_vcf_file(content, tempdir)
+        self._read_records(os.path.join(tempdir.get_path(), '*.vcf'),
+                           vcf_parser_type=VcfParserType.PYSAM)
+
+  def test_allow_malformed_records_pysam(self):
+    invalid_records, invalid_headers = self._get_invalid_file_contents(
+        is_pysam=True)
+
+    # Invalid records should not raise errors
+    for content in invalid_records:
+      with TempDir() as tempdir:
+        self._read_records(self._create_temp_vcf_file(content, tempdir),
+                           allow_malformed_records=True,
+                           vcf_parser_type=VcfParserType.PYSAM)
+    # Invalid headers should still raise errors
+    for content in invalid_headers:
+      with TempDir() as tempdir, self.assertRaises(ValueError):
+        self._read_records(self._create_temp_vcf_file(content, tempdir),
+                           allow_malformed_records=True,
+                           vcf_parser_type=VcfParserType.PYSAM)
+
+  def test_no_samples_pysam(self):
+    header_line = '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO\n'
+    record_line = '19	123	.	G	A	.	PASS	AF=0.2'
+    expected_variant = Variant(
+        reference_name='19', start=122, end=123, reference_bases='G',
+        alternate_bases=['A'], filters=['PASS'], info={'AF': [0.2]})
+    read_data = self._create_temp_file_and_read_records(
+        _SAMPLE_HEADER_LINES[:-1] + [header_line, record_line],
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(1, len(read_data))
+    self.assertEqual(expected_variant, read_data[0])
+
+  def test_no_info_pysam(self):
+    record_line = 'chr19	123	.	.	.	.	.	.	GT	.	.'
+    expected_variant = Variant(reference_name='chr19', start=122, end=123)
+    expected_variant.calls.append(
+        VariantCall(name='Sample1', genotype=[vcfio.MISSING_GENOTYPE_VALUE]))
+    expected_variant.calls.append(
+        VariantCall(name='Sample2', genotype=[vcfio.MISSING_GENOTYPE_VALUE]))
+    read_data = self._create_temp_file_and_read_records(
+        _SAMPLE_HEADER_LINES + [record_line],
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(1, len(read_data))
+    self.assertEqual(expected_variant, read_data[0])
+
+  def test_info_numbers_and_types_pysam(self):
+    info_headers = [
+        '##INFO=<ID=HA,Number=A,Type=String,Description="StringInfo_A">\n',
+        '##INFO=<ID=HG,Number=G,Type=Integer,Description="IntInfo_G">\n',
+        '##INFO=<ID=HR,Number=R,Type=Character,Description="ChrInfo_R">\n',
+        '##INFO=<ID=HF,Number=0,Type=Flag,Description="FlagInfo">\n',
+        '##INFO=<ID=HU,Number=.,Type=Float,Description="FloatInfo_variable">\n']
+    record_lines = [
+        '19	2	.	A	T,C	.	.	HA=a1,a2;HG=1,2,3;HR=a,b,c;HF;HU=0.1	GT	1/0	0/1\n',
+        '19	124	.	A	T	.	.	HG=3,4,5;HR=d,e;HU=1.1,1.2	GT	0/0	0/1']
+    variant_1 = Variant(
+        reference_name='19', start=1, end=2, reference_bases='A',
+        alternate_bases=['T', 'C'],
+        info={'HA': ['a1', 'a2'], 'HG': [1, 2, 3], 'HR': ['a', 'b', 'c'],
+              'HF': True, 'HU': [0.1]})
+    variant_1.calls.append(VariantCall(name='Sample1', genotype=[1, 0]))
+    variant_1.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
+    variant_2 = Variant(
+        reference_name='19', start=123, end=124, reference_bases='A',
+        alternate_bases=['T'],
+        info={'HG': [3, 4, 5], 'HR': ['d', 'e'], 'HU': [1.1, 1.2]})
+    variant_2.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
+    variant_2.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
+    read_data = self._create_temp_file_and_read_records(
+        info_headers + _SAMPLE_HEADER_LINES[1:] + record_lines,
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(2, len(read_data))
+    self._assert_variants_equal([variant_1, variant_2], read_data)
+
+  def test_use_of_representative_header_pysam(self):
+    # Info field `HU` is defined as Float in file header while data is String.
+    # This results in parser failure. We test if parser completes successfully
+    # when a representative headers with String definition for field `HU` is
+    # given.
+    file_content = [
+        '##INFO=<ID=HU,Number=.,Type=String,Descr\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\r\n',
+        '#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	Sample1	Sample2\r\n',
+        '19	2	.	A	T	.	.	HU=a,b	GT	0/0	0/1\n',]
+    representative_header_lines = [
+        '##INFO=<ID=HU,Number=.,Type=String,Description="Info">\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\r\n',]
+    variant = Variant(
+        reference_name='19', start=1, end=2, reference_bases='A',
+        alternate_bases=['T'], info={'HU': ['a', 'b']})
+    variant.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
+    variant.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
+
+    # `file_headers` is used.
+    with self.assertRaises(ValueError):
+      read_data = self._create_temp_file_and_read_records(
+          file_content,
+          vcf_parser_type=VcfParserType.PYSAM)
+
+    # `representative_header` is used.
+    read_data = self._create_temp_file_and_read_records(
+        file_content, representative_header_lines,
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(1, len(read_data))
+    self._assert_variants_equal([variant], read_data)
+
+  def test_use_of_representative_header_two_files_pysam(self):
+    # Info field `HU` is defined as Float in file header while data is String.
+    # This results in parser failure. We test if parser completes successfully
+    # when a representative headers with String definition for field `HU` is
+    # given.
+    file_content_1 = [
+        '##INFO=<ID=HU,Number=.,Type=Float,Descri\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\r\n',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSample1\r\n',
+        '9\t2\t.\tA\tT\t.\t.\tHU=a,b\tGT\t0/0']
+    file_content_2 = [
+        '##INFO=<ID=HU,Number=.,Type=Float,Descri\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\r\n',
+        '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tSample2\r\n',
+        '19\t2\t.\tA\tT\t.\t.\tHU=a,b\tGT\t0/1\n',]
+    representative_header_lines = [
+        '##INFO=<ID=HU,Number=.,Type=String,Description="Info">\n',
+        '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">\r\n',]
+
+    variant_1 = Variant(
+        reference_name='9', start=1, end=2, reference_bases='A',
+        alternate_bases=['T'], info={'HU': ['a', 'b']})
+    variant_1.calls.append(VariantCall(name='Sample1', genotype=[0, 0]))
+
+    variant_2 = Variant(
+        reference_name='19', start=1, end=2, reference_bases='A',
+        alternate_bases=['T'], info={'HU': ['a', 'b']})
+    variant_2.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
+
+    read_data_1 = self._create_temp_file_and_read_records(
+        file_content_1, representative_header_lines,
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(1, len(read_data_1))
+    self._assert_variants_equal([variant_1], read_data_1)
+
+    read_data_2 = self._create_temp_file_and_read_records(
+        file_content_2, representative_header_lines,
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(1, len(read_data_2))
+    self._assert_variants_equal([variant_2], read_data_2)
+
+  def test_end_info_key_pysam(self):
+    end_info_header_line = (
+        '##INFO=<ID=END,Number=1,Type=Integer,Description="End of record.">\n')
+    record_lines = ['19	123	.	A	T	.	.	END=1111	GT	1/0	0/1\n',
+                    '19	123	.	A	T	.	.	.	GT	0/1	1/1\n']
+    variant_1 = Variant(
+        reference_name='19', start=122, end=1111, reference_bases='A',
+        alternate_bases=['T'])
+    variant_1.calls.append(VariantCall(name='Sample1', genotype=[1, 0]))
+    variant_1.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
+    variant_2 = Variant(
+        reference_name='19', start=122, end=123, reference_bases='A',
+        alternate_bases=['T'])
+    variant_2.calls.append(VariantCall(name='Sample1', genotype=[0, 1]))
+    variant_2.calls.append(VariantCall(name='Sample2', genotype=[1, 1]))
+    read_data = self._create_temp_file_and_read_records(
+        [end_info_header_line] + _SAMPLE_HEADER_LINES[1:] + record_lines,
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(2, len(read_data))
+    self._assert_variants_equal([variant_1, variant_2], read_data)
+
+  def test_end_info_key_unknown_number_pysam(self):
+    end_info_header_line = (
+        '##INFO=<ID=END,Number=.,Type=Integer,Description="End of record.">\n')
+    record_lines = ['19	123	.	A	T	.	.	END=1111	GT	1/0	0/1\n']
+    variant_1 = Variant(
+        reference_name='19', start=122, end=1111, reference_bases='A',
+        alternate_bases=['T'])
+    variant_1.calls.append(VariantCall(name='Sample1', genotype=[1, 0]))
+    variant_1.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
+    read_data = self._create_temp_file_and_read_records(
+        [end_info_header_line] + _SAMPLE_HEADER_LINES[1:] + record_lines,
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(1, len(read_data))
+    self._assert_variants_equal([variant_1], read_data)
+
+  def test_end_info_key_unknown_number_invalid_pysam(self):
+    end_info_header_line = (
+        '##INFO=<ID=END,Number=.,Type=Integer,Description="End of record.">\n')
+    # PySam should only take first END field.
+    variant = Variant(
+        reference_name='19', start=122, end=150, reference_bases='A',
+        alternate_bases=['T'])
+    variant.calls.append(VariantCall(name='Sample1', genotype=[1, 0]))
+    variant.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
+    read_data = self._create_temp_file_and_read_records(
+        [end_info_header_line] + _SAMPLE_HEADER_LINES[1:] +
+        ['19	123	.	A	T	.	.	END=150,160	GT	1/0	0/1\n'],
+        vcf_parser_type=VcfParserType.PYSAM)
+
+    self.assertEqual(1, len(read_data))
+    self._assert_variants_equal([variant], read_data)
+
+    # END should be rounded down.
+    read_data = self._create_temp_file_and_read_records(
+        [end_info_header_line] + _SAMPLE_HEADER_LINES[1:] +
+        ['19	123	.	A	T	.	.	END=150.9	GT	1/0	0/1\n'],
+        vcf_parser_type=VcfParserType.PYSAM)
+
+    self.assertEqual(1, len(read_data))
+    self._assert_variants_equal([variant], read_data)
+
+    # END should not be a string.
+    with self.assertRaises(ValueError):
+      self._create_temp_file_and_read_records(
+          [end_info_header_line] + _SAMPLE_HEADER_LINES[1:] +
+          ['19	123	.	A	T	.	.	END=text	GT	1/0	0/1\n'],
+          vcf_parser_type=VcfParserType.PYSAM)
+
+  def test_custom_phaseset_pysam(self):
+    phaseset_header_line = (
+        '##FORMAT=<ID=PS,Number=1,Type=Integer,Description="Phaseset">\n')
+    record_lines = ['19	123	.	A	T	.	.	.	GT:PS	1|0:1111	0/1:.\n',
+                    '19	121	.	A	T	.	.	.	GT:PS	1|0:2222	0/1:2222\n']
+    variant_1 = Variant(
+        reference_name='19', start=122, end=123, reference_bases='A',
+        alternate_bases=['T'])
+    variant_1.calls.append(
+        VariantCall(name='Sample1', genotype=[1, 0], phaseset='1111'))
+    variant_1.calls.append(VariantCall(name='Sample2', genotype=[0, 1]))
+    variant_2 = Variant(
+        reference_name='19', start=120, end=121, reference_bases='A',
+        alternate_bases=['T'])
+    variant_2.calls.append(
+        VariantCall(name='Sample1', genotype=[1, 0], phaseset='2222'))
+    variant_2.calls.append(
+        VariantCall(name='Sample2', genotype=[0, 1], phaseset='2222'))
+    read_data = self._create_temp_file_and_read_records(
+        [phaseset_header_line] + _SAMPLE_HEADER_LINES[1:] + record_lines,
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(2, len(read_data))
+    self._assert_variants_equal([variant_1, variant_2], read_data)
+
+  def test_format_numbers_pysam(self):
+    format_headers = [
+        '##FORMAT=<ID=FU,Number=.,Type=String,Description="Format_variable">\n',
+        '##FORMAT=<ID=F1,Number=1,Type=Integer,Description="Format_1">\n',
+        '##FORMAT=<ID=F2,Number=2,Type=Character,Description="Format_2">\n',
+        '##FORMAT=<ID=AO,Number=A,Type=Integer,Description="Format_3">\n',
+        '##FORMAT=<ID=AD,Number=G,Type=Integer,Description="Format_4">\n',]
+
+    record_lines = [
+        ('19	2	.	A	T,C	.	.	.	'
+         'GT:FU:F1:F2:AO:AD	1/0:a1:3:a,b:1:3,4	'
+         '0/1:a2,a3:4:b,c:1,2:3')]
+    expected_variant = Variant(
+        reference_name='19', start=1, end=2, reference_bases='A',
+        alternate_bases=['T', 'C'])
+    expected_variant.calls.append(VariantCall(
+        name='Sample1',
+        genotype=[1, 0],
+        info={'FU': ['a1'], 'F1': 3, 'F2': ['a', 'b'], 'AO': [1],
+              'AD': [3, 4]}))
+    expected_variant.calls.append(VariantCall(
+        name='Sample2',
+        genotype=[0, 1],
+        info={'FU': ['a2', 'a3'], 'F1': 4, 'F2': ['b', 'c'], 'AO': [1, 2],
+              'AD':[3]}))
+    read_data = self._create_temp_file_and_read_records(
+        format_headers + _SAMPLE_HEADER_LINES[1:] + record_lines,
+        vcf_parser_type=VcfParserType.PYSAM)
+    self.assertEqual(1, len(read_data))
+    self.assertEqual(expected_variant, read_data[0])
+
+  def test_pipeline_read_single_file_pysam(self):
+    with TempDir() as tempdir:
+      file_name = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir)
+      self._assert_pipeline_read_files_record_count_equal(
+          file_name, len(_SAMPLE_TEXT_LINES),
+          vcf_parser_type=VcfParserType.PYSAM)
+
+  def test_pipeline_read_all_single_file_pysam(self):
+    with TempDir() as tempdir:
+      file_name = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir)
+      self._assert_pipeline_read_files_record_count_equal(
+          file_name, len(_SAMPLE_TEXT_LINES), use_read_all=True,
+          vcf_parser_type=VcfParserType.PYSAM)
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_pipeline_read_single_file_large_pysam(self):
+    self._assert_pipeline_read_files_record_count_equal(
+        testdata_util.get_full_file_path('valid-4.1-large.vcf'), 9882,
+        vcf_parser_type=VcfParserType.PYSAM)
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_pipeline_read_all_single_file_large_pysam(self):
+    self._assert_pipeline_read_files_record_count_equal(
+        testdata_util.get_full_file_path('valid-4.1-large.vcf'), 9882,
+        use_read_all=True, vcf_parser_type=VcfParserType.PYSAM)
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_pipeline_read_file_pattern_large_pysam(self):
+    self._assert_pipeline_read_files_record_count_equal(
+        os.path.join(testdata_util.get_full_dir(), 'valid-*.vcf'), 9900,
+        vcf_parser_type=VcfParserType.PYSAM)
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_pipeline_read_all_file_pattern_large_pysam(self):
+    self._assert_pipeline_read_files_record_count_equal(
+        os.path.join(testdata_util.get_full_dir(), 'valid-*.vcf'), 9900,
+        use_read_all=True, vcf_parser_type=VcfParserType.PYSAM)
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_pipeline_read_all_gzip_large_pysam(self):
+    self._assert_pipeline_read_files_record_count_equal(
+        os.path.join(testdata_util.get_full_dir(), 'valid-*.vcf.gz'), 9900,
+        use_read_all=True, vcf_parser_type=VcfParserType.PYSAM)
+
+  @unittest.skipIf(VCF_FILE_DIR_MISSING, 'VCF test file directory is missing')
+  def test_pipeline_read_all_multiple_files_large_pysam(self):
+    pipeline = TestPipeline()
+    pcoll = (pipeline
+             | 'Create' >> beam.Create(
+                 [testdata_util.get_full_file_path('valid-4.0.vcf'),
+                  testdata_util.get_full_file_path('valid-4.1-large.vcf'),
+                  testdata_util.get_full_file_path('valid-4.2.vcf')])
+             | 'Read' >> ReadAllFromVcf(vcf_parser_type=VcfParserType.PYSAM))
+    assert_that(pcoll, asserts.count_equals_to(9900))
+    pipeline.run()
+
+  def test_pipeline_read_all_gzip_pysam(self):
+    with TempDir() as tempdir:
+      file_name_1 = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir,
+          compression_type=CompressionTypes.GZIP)
+      file_name_2 = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir,
+          compression_type=CompressionTypes.GZIP)
+      pipeline = TestPipeline()
+      pcoll = (pipeline
+               | 'Create' >> beam.Create([file_name_1, file_name_2])
+               | 'Read' >> ReadAllFromVcf(vcf_parser_type=VcfParserType.PYSAM))
+      assert_that(pcoll, asserts.count_equals_to(2 * len(_SAMPLE_TEXT_LINES)))
+      pipeline.run()
+
+  def test_pipeline_read_all_bzip2_pysam(self):
+    with TempDir() as tempdir:
+      file_name_1 = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir,
+          compression_type=CompressionTypes.BZIP2)
+      file_name_2 = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir,
+          compression_type=CompressionTypes.BZIP2)
+      pipeline = TestPipeline()
+      pcoll = (pipeline
+               | 'Create' >> beam.Create([file_name_1, file_name_2])
+               | 'Read' >> ReadAllFromVcf(vcf_parser_type=VcfParserType.PYSAM))
+      assert_that(pcoll, asserts.count_equals_to(2 * len(_SAMPLE_TEXT_LINES)))
+      pipeline.run()
+
+  def test_pipeline_read_all_multiple_files_pysam(self):
+    with TempDir() as tempdir:
+      file_name_1 = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir)
+      file_name_2 = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir)
+      pipeline = TestPipeline()
+      pcoll = (pipeline
+               | 'Create' >> beam.Create([file_name_1, file_name_2])
+               | 'Read' >> ReadAllFromVcf(vcf_parser_type=VcfParserType.PYSAM))
+      assert_that(pcoll, asserts.count_equals_to(2 * len(_SAMPLE_TEXT_LINES)))
+      pipeline.run()
+
+  def test_read_reentrant_without_splitting_pysam(self):
+    with TempDir() as tempdir:
+      file_name = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir)
+      source = VcfSource(file_name, vcf_parser_type=VcfParserType.PYSAM)
+      source_test_utils.assert_reentrant_reads_succeed((source, None, None))
+
+  def test_read_reentrant_after_splitting_pysam(self):
+    with TempDir() as tempdir:
+      file_name = self._create_temp_vcf_file(
+          _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir)
+      source = VcfSource(file_name, vcf_parser_type=VcfParserType.PYSAM)
+      splits = [split for split in source.split(desired_bundle_size=100000)]
+      assert len(splits) == 1
+      source_test_utils.assert_reentrant_reads_succeed(
+          (splits[0].source, splits[0].start_position, splits[0].stop_position))
+
+  def test_dynamic_work_rebalancing_pysam(self):
     with TempDir() as tempdir:
       file_name = self._create_temp_vcf_file(
           _SAMPLE_HEADER_LINES + _SAMPLE_TEXT_LINES, tempdir)

--- a/gcp_variant_transforms/libs/vcf_field_conflict_resolver.py
+++ b/gcp_variant_transforms/libs/vcf_field_conflict_resolver.py
@@ -14,8 +14,6 @@
 
 """Class for resolving conflicts in VCF field definitions."""
 
-import vcf
-
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.libs import bigquery_schema_descriptor  # pylint: disable=unused-import
 from gcp_variant_transforms.libs import bigquery_util
@@ -151,7 +149,8 @@ class FieldConflictResolver(object):
     """
     if vcf_num in (0, 1):
       return False
-    elif (vcf_num == vcf.parser.field_counts['A'] and
+    elif (vcf_num in vcf_header_io.VCF_HEADER_INFO_NUM_FIELD_CONVERSION and
+          vcf_header_io.VCF_HEADER_INFO_NUM_FIELD_CONVERSION[vcf_num] == 'A' and
           self._split_alternate_allele_info_fields):
       # info field with `Number=A` does not become a repeated field if flag
       # `split_alternate_allele_info_fields` is on.

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -107,10 +107,15 @@ class VcfReadOptions(VariantTransformsOptions):
         default=vcfio.VcfParserType.PYVCF.name,
         choices=[parser.name for parser in vcfio.VcfParserType],
         help=('Choose the underlying parser for reading VCF files. Currently '
-              'we only support `{}` (default) and `{}`. Note: Nucleus parser '
-              'is still in experimental stage so using it for production jobs '
-              'is not recommended.'.format(vcfio.VcfParserType.PYVCF.name,
-                                           vcfio.VcfParserType.NUCLEUS.name)))
+              'we only support ``{}`` (default), ``{}`` and ``{}``. Note: '
+              'Nucleus parser is still in experimental stage so using it for '
+              'production jobs is not recommended. Additionally, if you are '
+              'running using PySam in a ``DirectRunner``, you may need to '
+              'install additional compression libraries on your machines, like '
+              '``zlib1g-dev``, ``libbz2-dev`` and ``liblzma-dev``'.format(
+                  vcfio.VcfParserType.PYVCF.name,
+                  vcfio.VcfParserType.NUCLEUS.name,
+                  vcfio.VcfParserType.PYSAM.name)))
 
   def validate(self, parsed_args):
     # type: (argparse.Namespace) -> None

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -227,7 +227,8 @@ def read_variants(
                 | 'ReadAllFromVcf' >> vcfio.ReadAllFromVcf(
                     representative_header_lines=representative_header_lines,
                     compression_type=compression_type,
-                    allow_malformed_records=allow_malformed_records))
+                    allow_malformed_records=allow_malformed_records,
+                    vcf_parser_type=vcf_parser))
   else:
     variants = pipeline | 'ReadFromVcf' >> vcfio.ReadFromVcf(
         all_patterns[0],

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -219,7 +219,8 @@ def read_variants(
               | 'ReadVariants'
               >> vcfio.ReadFromBGZF(splittable_bgzf,
                                     representative_header_lines,
-                                    allow_malformed_records))
+                                    allow_malformed_records,
+                                    vcf_parser_type=vcf_parser))
 
   if pipeline_mode == PipelineModes.LARGE:
     variants = (pipeline

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -185,18 +185,26 @@ def get_estimates(pipeline, pipeline_mode, all_patterns):
   return estimates
 
 
-def read_headers(pipeline, pipeline_mode, all_patterns):
-  # type: (beam.Pipeline, int, List[str]) -> pvalue.PCollection
+def read_headers(
+    pipeline,  #type: beam.Pipeline
+    pipeline_mode,  #type: int
+    all_patterns,  #type: List[str]
+    vcf_parser=vcfio.VcfParserType.PYVCF  #type: vcfio.VcfParserType
+    ):
+  # type: (...) -> pvalue.PCollection
   """Creates an initial PCollection by reading the VCF file headers."""
   compression_type = get_compression_type(all_patterns)
   if pipeline_mode == PipelineModes.LARGE:
     headers = (pipeline
                | beam.Create(all_patterns)
                | vcf_header_io.ReadAllVcfHeaders(
-                   compression_type=compression_type))
+                   compression_type=compression_type,
+                   vcf_parser=vcf_parser))
   else:
     headers = pipeline | vcf_header_io.ReadVcfHeaders(
-        all_patterns[0], compression_type=compression_type)
+        all_patterns[0],
+        compression_type=compression_type,
+        vcf_parser=vcf_parser)
 
   return headers
 

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -25,6 +25,7 @@ from apache_beam.testing.util import assert_that
 import mock
 
 from gcp_variant_transforms import pipeline_common
+from gcp_variant_transforms.beam_io.vcfio import VcfParserType
 from gcp_variant_transforms.pipeline_common import PipelineModes
 from gcp_variant_transforms.testing import asserts
 from gcp_variant_transforms.testing import temp_dir
@@ -266,5 +267,27 @@ class CommonPipelineTest(unittest.TestCase):
                                              all_patterns,
                                              PipelineModes.LARGE,
                                              False)
+    assert_that(variants, asserts.count_equals_to(5))
+    pipeline.run()
+
+  def test_read_variants_pysam(self):
+    pipeline = test_pipeline.TestPipeline()
+    all_patterns = [testdata_util.get_full_file_path('valid-4.0.vcf')]
+    variants = pipeline_common.read_variants(pipeline,
+                                             all_patterns,
+                                             PipelineModes.SMALL,
+                                             False,
+                                             vcf_parser=VcfParserType.PYSAM)
+    assert_that(variants, asserts.count_equals_to(5))
+    pipeline.run()
+
+  def test_read_variants_large_mode_pysam(self):
+    pipeline = test_pipeline.TestPipeline()
+    all_patterns = [testdata_util.get_full_file_path('valid-4.0.vcf')]
+    variants = pipeline_common.read_variants(pipeline,
+                                             all_patterns,
+                                             PipelineModes.LARGE,
+                                             False,
+                                             vcf_parser=VcfParserType.PYSAM)
     assert_that(variants, asserts.count_equals_to(5))
     pipeline.run()

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/infer_header_fields_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/infer_header_fields_pysam.json
@@ -1,0 +1,60 @@
+[
+  {
+    "test_name": "infer-header-fields",
+    "table_name": "infer_header_fields",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/infer-header-fields.vcf",
+    "infer_headers": "True",
+    "allow_incompatible_records": "True",
+    "runner": "DirectRunner",
+    "vcf_parser": "PYSAM",
+    "assertion_configs": [
+      {
+        "query": ["NUM_ROWS_QUERY"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(AA) AS cnt FROM {TABLE_NAME}"],
+        "expected_result": {"cnt": 3}
+      },
+      {
+        "query": ["SELECT COUNT(AF) AS cnt FROM {TABLE_NAME}"],
+        "expected_result": {"cnt": 3}
+      },
+      {
+        "query": ["SELECT COUNT(DB) AS cnt FROM {TABLE_NAME}"],
+        "expected_result": {"cnt": 1}
+      },
+      {
+        "query": ["SELECT COUNT(DP) AS cnt FROM {TABLE_NAME}"],
+        "expected_result": {"cnt": 3}
+      },
+      {
+        "query": ["SELECT COUNT(H2) AS cnt FROM {TABLE_NAME}"],
+        "expected_result": {"cnt": 1}
+      },
+      {
+        "query": ["SELECT COUNT(NS) AS cnt FROM {TABLE_NAME}"],
+        "expected_result": {"cnt": 3}
+      },
+      {
+        "query": [
+          "SELECT SUM(HQ) AS sum FROM {TABLE_NAME} t, t.call as call,",
+          "call.HQ as HQ"
+        ],
+        "expected_result": {"sum": 274}
+      },
+      {
+        "query": [
+          "SELECT SUM(call.GQ) AS sum FROM {TABLE_NAME} t, t.call as call"
+        ],
+        "expected_result": {"sum": 289}
+      },
+      {
+        "query": [
+          "SELECT SUM(call.DP) AS sum FROM {TABLE_NAME} t, t.call as call"
+        ],
+        "expected_result": {"sum": 33.2}
+      }
+    ]
+  }
+]

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2_pysam.json
@@ -4,7 +4,6 @@
     "table_name": "valid_4_0_bz2_pysam",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.bz2",
     "runner": "DirectRunner",
-    "zones": ["us-west1-b"],
     "vcf_parser": "PYSAM",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2_pysam.json
@@ -1,0 +1,24 @@
+[
+  {
+    "test_name": "valid-4-0-bz2-pysam",
+    "table_name": "valid_4_0_bz2_pysam",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.bz2",
+    "runner": "DirectRunner",
+    "zones": ["us-west1-b"],
+    "vcf_parser": "PYVCF",
+    "assertion_configs": [
+      {
+        "query": ["NUM_ROWS_QUERY"],
+        "expected_result": {"num_rows": 5}
+      },
+      {
+        "query": ["SUM_START_QUERY"],
+        "expected_result": {"sum_start": 3607195}
+      },
+      {
+        "query": ["SUM_END_QUERY"],
+        "expected_result": {"sum_end": 3607203}
+      }
+    ]
+  }
+]

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2_pysam.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.bz2",
     "runner": "DirectRunner",
     "zones": ["us-west1-b"],
-    "vcf_parser": "PYVCF",
+    "vcf_parser": "PYSAM",
     "assertion_configs": [
       {
         "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1_pysam.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.1-large.vcf",
     "runner": "DirectRunner",
     "zones": ["us-west1-b"],
-    "vcf_parser": "PYVCF",
+    "vcf_parser": "PYSAM",
     "assertion_configs": [
       {
         "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1_pysam.json
@@ -4,7 +4,6 @@
     "table_name": "valid_4_1_pysam",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.1-large.vcf",
     "runner": "DirectRunner",
-    "zones": ["us-west1-b"],
     "vcf_parser": "PYSAM",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1_pysam.json
@@ -1,0 +1,24 @@
+[
+  {
+    "test_name": "valid-4-1-pysam",
+    "table_name": "valid_4_1_pysam",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.1-large.vcf",
+    "runner": "DirectRunner",
+    "zones": ["us-west1-b"],
+    "vcf_parser": "PYVCF",
+    "assertion_configs": [
+      {
+        "query": ["NUM_ROWS_QUERY"],
+        "expected_result": {"num_rows": 9882}
+      },
+      {
+        "query": ["SUM_START_QUERY"],
+        "expected_result": {"sum_start": 5434957328}
+      },
+      {
+        "query": ["SUM_END_QUERY"],
+        "expected_result": {"sum_end": 5435327553}
+      }
+    ]
+  }
+]

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz_pysam.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf.gz",
     "runner": "DirectRunner",
     "zones": ["us-west1-b"],
-    "vcf_parser": "PYVCF",
+    "vcf_parser": "PYSAM",
     "assertion_configs": [
       {
         "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz_pysam.json
@@ -1,0 +1,24 @@
+[
+  {
+    "test_name": "valid-4-2-gz-pysam",
+    "table_name": "valid_4_2_gz_pysam",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf.gz",
+    "runner": "DirectRunner",
+    "zones": ["us-west1-b"],
+    "vcf_parser": "PYVCF",
+    "assertion_configs": [
+      {
+        "query": ["NUM_ROWS_QUERY"],
+        "expected_result": {"num_rows": 13}
+      },
+      {
+        "query": ["SUM_START_QUERY"],
+        "expected_result": {"sum_start": 23031929}
+      },
+      {
+        "query": ["SUM_END_QUERY"],
+        "expected_result": {"sum_end": 23033052}
+      }
+    ]
+  }
+]

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz_pysam.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz_pysam.json
@@ -4,7 +4,6 @@
     "table_name": "valid_4_2_gz_pysam",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf.gz",
     "runner": "DirectRunner",
-    "zones": ["us-west1-b"],
     "vcf_parser": "PYSAM",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -321,7 +321,9 @@ def _merge_headers(known_args, pipeline_args,
 
   with beam.Pipeline(options=options) as p:
     headers = pipeline_common.read_headers(
-        p, pipeline_mode, known_args.all_patterns)
+        p, pipeline_mode,
+        known_args.all_patterns,
+        vcfio.VcfParserType[known_args.vcf_parser])
     merged_header = pipeline_common.get_merged_headers(
         headers,
         known_args.split_alternate_allele_info_fields,
@@ -384,9 +386,11 @@ def _create_sample_info_table(pipeline,  # type: beam.Pipeline
                               known_args,  # type: argparse.Namespace
                              ):
   # type: (...) -> None
-  headers = pipeline_common.read_headers(pipeline,
-                                         pipeline_mode,
-                                         known_args.all_patterns)
+  headers = pipeline_common.read_headers(
+      pipeline,
+      pipeline_mode,
+      known_args.all_patterns,
+      vcfio.VcfParserType[known_args.vcf_parser])
   _ = (headers | 'SampleInfoToBigQuery' >>
        sample_info_to_bigquery.SampleInfoToBigQuery(
            known_args.output_table,

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,9 @@ import setuptools
 
 PYSAM_DEPENDENCY_COMMANDS = [
     ['apt-get', 'update'],
-    ['apt-get', '-y', 'install', 'autoconf', 'automake', 'make', 'gcc', 'perl',
-     'zlib1g-dev', 'libbz2-dev', 'liblzma-dev', 'libcurl4-openssl-dev',
-     'libssl-dev']
+    ['apt-get', '-y', 'install', 'autoconf', 'automake', 'gcc', 'libbz2-dev',
+     'libcurl4-openssl-dev', 'liblzma-dev', 'libssl-dev', 'make', 'perl',
+     'zlib1g-dev']
 ]
 
 PYSAM_INSTALLATION_COMMAND = ['pip', 'install', 'pysam>=0.15.3']
@@ -62,16 +62,10 @@ class CustomCommands(setuptools.Command):
 
   def RunCustomCommand(self, command_list):
     print 'Running command: %s' % command_list
-    p = subprocess.Popen(
-        command_list,
-        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    # Can use communicate(input='y\n'.encode()) if the command run requires
-    # some confirmation.
-    stdout_data, _ = p.communicate()
-    print 'Command output: %s' % stdout_data
-    if p.returncode != 0:
-      raise RuntimeError(
-          'Command %s failed: exit code: %s' % (command_list, p.returncode))
+    try:
+      subprocess.call(command_list)
+    except Exception as e:
+      raise RuntimeError('Command %s failed with error: %s' % (command_list, e))
 
   def run(self):
     try:
@@ -84,8 +78,8 @@ class CustomCommands(setuptools.Command):
     except RuntimeError:
       raise RuntimeError(
           'PySam installation has failed. Make sure you have the ' + \
-          'following packages installed: autoconf automake make gcc perl ' + \
-          'zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev')
+          'following packages installed: autoconf automake gcc libbz2-dev ' + \
+          'liblzma-dev libcurl4-openssl-dev libssl-dev make perl zlib1g-dev')
 
 class build(_build):  # pylint: disable=invalid-name
   """A build command class that will be invoked during package install.

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,9 @@ REQUIRED_PACKAGES = [
     # Nucleus needs uptodate protocol buffer compiler (protoc).
     'protobuf>=3.6.1',
     'mmh3<2.6',
-<<<<<<< HEAD
     # Refer to issue #528
     'google-cloud-storage<1.23.0',
     'pyfarmhash'
-=======
-    'google-cloud-storage'
->>>>>>> Address eights iteration of comments.
 ]
 
 REQUIRED_SETUP_PACKAGES = [

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@
 import setuptools
 
 REQUIRED_PACKAGES = [
-    'pysam',
+    'pysam>=0.15.3',
     'cython>=0.28.1',
     'apache-beam[gcp]',
     # Note that adding 'google-api-python-client>=1.6' causes some dependency

--- a/setup.py
+++ b/setup.py
@@ -42,9 +42,13 @@ REQUIRED_PACKAGES = [
     # Nucleus needs uptodate protocol buffer compiler (protoc).
     'protobuf>=3.6.1',
     'mmh3<2.6',
+<<<<<<< HEAD
     # Refer to issue #528
     'google-cloud-storage<1.23.0',
     'pyfarmhash'
+=======
+    'google-cloud-storage'
+>>>>>>> Address eights iteration of comments.
 ]
 
 REQUIRED_SETUP_PACKAGES = [
@@ -83,6 +87,7 @@ class CustomCommands(setuptools.Command):
 
 class build(_build):  # pylint: disable=invalid-name
   """A build command class that will be invoked during package install.
+
   The package built using the current setup.py will be staged and later
   installed in the worker using `pip install package'. This class will be
   instantiated during install for this specific scenario and will trigger

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ class CustomCommands(setuptools.Command):
         for command in PYSAM_DEPENDENCY_COMMANDS:
           self.RunCustomCommand(command)
       self.RunCustomCommand(PYSAM_INSTALLATION_COMMAND)
-        
+
     except RuntimeError:
       raise RuntimeError(
           'PySam installation has failed. Make sure you have the ' + \

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@
 import setuptools
 
 REQUIRED_PACKAGES = [
+    'pysam',
     'cython>=0.28.1',
     'apache-beam[gcp]',
     # Note that adding 'google-api-python-client>=1.6' causes some dependency


### PR DESCRIPTION
Uses multi threading and two pipes - to send data from parent thread to child, and from child into PySam class VariantFile (which is used by parent to read records). This is required to comply and to not overwrite base methods in VcfParser.

In order to send a line at a time in each and parse them one by one, readline() method is used - alternative methods deadlock, as they expect EOF before they can proceed. Therefore, every line read should be accompanied with a break-line character.

Due to quota issues, haven't checked the correctness of the integration tests yet, but manual run works and produces a table. Will update once quota is available and integration tests are run.