### PR TITLE
Fix the VEP error (cannot detect the format) for empty files.

### DIFF
--- a/gcp_variant_transforms/libs/annotation/vep/vep_runner.py
+++ b/gcp_variant_transforms/libs/annotation/vep/vep_runner.py
@@ -195,7 +195,7 @@ class VepRunner(object):
                 # VEP database for a wrong reference sequence is being used
                 # and this has to caught and communicated to the user.
                 'OTHER_VEP_OPTS':
-                    '--everything --check_ref --allow_non_variant',
+                    '--everything --check_ref --allow_non_variant --format vcf',
             },
             'resources': {
                 'projectId': self._project,


### PR DESCRIPTION
VEP fails when annotating a VCF file without variants since it cannot detect the format.

The fix is based on: https://github.com/Ensembl/ensembl-vep/issues/215

Related issue: https://github.com/googlegenomics/gcp-variant-transforms/issues/399