### PR TITLE
Fix BGZF parser failure:

### DIFF
--- a/gcp_variant_transforms/beam_io/bgzf.py
+++ b/gcp_variant_transforms/beam_io/bgzf.py
@@ -52,6 +52,11 @@ class BGZF(filesystem.CompressedFile):
   This class repeatedly fetches the `unused_data` from the decompressor until
   all GZIP blocks are decompressed.
   """
+  def __init__(self,
+               fileobj,
+               compression_type=filesystem.CompressionTypes.GZIP):
+    super(BGZF, self).__init__(fileobj, compression_type)
+    self._first_time = True
 
   def _fetch_to_internal_buffer(self, num_bytes):
     """Fetches up to `num_bytes` into the internal buffer."""
@@ -59,6 +64,7 @@ class BGZF(filesystem.CompressedFile):
       return
     self._reset_read_buffer_to_accommodate_more_data()
     self._fetch_and_decompress_data_to_buffer(num_bytes)
+    self._first_time = False
 
   def _enough_data_in_buffer(self, num_bytes):
     return self._read_buffer.tell() - self._read_position >= num_bytes
@@ -99,7 +105,7 @@ class BGZF(filesystem.CompressedFile):
     return self._file.read(self._read_size)
 
   def _is_first_time(self):
-    return self._read_position == 0
+    return self._first_time
 
 
 class BGZFBlockSource(textio._TextSource):
@@ -153,13 +159,9 @@ class BGZFBlock(BGZF):
 
   It reads contents from `self._block`.
     - The string before first `\n` is discarded.
-    - Decompress the next 64KB after self._block and reads the first line. It
-      assumes one row can at most spans in two Blocks.
+    - Retrieves the next 16MB after self._block and reads the first line. It
+      assumes one row cannot be larger than 16 MB in compressed form.
   """
-
-  # Each block in BGZF is no larger than `_MAX_GZIP_SIZE`.
-  _MAX_GZIP_SIZE = 64 * 1024
-
   def __init__(self,
                fileobj,
                block,
@@ -174,12 +176,23 @@ class BGZFBlock(BGZF):
       self._read_first_gzip_block_into_buffer()
     super(BGZFBlock, self)._fetch_and_decompress_data_to_buffer(num_bytes)
     if self._read_eof:
-      self._complete_last_line()
+      self._complete_last_line(num_bytes)
 
   def _read_first_gzip_block_into_buffer(self):
     buf = self._read_data_from_source()
     decompressed = self._decompressor.decompress(buf)
     del buf
+    # Discards all data before first `\n`.
+    while '\n' not in decompressed:
+      if self._decompressor.unused_data != b'':
+        buf = self._decompressor.unused_data
+        self._decompressor = zlib.decompressobj(self._gzip_mask)
+        decompressed = self._decompressor.decompress(buf)
+        del buf
+      else:
+        raise ValueError('Read failed. The block {} does not contain any '
+                         'valid record.'.format(self._block))
+
     lines = decompressed.split('\n')
     self._read_buffer.write('\n'.join(lines[1:]))
 
@@ -191,11 +204,22 @@ class BGZFBlock(BGZF):
     self._start_offset += len(buf)
     return buf
 
-  def _complete_last_line(self):
-    # Fetch the first line in the next `self._MAX_GZIP_SIZE` bytes.
+  def _complete_last_line(self, num_bytes):
+    # Fetches the first line in the next `num_bytes` bytes.
     buf = self._file.raw._downloader.get_range(
-        self._block.end, self._block.end + self._MAX_GZIP_SIZE)
+        self._block.end, self._block.end + num_bytes)
     self._decompressor = zlib.decompressobj(self._gzip_mask)
     decompressed = self._decompressor.decompress(buf)
     del buf
+    # Writes all data to the buffer until the first `\n` is reached.
+    while '\n' not in decompressed:
+      if self._decompressor.unused_data != b'':
+        self._read_buffer.write(decompressed)
+        buf = self._decompressor.unused_data
+        self._decompressor = zlib.decompressobj(self._gzip_mask)
+        decompressed = self._decompressor.decompress(buf)
+        del buf
+      else:
+        raise ValueError('Read failed. The record is longer than {}'
+                         'bytes.'.format(num_bytes))
     self._read_buffer.write(decompressed.split('\n')[0] + '\n')

--- a/gcp_variant_transforms/beam_io/bgzf_test.py
+++ b/gcp_variant_transforms/beam_io/bgzf_test.py
@@ -66,7 +66,9 @@ class BgzfBlockTest(unittest.TestCase):
     mime_type = filesystem.CompressionTypes.mime_type(compression_type)
     raw_file = self.gcs.open(file_name, mime_type=mime_type,
                              read_buffer_size=read_buffer_size)
-    return bgzf.BGZFBlock(raw_file, block)
+    bgzf_block = bgzf.BGZFBlock(raw_file, block)
+    bgzf_block._read_size = 8*1024*1024
+    return bgzf_block
 
   def _read_all_lines(self, file_to_read):
     lines = []


### PR DESCRIPTION
- Fix the bug when discarding the first line and reading the last line for one block if the record is larger than one GZIP block.
- Use a variable to check whether it is the first time.