### PR TITLE
Fix bq-to-vcf-option-customized-export test

### DIFF
--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -178,7 +178,7 @@ def _bigquery_to_vcf_shards(
                 | bigquery_to_variant.BigQueryToVariant(annotation_names))
     if known_args.call_names:
       call_names = (p
-                    | transforms.Create(known_args.call_names)
+                    | transforms.Create(known_args.call_names, reshuffle=False)
                     | beam.combiners.ToList())
     else:
       call_names = (variants


### PR DESCRIPTION
Also make bq_to_vcf to produce correctly ordered call_names when they are
provided. This is due to the Beam-2.18.0 known issue of not preserving the
order unless `reshuffle=False` is provided. For more information please
refer to:
https://beam.apache.org/blog/2020/01/13/beam-2.18.0.html