### PR TITLE
Fix failing tests due to Beam 2.18.0

### DIFF
--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -794,7 +794,7 @@ class VcfSinkTest(unittest.TestCase):
 
   def test_write_dataflow(self):
     pipeline = TestPipeline()
-    pcoll = pipeline | beam.Create(self.variants)
+    pcoll = pipeline | beam.Create(self.variants, reshuffle=False)
     _ = pcoll | 'Write' >> vcfio.WriteToVcf(self.path)
     pipeline.run()
 
@@ -808,7 +808,7 @@ class VcfSinkTest(unittest.TestCase):
 
   def test_write_dataflow_auto_compression(self):
     pipeline = TestPipeline()
-    pcoll = pipeline | beam.Create(self.variants)
+    pcoll = pipeline | beam.Create(self.variants, reshuffle=False)
     _ = pcoll | 'Write' >> vcfio.WriteToVcf(
         self.path + '.gz',
         compression_type=CompressionTypes.AUTO)
@@ -824,7 +824,7 @@ class VcfSinkTest(unittest.TestCase):
 
   def test_write_dataflow_header(self):
     pipeline = TestPipeline()
-    pcoll = pipeline | 'Create' >> beam.Create(self.variants)
+    pcoll = pipeline | 'Create' >> beam.Create(self.variants, reshuffle=False)
     headers = ['foo\n']
     _ = pcoll | 'Write' >> vcfio.WriteToVcf(
         self.path + '.gz',

--- a/gcp_variant_transforms/transforms/extract_input_size_test.py
+++ b/gcp_variant_transforms/transforms/extract_input_size_test.py
@@ -77,7 +77,7 @@ class ExtractInputSizeTest(unittest.TestCase):
     pipeline = TestPipeline()
     sample_map = (
         pipeline
-        | transforms.Create(vcf_estimates)
+        | transforms.Create(vcf_estimates, reshuffle=False)
         | 'GetSampleMap' >> extract_input_size.GetSampleMap())
     assert_that(sample_map, equal_to(self._create_sample_map()))
     pipeline.run()

--- a/gcp_variant_transforms/transforms/merge_header_definitions_test.py
+++ b/gcp_variant_transforms/transforms/merge_header_definitions_test.py
@@ -150,7 +150,7 @@ class MergeHeadersTest(unittest.TestCase):
     pipeline = TestPipeline()
     merged_definitions = (
         pipeline
-        | Create(headers)
+        | Create(headers, reshuffle=False)
         | 'MergeDefinitions' >> merge_header_definitions.MergeDefinitions())
 
     expected = VcfHeaderDefinitions()

--- a/gcp_variant_transforms/transforms/merge_variants_test.py
+++ b/gcp_variant_transforms/transforms/merge_variants_test.py
@@ -101,7 +101,7 @@ class MergeVariantsTest(unittest.TestCase):
     pipeline = TestPipeline()
     merged_variants = (
         pipeline
-        | Create(variant_list + unmerged_variant_list)
+        | Create(variant_list + unmerged_variant_list, reshuffle=False)
         | 'MergeVariants' >> merge_variants.MergeVariants(variant_merger))
     assert_that(merged_variants,
                 asserts.variants_equal_to_ignore_order([merged_variant] +

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ PYSAM_INSTALLATION_COMMAND = ['pip', 'install', 'pysam>=0.15.3']
 
 REQUIRED_PACKAGES = [
     'cython>=0.28.1',
-    'apache-beam[gcp]',
+    'apache-beam[gcp]<=2.18.0',
     # Note that adding 'google-api-python-client>=1.6' causes some dependency
     # mismatch issues. This is fatal if using 'setup.py install', but works on
     # 'pip install .' as it ignores conflicting versions. See Issue #71.


### PR DESCRIPTION
Also pin Beam version to the latest (2.18.0) to avoid breaking our
master. In future, with each new release of Beam we manually update this
version and run all the tests. This can save us from wasting time on
figuring out random failures with each update.