### PR TITLE
Fix Pylint failures

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -121,6 +121,13 @@ disable =
   # OK as we don't call in all PTransforms.
   super-init-not-called,
 
+[TYPECHECK]
+generated-members =
+  # The transforms (e.g. Create) in beam declared in __all__ cannot be detected
+  # by pylint.
+  beam.*,
+  apache_beam.*,
+
 [REPORTS]
 # Tells whether to display a full report or only the messages
 reports=no

--- a/gcp_variant_transforms/transforms/partition_variants.py
+++ b/gcp_variant_transforms/transforms/partition_variants.py
@@ -28,6 +28,6 @@ class PartitionVariants(beam.PartitionFn):
     # type: (variant_partition.VariantPartition) -> None
     self._partition = partition
 
-  def partition_for(self, variant, num_partitions):
+  def partition_for(self, variant, _):
     # type: (vcfio.Variant, int) -> int
     return self._partition.get_partition(variant.reference_name, variant.start)

--- a/gcp_variant_transforms/transforms/partition_variants_test.py
+++ b/gcp_variant_transforms/transforms/partition_variants_test.py
@@ -18,7 +18,7 @@ from __future__ import absolute_import
 
 import unittest
 
-from apache_beam import Partition
+import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
@@ -91,7 +91,7 @@ class PartitionVariantsTest(unittest.TestCase):
     partitions = (
         pipeline
         | Create(variants)
-        | 'PartitionVariants' >> Partition(
+        | 'PartitionVariants' >> beam.Partition(
             partition_variants.PartitionVariants(partitioner),
             partitioner.get_num_partitions()))
     for i in xrange(partitioner.get_num_partitions()):

--- a/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery_test.py
@@ -18,8 +18,8 @@ from __future__ import absolute_import
 
 import unittest
 
+import apache_beam as beam
 from apache_beam.io.gcp.internal.clients import bigquery
-from apache_beam import ParDo
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
@@ -243,7 +243,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     bigquery_rows = (
         pipeline
         | Create([proc_var_1, proc_var_2, proc_var_3])
-        | 'ConvertToRow' >> ParDo(ConvertVariantToRow(
+        | 'ConvertToRow' >> beam.ParDo(ConvertVariantToRow(
             self._row_generator)))
     assert_that(bigquery_rows, equal_to([row_1, row_2, row_3]))
     pipeline.run()
@@ -257,7 +257,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     bigquery_rows = (
         pipeline
         | Create([proc_var])
-        | 'ConvertToRow' >> ParDo(ConvertVariantToRow(
+        | 'ConvertToRow' >> beam.ParDo(ConvertVariantToRow(
             self._row_generator, omit_empty_sample_calls=True)))
     assert_that(bigquery_rows, equal_to([row]))
     pipeline.run()
@@ -272,7 +272,7 @@ class ConvertToBigQueryTableRowTest(unittest.TestCase):
     bigquery_rows = (
         pipeline
         | Create([proc_var])
-        | 'ConvertToRow' >> ParDo(ConvertVariantToRow(
+        | 'ConvertToRow' >> beam.ParDo(ConvertVariantToRow(
             self._row_generator, allow_incompatible_records=True)))
     assert_that(bigquery_rows, equal_to([row]))
     pipeline.run()


### PR DESCRIPTION
- False positive: Pylint stopped considering `__all__`, add beam members into `generated-members` to prevent no-member errors.
- Correct some other failures accordingly.