### PR TITLE
Move the vep cache and vep image to cloud-lifesciences project

### DIFF
--- a/docs/variant_annotation.md
+++ b/docs/variant_annotation.md
@@ -116,14 +116,14 @@ pipeline may take longer to finish for smaller value of this flag.
 * [`--vep_image_uri`](https://github.com/googlegenomics/gcp-variant-transforms/blob/c4659bba2cf577d64f15db5cd9f477d9ea2b51b0/gcp_variant_transforms/options/variant_transform_options.py#L196)
 the docker image for VEP created using the
 [Dockerfile in variant-annotation](https://github.com/googlegenomics/variant-annotation/tree/master/batch/vep)
-GitHub repo. By default `gcr.io/gcp-variant-annotation/vep_91` is used which is
+GitHub repo. By default `gcr.io/cloud-lifesciences/vep_91` is used which is
 a public image that Google maintains (VEP version 91).
 
 * [`--vep_cache_path`](https://github.com/googlegenomics/gcp-variant-transforms/blob/c4659bba2cf577d64f15db5cd9f477d9ea2b51b0/gcp_variant_transforms/options/variant_transform_options.py#L200)
 the GCS location that has the compressed version of VEP cache. This file can be
 created using
 [build_vep_cache.sh](https://github.com/googlegenomics/variant-annotation/blob/master/batch/vep/build_vep_cache.sh)
-script. By default `gs://gcp-variant-annotation-vep-cache/vep_cache_homo_sapiens_GRCh38_91.tar.gz`
+script. By default `gs://cloud-lifesciences/vep/vep_cache_homo_sapiens_GRCh38_91.tar.gz`
 is used which is good for human genome aligned with GRCh38 reference sequence.
 
 * [`--vep_info_field`](https://github.com/googlegenomics/gcp-variant-transforms/blob/c4659bba2cf577d64f15db5cd9f477d9ea2b51b0/gcp_variant_transforms/options/variant_transform_options.py#L204)

--- a/gcp_variant_transforms/libs/annotation/vep/vep_runner.py
+++ b/gcp_variant_transforms/libs/annotation/vep/vep_runner.py
@@ -98,7 +98,7 @@ def create_runner(known_args, pipeline_args, input_pattern, watchdog_file,
 class VepRunner(object):
   """A class for running vep through Pipelines API on a set of input files."""
 
-  _VEP_CACHE_BASE = ('gs://gcp-variant-annotation-vep-cache/'
+  _VEP_CACHE_BASE = ('gs://cloud-lifesciences/vep/'
                      'vep_cache_{species}_{assembly}_91.tar.gz')
 
   def __init__(

--- a/gcp_variant_transforms/libs/annotation/vep/vep_runner_test.py
+++ b/gcp_variant_transforms/libs/annotation/vep/vep_runner_test.py
@@ -108,14 +108,14 @@ class VepRunnerTest(unittest.TestCase):
         _VEP_INFO_FIELD, _IMAGE, '', _NUM_FORK, self._get_pipeline_args(),
         None, 30)
     self.assertEqual(test_instance._vep_cache_path,
-                     ('gs://gcp-variant-annotation-vep-cache/'
+                     ('gs://cloud-lifesciences/vep/'
                       'vep_cache_homo_sapiens_GRCh38_91.tar.gz'))
     test_instance = vep_runner.VepRunner(
         self._mock_service, 'mouse', 'mm9', _INPUT_PATTERN, _OUTPUT_DIR,
         _VEP_INFO_FIELD, _IMAGE, '', _NUM_FORK, self._get_pipeline_args(),
         None, 30)
     self.assertEqual(test_instance._vep_cache_path,
-                     ('gs://gcp-variant-annotation-vep-cache/'
+                     ('gs://cloud-lifesciences/vep/'
                       'vep_cache_mouse_mm9_91.tar.gz'))
 
   def test_get_output_pattern(self):

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -299,20 +299,20 @@ class AnnotationOptions(VariantTransformsOptions):
               'process of running VEP pipelines.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_IMAGE_FLAG,
-        default='gcr.io/gcp-variant-annotation/vep_91',
+        default='gcr.io/cloud-lifesciences/vep_91',
         help=('The URI of the docker image for VEP.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_CACHE_FLAG,
         default='',
         help=('The path for VEP cache on Google Cloud Storage. By default, '
-              'this will be set to gs://gcp-variant-annotation-vep-cache/'
+              'this will be set to gs://cloud-lifesciences/vep/'
               'vep_cache_homo_sapiens_GRCh38_91.tar.gz, assuming neither the '
               '`--vep_species` nor the `--vep_assembly` flags have been set. '
               'For convenience, if either of those flags are provided, this '
               'path will be automatically updated to reflect the new cache, '
               'given values are a species and/or assembly we maintain. For '
               'example, `--vep_assembly GRCh37` is satisfactory for specifying '
-              'our gs://gcp-variant-annotation-vep-cache/'
+              'our gs://cloud-lifesciences/vep/'
               'vep_cache_homo_sapiens_GRCh37_91.tar.gz cache.'))
     parser.add_argument(
         '--vep_info_field',


### PR DESCRIPTION
- The vep cache and vep image are copied to cloud-lifesciences project.
- Change the default cache and vep image to point to cloud-lifesciences project.


Related issues: https://github.com/googlegenomics/gcp-variant-transforms/issues/494
