### PR TITLE
Update default docker images to cloud-lifesciences

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ running `gcloud components update` (more details [here](https://cloud.google.com
 
 Use the following command to get the latest version of Variant Transforms.
 ```bash
-docker pull gcr.io/gcp-variant-transforms/gcp-variant-transforms
+docker pull gcr.io/cloud-lifesciences/gcp-variant-transforms
 ```
 
 Run the script below and replace the following parameters:
@@ -81,7 +81,7 @@ COMMAND="vcf_to_bq \
   --runner DataflowRunner"
 
 docker run -v ~/.config:/root/.config \
-  gcr.io/gcp-variant-transforms/gcp-variant-transforms \
+  gcr.io/cloud-lifesciences/gcp-variant-transforms \
   --project "${GOOGLE_CLOUD_PROJECT}" \
   --zones us-west1-b \
   "${COMMAND}"

--- a/cloudbuild_release.yaml
+++ b/cloudbuild_release.yaml
@@ -14,7 +14,7 @@
 
 # This is meant to be used by the Build Trigger set in Cloud Build for auto
 # release. It tags the verified image and pushes to the main project
-# (gcp-variant-transforms).
+# (cloud-lifesciences).
 
 steps:
   - name: 'gcr.io/cloud-builders/docker'
@@ -27,24 +27,24 @@ steps:
     args:
       - 'tag'
       - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
+      - 'gcr.io/cloud-lifesciences/gcp-variant-transforms:${COMMIT_SHA}'
     id: 'tag-image-commit-sha'
 
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'tag'
-      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
-      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${TAG_NAME}'
+      - 'gcr.io/cloud-lifesciences/gcp-variant-transforms:${COMMIT_SHA}'
+      - 'gcr.io/cloud-lifesciences/gcp-variant-transforms:${TAG_NAME}'
     id: 'tag-image-release-version'
 
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'tag'
-      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
-      - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:latest'
+      - 'gcr.io/cloud-lifesciences/gcp-variant-transforms:${COMMIT_SHA}'
+      - 'gcr.io/cloud-lifesciences/gcp-variant-transforms:latest'
     id: 'tag-image-latest'
 
 images:
-  - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}'
-  - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:${TAG_NAME}'
-  - 'gcr.io/gcp-variant-transforms/gcp-variant-transforms:latest'
+  - 'gcr.io/cloud-lifesciences/gcp-variant-transforms:${COMMIT_SHA}'
+  - 'gcr.io/cloud-lifesciences/gcp-variant-transforms:${TAG_NAME}'
+  - 'gcr.io/cloud-lifesciences/gcp-variant-transforms:latest'

--- a/docker/pipelines_runner.sh
+++ b/docker/pipelines_runner.sh
@@ -57,7 +57,7 @@ function main {
   parse_args "$@"
 
   google_cloud_project="${google_cloud_project:-$(gcloud config get-value project)}"
-  vt_docker_image="${vt_docker_image:-gcr.io/gcp-variant-transforms/gcp-variant-transforms:${COMMIT_SHA}}"
+  vt_docker_image="${vt_docker_image:-gcr.io/cloud-lifesciences/gcp-variant-transforms:${COMMIT_SHA}}"
   zones="${zones:-$(gcloud config get-value compute/zone)}"
   temp_location="${temp_location:-''}"
 

--- a/docs/bigquery_to_vcf.md
+++ b/docs/bigquery_to_vcf.md
@@ -42,7 +42,7 @@ COMMAND="bq_to_vcf \
   --runner DataflowRunner"
 
 docker run -v ~/.config:/root/.config \
-  gcr.io/gcp-variant-transforms/gcp-variant-transforms \
+  gcr.io/cloud-lifesciences/gcp-variant-transforms \
   --project "${GOOGLE_CLOUD_PROJECT}" \
   --zones us-west1-b \
   "${COMMAND}"

--- a/docs/vcf_files_preprocessor.md
+++ b/docs/vcf_files_preprocessor.md
@@ -81,7 +81,7 @@ COMMAND="vcf_to_bq_preprocess \
   --runner DataflowRunner"
 
 docker run -v ~/.config:/root/.config \
-  gcr.io/gcp-variant-transforms/gcp-variant-transforms \
+  gcr.io/cloud-lifesciences/gcp-variant-transforms \
   --project "${GOOGLE_CLOUD_PROJECT}" \
   --zones us-west1-b \
   "${COMMAND}"

--- a/gcp_variant_transforms/testing/integration/run_tests_common.py
+++ b/gcp_variant_transforms/testing/integration/run_tests_common.py
@@ -28,7 +28,7 @@ from collections import namedtuple
 from typing import Dict, List, Optional  # pylint: disable=unused-import
 
 
-_DEFAULT_IMAGE_NAME = 'gcr.io/gcp-variant-transforms/gcp-variant-transforms'
+_DEFAULT_IMAGE_NAME = 'gcr.io/cloud-lifesciences/gcp-variant-transforms'
 _DEFAULT_ZONES = ['us-east1-b']
 
 # `TestCaseState` saves current running test and the remaining tests in the same


### PR DESCRIPTION
- The existing images in gcp-variant-transforms have been copied to cloud-lifesciences
- The future releases will publish in cloud-lifesciences

Related issue: https://github.com/googlegenomics/gcp-variant-transforms/issues/494