### PR TITLE
run annotation pipeline as a standalone tool

### DIFF
--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -389,7 +389,8 @@ def run(argv=None):
     _get_input_dimensions(known_args, pipeline_args)
 
   annotated_vcf_pattern = _run_annotation_pipeline(known_args, pipeline_args)
-
+  if not known_args.output_table and not known_args.output_avro_path:
+    return
   all_patterns = (
       [annotated_vcf_pattern] if annotated_vcf_pattern
       else known_args.all_patterns)


### PR DESCRIPTION
This PR allows the user to run annotation as a standalone tool: if --run_annotation_pipeline is set and --output_table is not provided.

FR: https://github.com/googlegenomics/gcp-variant-transforms/issues/504
