### PR TITLE
Resolve google-resumable-media package conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ REQUIRED_PACKAGES = [
     # Nucleus needs uptodate protocol buffer compiler (protoc).
     'protobuf>=3.6.1',
     'mmh3<2.6',
-    'google-cloud-storage',
+    # Refer to issue #528
+    'google-cloud-storage<1.23.0',
     'pyfarmhash'
 ]
 


### PR DESCRIPTION
Resolves #528  which is caused by conflict between:
* `google-cloud-storage>=1.23.0`
* and `google-cloud-bigquery<1.22.0`

We have to pin to `google-cloud-storage<1.23.0` until Beam updates to `google-cloud-bigquery>=1.22.0`.