### PR TITLE
Store sample ID hash hex string in BQ tables.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -447,7 +447,6 @@ class PySamParser(VcfParser):
     self._original_info_list = None
     self._process_pid = None
     self._encoded_sample_names = {}
-    self._file_name = file_name
     self._sample_name_encoding = sample_name_encoding
 
   def send_kill_signal_to_child(self):

--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -447,7 +447,6 @@ class PySamParser(VcfParser):
     self._original_info_list = None
     self._process_pid = None
     self._encoded_sample_names = {}
-
     self._file_name = ''
     if sample_name_encoding == SampleNameEncoding.WITH_FILE_PATH:
       self._file_name = file_name
@@ -612,7 +611,7 @@ class PySamParser(VcfParser):
       value = value.encode('utf-8')
     return str(value)
 
-  def _encode(self, sample_name):
+  def _lookup_encoded_sample_name(self, sample_name):
     sample_code_hex = self._encoded_sample_names.get(sample_name)
     if not sample_code_hex:
       sample_code_hex = hex(hashing_util.generate_sample_id(sample_name,
@@ -651,7 +650,7 @@ class PySamParser(VcfParser):
       # before settings default phaseset value.
       if phaseset is None and sample.phased and len(genotype) > 1:
         phaseset = DEFAULT_PHASESET_VALUE
-      encoded_name = self._encode(name)
+      encoded_name = self._lookup_encoded_sample_name(name)
       calls.append(VariantCall(encoded_name, genotype, phaseset, info))
 
     return calls

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -47,6 +47,7 @@ DEFAULT_PHASESET_VALUE = vcf_parser.DEFAULT_PHASESET_VALUE
 MISSING_GENOTYPE_VALUE = vcf_parser.MISSING_GENOTYPE_VALUE
 Variant = vcf_parser.Variant
 VariantCall = vcf_parser.VariantCall
+SampleNameEncoding = vcf_parser.SampleNameEncoding
 
 
 class _ToVcfRecordCoder(coders.Coder):
@@ -58,7 +59,6 @@ class _ToVcfRecordCoder(coders.Coder):
     encoded_info = self._encode_variant_info(variant)
     format_keys = self._get_variant_format_keys(variant)
     encoded_calls = self._encode_variant_calls(variant, format_keys)
-
     columns = [
         variant.reference_name,
         None if variant.start is None else variant.start + 1,
@@ -182,15 +182,17 @@ class _VcfSource(filebasedsource.FileBasedSource):
 
   DEFAULT_VCF_READ_BUFFER_SIZE = 65536  # 64kB
 
-  def __init__(self,
-               file_pattern,  # type: str
-               representative_header_lines=None,  # type: List[str]
-               compression_type=CompressionTypes.AUTO,  # type: str
-               buffer_size=DEFAULT_VCF_READ_BUFFER_SIZE,  # type: int
-               validate=True,  # type: bool
-               allow_malformed_records=False,  # type: bool
-               pre_infer_headers=False,  # type: bool
-              ):
+  def __init__(
+      self,
+      file_pattern,  # type: str
+      representative_header_lines=None,  # type: List[str]
+      compression_type=CompressionTypes.AUTO,  # type: str
+      buffer_size=DEFAULT_VCF_READ_BUFFER_SIZE,  # type: int
+      validate=True,  # type: bool
+      allow_malformed_records=False,  # type: bool
+      pre_infer_headers=False,  # type: bool
+      sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH  # type: int
+      ):
     # type: (...) -> None
     super(_VcfSource, self).__init__(file_pattern,
                                      compression_type=compression_type,
@@ -200,6 +202,8 @@ class _VcfSource(filebasedsource.FileBasedSource):
     self._buffer_size = buffer_size
     self._allow_malformed_records = allow_malformed_records
     self._pre_infer_headers = pre_infer_headers
+    self._sample_name_encoding = sample_name_encoding
+
 
   def read_records(self,
                    file_name,  # type: str
@@ -214,6 +218,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
         file_pattern=self._pattern,
         representative_header_lines=self._representative_header_lines,
         pre_infer_headers=self._pre_infer_headers,
+        sample_name_encoding=self._sample_name_encoding,
         buffer_size=self._buffer_size,
         skip_header_lines=0)
 
@@ -229,7 +234,9 @@ class ReadFromBGZF(beam.PTransform):
                input_files,
                representative_header_lines,
                allow_malformed_records,
-               pre_infer_headers):
+               pre_infer_headers,
+               sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH
+              ):
     # type: (List[str], List[str], bool) -> None
     """Initializes the transform.
 
@@ -239,11 +246,16 @@ class ReadFromBGZF(beam.PTransform):
         VCF files.
       allow_malformed_records: If true, malformed records from VCF files will be
         returned as `MalformedVcfRecord` instead of failing the pipeline.
+      pre_infer_headers: If true, drop headers and make sure PySam return the
+        exact data for variants and calls, without type matching.
+      sample_name_encoding: specify whether we want to encode sample_name mainly
+        to deal with same sample_name used across multiple VCF files.
     """
     self._input_files = input_files
     self._representative_header_lines = representative_header_lines
     self._allow_malformed_records = allow_malformed_records
     self._pre_infer_headers = pre_infer_headers
+    self._sample_name_encoding = sample_name_encoding
 
   def _read_records(self, (file_path, block)):
     # type: (Tuple[str, Block]) -> Iterable(Variant)
@@ -255,7 +267,8 @@ class ReadFromBGZF(beam.PTransform):
         self._allow_malformed_records,
         representative_header_lines=self._representative_header_lines,
         splittable_bgzf=True,
-        pre_infer_headers=self._pre_infer_headers)
+        pre_infer_headers=self._pre_infer_headers,
+        sample_name_encoding=self._sample_name_encoding)
 
     for record in record_iterator:
       yield record
@@ -286,6 +299,7 @@ class ReadFromVcf(PTransform):
       validate=True,  # type: bool
       allow_malformed_records=False,  # type: bool
       pre_infer_headers=False,  # type: bool
+      sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -302,6 +316,10 @@ class ReadFromVcf(PTransform):
         underlying file_path's extension will be used to detect the compression.
       validate: flag to verify that the files exist during the pipeline creation
         time.
+      pre_infer_headers: If true, drop headers and make sure PySam return the
+        exact data for variants and calls, without type matching.
+      sample_name_encoding: specify whether we want to encode sample_name mainly
+        to deal with same sample_name used across multiple VCF files
     """
     super(ReadFromVcf, self).__init__(**kwargs)
 
@@ -311,7 +329,8 @@ class ReadFromVcf(PTransform):
         compression_type,
         validate=validate,
         allow_malformed_records=allow_malformed_records,
-        pre_infer_headers=pre_infer_headers)
+        pre_infer_headers=pre_infer_headers,
+        sample_name_encoding=sample_name_encoding)
 
   def expand(self, pvalue):
     return pvalue.pipeline | Read(self._source)
@@ -319,12 +338,14 @@ class ReadFromVcf(PTransform):
 
 def _create_vcf_source(
     file_pattern=None, representative_header_lines=None, compression_type=None,
-    allow_malformed_records=None, pre_infer_headers=False):
+    allow_malformed_records=None, pre_infer_headers=False,
+    sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH):
   return _VcfSource(file_pattern=file_pattern,
                     representative_header_lines=representative_header_lines,
                     compression_type=compression_type,
                     allow_malformed_records=allow_malformed_records,
-                    pre_infer_headers=pre_infer_headers)
+                    pre_infer_headers=pre_infer_headers,
+                    sample_name_encoding=sample_name_encoding)
 
 
 class ReadAllFromVcf(PTransform):
@@ -348,6 +369,7 @@ class ReadAllFromVcf(PTransform):
       compression_type=CompressionTypes.AUTO,  # type: str
       allow_malformed_records=False,  # type: bool
       pre_infer_headers=False,  # type: bool
+      sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -366,6 +388,10 @@ class ReadAllFromVcf(PTransform):
         underlying file_path's extension will be used to detect the compression.
       allow_malformed_records: If true, malformed records from VCF files will be
         returned as :class:`MalformedVcfRecord` instead of failing the pipeline.
+      pre_infer_headers: If true, drop headers and make sure PySam return the
+        exact data for variants and calls, without type matching.
+      sample_name_encoding: specify whether we want to encode sample_name mainly
+        to deal with same sample_name used across multiple VCF files
     """
     super(ReadAllFromVcf, self).__init__(**kwargs)
     source_from_file = partial(
@@ -373,7 +399,8 @@ class ReadAllFromVcf(PTransform):
         representative_header_lines=representative_header_lines,
         compression_type=compression_type,
         allow_malformed_records=allow_malformed_records,
-        pre_infer_headers=pre_infer_headers)
+        pre_infer_headers=pre_infer_headers,
+        sample_name_encoding=sample_name_encoding)
     self._read_all_files = filebasedsource.ReadAllFiles(
         True,  # splittable
         CompressionTypes.AUTO, desired_bundle_size,

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -248,7 +248,7 @@ class ReadFromBGZF(beam.PTransform):
         returned as `MalformedVcfRecord` instead of failing the pipeline.
       pre_infer_headers: If true, drop headers and make sure PySam return the
         exact data for variants and calls, without type matching.
-      sample_name_encoding: specify whether we want to encode sample_name mainly
+      sample_name_encoding: specify how we want to encode sample_name mainly
         to deal with same sample_name used across multiple VCF files.
     """
     self._input_files = input_files
@@ -318,7 +318,7 @@ class ReadFromVcf(PTransform):
         time.
       pre_infer_headers: If true, drop headers and make sure PySam return the
         exact data for variants and calls, without type matching.
-      sample_name_encoding: specify whether we want to encode sample_name mainly
+      sample_name_encoding: specify how we want to encode sample_name mainly
         to deal with same sample_name used across multiple VCF files
     """
     super(ReadFromVcf, self).__init__(**kwargs)
@@ -390,7 +390,7 @@ class ReadAllFromVcf(PTransform):
         returned as :class:`MalformedVcfRecord` instead of failing the pipeline.
       pre_infer_headers: If true, drop headers and make sure PySam return the
         exact data for variants and calls, without type matching.
-      sample_name_encoding: specify whether we want to encode sample_name mainly
+      sample_name_encoding: specify how we want to encode sample_name mainly
         to deal with same sample_name used across multiple VCF files
     """
     super(ReadAllFromVcf, self).__init__(**kwargs)

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -151,9 +151,9 @@ class BigQueryWriteOptions(VariantTransformsOptions):
         default=vcf_parser.SampleNameEncoding.WITHOUT_FILE_PATH.name,
         choices=[encoding.name for encoding in vcf_parser.SampleNameEncoding],
         help=('Choose the way sample ID should be hashed. if `{}` is supplied, '
-              'sample_id will be [sample_name] (default); alternatively, if '
-              '`{}` is supplied, sample_id will be hashed from '
-              '[file_name, sample_id]'.format(
+              'sample_id will be hash value of [sample_name] (default); '
+              'alternatively, if `{}` is supplied, sample_id will be hashed '
+              'from [file_name, sample_id]'.format(
                   vcf_parser.SampleNameEncoding.WITHOUT_FILE_PATH.name,
                   vcf_parser.SampleNameEncoding.WITH_FILE_PATH.name)))
 

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -77,11 +77,6 @@ def parse_args(argv, command_line_options):
   if hasattr(known_args, 'input_pattern') or hasattr(known_args, 'input_file'):
     known_args.all_patterns = _get_all_patterns(
         known_args.input_pattern, known_args.input_file)
-  if (hasattr(known_args, 'samples_span_multiple_files') and
-      known_args.samples_span_multiple_files):
-    known_args.sample_name_encoding = SampleNameEncoding.WITHOUT_FILE_PATH
-  else:
-    known_args.sample_name_encoding = SampleNameEncoding.WITH_FILE_PATH
   return known_args, pipeline_args
 
 

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_filter_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_filter_to_calls.json
@@ -23,7 +23,7 @@
         "query": [
           "SELECT COUNT(0) AS num_rows ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00001' ",
+          "WHERE start_position = 14369 AND call.name ='0x1447114f17e91025L' ",
           "AND 'q10' IN UNNEST (call.filter)"
         ],
         "expected_result": {"num_rows": 1}
@@ -32,7 +32,7 @@
         "query": [
           "SELECT COUNT(0) AS num_rows ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00002' ",
+          "WHERE start_position = 14369 AND call.name ='0x7588a624d89b0eb2L' ",
           "AND 'q10' IN UNNEST (call.filter)"
         ],
         "expected_result": {"num_rows": 1}
@@ -41,7 +41,7 @@
         "query": [
           "SELECT COUNT(0) AS num_rows ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00003' ",
+          "WHERE start_position = 14369 AND call.name ='0x276d7d35dbcc18a6L' ",
           "AND 'PASS' IN UNNEST (call.filter)"
         ],
         "expected_result": {"num_rows": 1}
@@ -50,7 +50,7 @@
         "query": [
           "SELECT COUNT(0) AS num_rows ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00004' ",
+          "WHERE start_position = 14369 AND call.name ='0x65101f53be02557dL' ",
           "AND 'PASS' IN UNNEST (call.filter)"
         ],
         "expected_result": {"num_rows": 1}

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_quality_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_quality_to_calls.json
@@ -23,7 +23,7 @@
         "query": [
           "SELECT call.quality AS quality ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00001'"
+          "WHERE start_position = 14369 AND call.name ='0x1447114f17e91025L'"
         ],
         "expected_result": {"quality": 10.0}
       },
@@ -31,7 +31,7 @@
         "query": [
           "SELECT call.quality AS quality ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00002'"
+          "WHERE start_position = 14369 AND call.name ='0x7588a624d89b0eb2L'"
         ],
         "expected_result": {"quality": 10.0}
       },
@@ -39,7 +39,7 @@
         "query": [
           "SELECT call.quality AS quality ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00003'"
+          "WHERE start_position = 14369 AND call.name ='0x276d7d35dbcc18a6L'"
         ],
         "expected_result": {"quality": 29.0}
       },
@@ -47,7 +47,7 @@
         "query": [
           "SELECT call.quality AS quality ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00004'"
+          "WHERE start_position = 14369 AND call.name ='0x65101f53be02557dL'"
         ],
         "expected_result": {"quality": 30.0}
       }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_info_keys_to_move_to_calls_regex.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_info_keys_to_move_to_calls_regex.json
@@ -23,7 +23,7 @@
         "query": [
           "SELECT call.NS AS NS ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00001'"
+          "WHERE start_position = 14369 AND call.name ='0x1447114f17e91025L'"
         ],
         "expected_result": {"NS": 2}
       },
@@ -31,7 +31,7 @@
         "query": [
           "SELECT call.NS AS NS ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00002'"
+          "WHERE start_position = 14369 AND call.name ='0x7588a624d89b0eb2L'"
         ],
         "expected_result": {"NS": 2}
       },
@@ -39,7 +39,7 @@
         "query": [
           "SELECT call.NS AS NS ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00003'"
+          "WHERE start_position = 14369 AND call.name ='0x276d7d35dbcc18a6L'"
         ],
         "expected_result": {"NS": 1}
       },
@@ -47,7 +47,7 @@
         "query": [
           "SELECT call.NS AS NS ",
           "FROM {TABLE_NAME} AS t, t.call as call ",
-          "WHERE start_position = 14369 AND call.name ='NA00004'"
+          "WHERE start_position = 14369 AND call.name ='0x65101f53be02557dL'"
         ],
         "expected_result": {"NS": 1}
       }

--- a/gcp_variant_transforms/transforms/sample_info_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_bigquery.py
@@ -27,7 +27,7 @@ SampleNameEncoding = vcf_parser.SampleNameEncoding
 class ConvertSampleInfoToRow(beam.DoFn):
   """Extracts sample info from `VcfHeader` and converts it to a BigQuery row."""
 
-  def __init__(self, sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH):
+  def __init__(self, sample_name_encoding):
     # type: (int) -> None
     self._sample_name_encoding = sample_name_encoding
 
@@ -52,8 +52,7 @@ class ConvertSampleInfoToRow(beam.DoFn):
 class SampleInfoToBigQuery(beam.PTransform):
   """Writes sample info to BigQuery."""
 
-  def __init__(self, output_table_prefix, append=False,
-               sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH):
+  def __init__(self, output_table_prefix, sample_name_encoding, append=False):
     # type: (str, Dict[str, str], bool, int) -> None
     """Initializes the transform.
 

--- a/gcp_variant_transforms/transforms/sample_info_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_bigquery_test.py
@@ -22,6 +22,7 @@ from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 
 from gcp_variant_transforms.beam_io import vcf_header_io
+from gcp_variant_transforms.beam_io.vcf_parser import SampleNameEncoding
 from gcp_variant_transforms.libs import sample_info_table_schema_generator
 from gcp_variant_transforms.transforms import sample_info_to_bigquery
 
@@ -56,7 +57,7 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
         | transforms.Create([vcf_header_1, vcf_header_2])
         | 'ConvertToRow'
         >> transforms.ParDo(sample_info_to_bigquery.ConvertSampleInfoToRow(
-            False), ))
+            SampleNameEncoding.WITH_FILE_PATH), ))
 
     assert_that(bigquery_rows, equal_to(expected_rows))
     pipeline.run()
@@ -86,7 +87,7 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
         | transforms.Create([vcf_header_1, vcf_header_2])
         | 'ConvertToRow'
         >> transforms.ParDo(sample_info_to_bigquery.ConvertSampleInfoToRow(
-            True), ))
+            SampleNameEncoding.WITHOUT_FILE_PATH), ))
 
     assert_that(bigquery_rows, equal_to(expected_rows))
     pipeline.run()

--- a/gcp_variant_transforms/transforms/sample_info_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_bigquery_test.py
@@ -56,7 +56,7 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
         | transforms.Create([vcf_header_1, vcf_header_2])
         | 'ConvertToRow'
         >> transforms.ParDo(sample_info_to_bigquery.ConvertSampleInfoToRow(
-            ), False))
+            False), ))
 
     assert_that(bigquery_rows, equal_to(expected_rows))
     pipeline.run()
@@ -86,7 +86,7 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
         | transforms.Create([vcf_header_1, vcf_header_2])
         | 'ConvertToRow'
         >> transforms.ParDo(sample_info_to_bigquery.ConvertSampleInfoToRow(
-            ), True))
+            True), ))
 
     assert_that(bigquery_rows, equal_to(expected_rows))
     pipeline.run()

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -397,7 +397,7 @@ def _create_sample_info_table(pipeline,  # type: beam.Pipeline
        sample_info_to_bigquery.SampleInfoToBigQuery(
            known_args.output_table,
            known_args.append,
-           known_args.samples_span_multiple_files))
+           known_args.sample_name_encoding))
 
 
 def run(argv=None):

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -109,7 +109,8 @@ def _read_variants(all_patterns,  # type: List[str]
       pipeline_mode,
       known_args.allow_malformed_records,
       representative_header_lines,
-      pre_infer_headers=pre_infer_headers)
+      pre_infer_headers=pre_infer_headers,
+      sample_name_encoding=known_args.sample_name_encoding)
 
 
 def _get_variant_merge_strategy(known_args  # type: argparse.Namespace

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -398,8 +398,8 @@ def _create_sample_info_table(pipeline,  # type: beam.Pipeline
   _ = (headers | 'SampleInfoToBigQuery' >>
        sample_info_to_bigquery.SampleInfoToBigQuery(
            known_args.output_table,
-           known_args.append,
-           SampleNameEncoding[known_args.sample_name_encoding]))
+           SampleNameEncoding[known_args.sample_name_encoding],
+           known_args.append))
 
 
 def run(argv=None):

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -45,6 +45,7 @@ from apache_beam.io import filesystems
 from apache_beam.options import pipeline_options
 
 from gcp_variant_transforms import pipeline_common
+from gcp_variant_transforms.beam_io import vcf_parser
 from gcp_variant_transforms.libs import metrics_util
 from gcp_variant_transforms.libs import processed_variant
 from gcp_variant_transforms.libs import schema_converter
@@ -89,6 +90,7 @@ _SHARD_VCF_FILES_JOB_NAME = 'shard-files'
 _BQ_SCHEMA_FILE_SUFFIX = 'schema.json'
 _SHARDS_FOLDER = 'shards'
 _GCS_RECURSIVE_WILDCARD = '**'
+SampleNameEncoding = vcf_parser.SampleNameEncoding
 
 
 def _read_variants(all_patterns,  # type: List[str]
@@ -110,7 +112,7 @@ def _read_variants(all_patterns,  # type: List[str]
       known_args.allow_malformed_records,
       representative_header_lines,
       pre_infer_headers=pre_infer_headers,
-      sample_name_encoding=known_args.sample_name_encoding)
+      sample_name_encoding=SampleNameEncoding[known_args.sample_name_encoding])
 
 
 def _get_variant_merge_strategy(known_args  # type: argparse.Namespace
@@ -397,7 +399,7 @@ def _create_sample_info_table(pipeline,  # type: beam.Pipeline
        sample_info_to_bigquery.SampleInfoToBigQuery(
            known_args.output_table,
            known_args.append,
-           known_args.sample_name_encoding))
+           SampleNameEncoding[known_args.sample_name_encoding]))
 
 
 def run(argv=None):


### PR DESCRIPTION
This commit needs to be followed up with removing hex-ing of the hash and storing sample IDs as integers instead.