### PR TITLE
Bq mk table

### DIFF
--- a/cloudbuild_CI.yaml
+++ b/cloudbuild_CI.yaml
@@ -56,4 +56,4 @@ steps:
       # - '--gs_dir bashir-variant_integration_test_runs'
 images:
   - 'gcr.io/${PROJECT_ID}/gcp-variant-transforms:${COMMIT_SHA}'
-timeout: 180m
+timeout: 200m

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -29,7 +29,7 @@ from gcp_variant_transforms.beam_io import vcfio
 
 _VcfHeaderTypeConstants = vcf_header_io.VcfHeaderFieldTypeConstants
 
-_NUM_BQ_RANGE_PARTITIONS = 4000
+_MAX_BQ_NUM_PARTITIONS = 4000
 _TOTAL_BASE_PAIRS_SIG_DIGITS = 4
 _PARTITION_SIZE_SIG_DIGITS = 1
 
@@ -317,16 +317,38 @@ def _get_merged_field_schemas(
 
 
 def calculate_optimal_partition_size(total_base_pairs):
-  # These two operations adds [10^4, 2 * 10^4) buffer to total_base_pairs.
+  # type: (int) -> Tuple[int, int]
+  """Calculates the optimal partition size given total_base_pairs value.
+
+  BQ allows up to 4000 integer range partitions. This method divides
+  [0, total_base_pairs] range into 3999 partitions. Every value outside of this
+  range will fall into the 4000th partition. Note this partitioning method
+  assumes variants are distributed uniformly.
+
+  Since given total_base_pairs might be a lower estimate, we add a little extra
+  buffer to the given value to avoid a situation where too many rows fall
+  into the 4000th partition. The size of added buffer is controlled by the
+  value of two consts:
+    * _TOTAL_BASE_PAIRS_SIG_DIGITS is set to 4 which adds [10^4, 2 * 10^4)
+    * _PARTITION_SIZE_SIG_DIGITS is set to 1 which adds [0, 10i^1 * 3999)
+  In total we add [10^4, 10 * 3999 + 2 * 10^4) buffer to total_base_pairs.
+
+  Args:
+    total_base_paris: The number of total base pairs expected in the BQ table.
+
+  Returns:
+    A tuple (partition size, partition size * 3999).
+  """
+  # These two operations add [10^4, 2 * 10^4) buffer to total_base_pairs.
   total_base_pairs += math.pow(10, _TOTAL_BASE_PAIRS_SIG_DIGITS)
   total_base_pairs = (
       math.ceil(total_base_pairs / math.pow(10, _TOTAL_BASE_PAIRS_SIG_DIGITS)) *
       math.pow(10, _TOTAL_BASE_PAIRS_SIG_DIGITS))
   # We use 4000 - 1 = 3999 partitions just to avoid hitting the BQ limits.
-  partition_size = total_base_pairs / (_NUM_BQ_RANGE_PARTITIONS - 1)
+  partition_size = total_base_pairs / (_MAX_BQ_NUM_PARTITIONS - 1)
   # This operation adds another [0, 10 * 3999) buffer to the total_base_pairs.
   partition_size_round_up = int(
       math.ceil(partition_size / pow(10, _PARTITION_SIZE_SIG_DIGITS)) *
       math.pow(10, _PARTITION_SIZE_SIG_DIGITS))
   return (partition_size_round_up,
-          partition_size_round_up * (_NUM_BQ_RANGE_PARTITIONS - 1))
+          partition_size_round_up * (_MAX_BQ_NUM_PARTITIONS - 1))

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -325,7 +325,7 @@ def calculate_optimal_partition_size(total_base_pairs):
   # We use 4000 - 1 = 3999 partitions just to avoid hitting the BQ limits.
   partition_size = total_base_pairs / (_NUM_BQ_RANGE_PARTITIONS - 1)
   # This operation adds another [0, 10 * 3999) buffer to the total_base_pairs.
-  partition_size_round_up = (
+  partition_size_round_up = int(
       math.ceil(partition_size / pow(10, _PARTITION_SIZE_SIG_DIGITS)) *
       math.pow(10, _PARTITION_SIZE_SIG_DIGITS))
   return (partition_size_round_up,

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -316,7 +316,7 @@ def _get_merged_field_schemas(
   return merged_field_schemas
 
 
-def calculate_optimize_partition_size(total_base_pairs):
+def calculate_optimal_partition_size(total_base_pairs):
   # These two operations adds [10^4, 2 * 10^4) buffer to total_base_pairs.
   total_base_pairs += math.pow(10, _TOTAL_BASE_PAIRS_SIG_DIGITS)
   total_base_pairs = (
@@ -330,4 +330,3 @@ def calculate_optimize_partition_size(total_base_pairs):
       math.pow(10, _PARTITION_SIZE_SIG_DIGITS))
   return (partition_size_round_up,
           partition_size_round_up * (_NUM_BQ_RANGE_PARTITIONS - 1))
-

--- a/gcp_variant_transforms/libs/bigquery_util_test.py
+++ b/gcp_variant_transforms/libs/bigquery_util_test.py
@@ -478,5 +478,5 @@ class BigqueryUtilTest(unittest.TestCase):
               total_base_pairs))
       self.assertEqual(expected_partition_size, partition_size)
       self.assertEqual(expected_partition_size *
-                       (bigquery_util._NUM_BQ_RANGE_PARTITIONS - 1),
+                       (bigquery_util._MAX_BQ_NUM_PARTITIONS - 1),
                        total_base_pairs_enlarged)

--- a/gcp_variant_transforms/libs/bigquery_util_test.py
+++ b/gcp_variant_transforms/libs/bigquery_util_test.py
@@ -460,21 +460,21 @@ class BigqueryUtilTest(unittest.TestCase):
                       bigquery_util.raise_error_if_dataset_not_exists,
                       client, 'project', 'dataset')
 
-  def test_calculate_optimize_partition_size(self):
+  def test_calculate_optimal_partition_size(self):
     total_base_pairs_to_expected_partition_size = {
-      39980000: 10000,
-      (39980000 - 1): 10000,
-      (39980000 - 9999): 10000,
-      39990000: 10010,
-      40000000: 10010,
-      40010000: 10010,
-      40020000: 10020,
-      40030000: 10020,
+        39980000: 10000,
+        (39980000 - 1): 10000,
+        (39980000 - 9999): 10000,
+        39990000: 10010,
+        40000000: 10010,
+        40010000: 10010,
+        40020000: 10020,
+        40030000: 10020,
     }
     for total_base_pairs, expected_partition_size in (
         total_base_pairs_to_expected_partition_size.items()):
       (partition_size, total_base_pairs_enlarged) = (
-          bigquery_util.calculate_optimize_partition_size(
+          bigquery_util.calculate_optimal_partition_size(
               total_base_pairs))
       self.assertEqual(expected_partition_size, partition_size)
       self.assertEqual(expected_partition_size *

--- a/gcp_variant_transforms/libs/bigquery_util_test.py
+++ b/gcp_variant_transforms/libs/bigquery_util_test.py
@@ -459,3 +459,24 @@ class BigqueryUtilTest(unittest.TestCase):
     self.assertRaises(exceptions.HttpError,
                       bigquery_util.raise_error_if_dataset_not_exists,
                       client, 'project', 'dataset')
+
+  def test_calculate_optimize_partition_size(self):
+    total_base_pairs_to_expected_partition_size = {
+      39980000: 10000,
+      (39980000 - 1): 10000,
+      (39980000 - 9999): 10000,
+      39990000: 10010,
+      40000000: 10010,
+      40010000: 10010,
+      40020000: 10020,
+      40030000: 10020,
+    }
+    for total_base_pairs, expected_partition_size in (
+        total_base_pairs_to_expected_partition_size.items()):
+      (partition_size, total_base_pairs_enlarged) = (
+          bigquery_util.calculate_optimize_partition_size(
+              total_base_pairs))
+      self.assertEqual(expected_partition_size, partition_size)
+      self.assertEqual(expected_partition_size *
+                       (bigquery_util._NUM_BQ_RANGE_PARTITIONS - 1),
+                       total_base_pairs_enlarged)

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -209,7 +209,6 @@ class BigQueryWriteOptions(VariantTransformsOptions):
               'For instance, [0, None, 1] will become '
               '[0, `null_numeric_value_replacement`, 1].'))
 
-
   def validate(self, parsed_args, client=None):
     # type: (argparse.Namespace, bigquery.BigqueryV2) -> None
     if not parsed_args.output_table and parsed_args.output_avro_path:

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -209,6 +209,7 @@ class BigQueryWriteOptions(VariantTransformsOptions):
               'For instance, [0, None, 1] will become '
               '[0, `null_numeric_value_replacement`, 1].'))
 
+
   def validate(self, parsed_args, client=None):
     # type: (argparse.Namespace, bigquery.BigqueryV2) -> None
     if not parsed_args.output_table and parsed_args.output_avro_path:

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -339,10 +339,10 @@ BQ_CREATE_PARTITIONED_TABLE = (
     '--clustering_fields=start_position,end_position '
     '{FULL_TABLE_ID} {SCHEMA_JSON}')
 
-def make_output_table_if_needed(known_args, full_table_id, total_base_pairs):
+def create_output_table_if_needed(known_args, full_table_id, total_base_pairs):
   if not known_args.append:
     (partition_size, total_base_pairs_enlarged) = (
-        bigquery_util.calculate_optimize_partition_size(total_base_pairs))
+        bigquery_util.calculate_optimal_partition_size(total_base_pairs))
     bq_command = BQ_CREATE_PARTITIONED_TABLE.format(
         TOTAL_BASE_PAIRS=total_base_pairs_enlarged,
         PARTITION_SIZE=partition_size,
@@ -352,4 +352,4 @@ def make_output_table_if_needed(known_args, full_table_id, total_base_pairs):
     if result != 0:
       raise ValueError(
           'Failed to create a bigquery table using "{}" command.'.format(
-              bq_make_command))
+              bq_command))

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -332,24 +332,34 @@ def generate_unique_name(job_name):
                    str(uuid.uuid4())])
 
 
-
-BQ_CREATE_PARTITIONED_TABLE = (
+BQ_CREATE_PARTITIONED_TABLE_COMMAND = (
     'bq mk --table '
     '--range_partitioning=start_position,0,{TOTAL_BASE_PAIRS},{PARTITION_SIZE} '
     '--clustering_fields=start_position,end_position '
-    '{FULL_TABLE_ID} {SCHEMA_JSON}')
+    '{FULL_TABLE_ID} {SCHEMA_FILE_PATH}')
 
-def create_output_table_if_needed(known_args, full_table_id, total_base_pairs):
-  if not known_args.append:
-    (partition_size, total_base_pairs_enlarged) = (
-        bigquery_util.calculate_optimal_partition_size(total_base_pairs))
-    bq_command = BQ_CREATE_PARTITIONED_TABLE.format(
-        TOTAL_BASE_PAIRS=total_base_pairs_enlarged,
-        PARTITION_SIZE=partition_size,
-        FULL_TABLE_ID=full_table_id,
-        SCHEMA_JSON=known_args.schema_json)
-    result = os.system(bq_command)
-    if result != 0:
-      raise ValueError(
-          'Failed to create a bigquery table using "{}" command.'.format(
-              bq_command))
+def create_output_table(full_table_id, total_base_pairs, schema_file_path):
+  # type: (str, int, str) -> None
+  """Creates an integer range partitioned table using `bq mk table...` command.
+
+  Since beam.io.BigQuerySink is unable to create an integer range partition
+  we use `bq mk table...` to achieve this goal. Note that this command runs on
+  the worker that monitors the Dataflow job.
+
+  Args:
+    full_table_id: for example: projet:dataset.table_base_name__chr1
+    total_base_pairs: the maximum expected value of `start_position` column.
+    schema_file_path: a json file that contains the schema of the table.
+  """
+  (partition_size, total_base_pairs_enlarged) = (
+      bigquery_util.calculate_optimal_partition_size(total_base_pairs))
+  bq_command = BQ_CREATE_PARTITIONED_TABLE_COMMAND.format(
+      TOTAL_BASE_PAIRS=total_base_pairs_enlarged,
+      PARTITION_SIZE=partition_size,
+      FULL_TABLE_ID=full_table_id,
+      SCHEMA_FILE_PATH=schema_file_path)
+  result = os.system(bq_command)
+  if result != 0:
+    raise ValueError(
+        'Failed to create a bigquery table using "{}" command.'.format(
+            bq_command))

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -49,6 +49,12 @@ _LARGE_DATA_THRESHOLD = 50000
 _DATAFLOW_RUNNER_ARG_VALUE = 'DataflowRunner'
 SampleNameEncoding = vcf_parser.SampleNameEncoding
 
+_BQ_CREATE_PARTITIONED_TABLE_COMMAND = (
+    'bq mk --table '
+    '--range_partitioning=start_position,0,{TOTAL_BASE_PAIRS},{PARTITION_SIZE} '
+    '--clustering_fields=start_position,end_position '
+    '{FULL_TABLE_ID} {SCHEMA_FILE_PATH}')
+
 
 class PipelineModes(enum.Enum):
   """An Enum specifying the mode of the pipeline based on the data size."""
@@ -332,12 +338,6 @@ def generate_unique_name(job_name):
                    str(uuid.uuid4())])
 
 
-BQ_CREATE_PARTITIONED_TABLE_COMMAND = (
-    'bq mk --table '
-    '--range_partitioning=start_position,0,{TOTAL_BASE_PAIRS},{PARTITION_SIZE} '
-    '--clustering_fields=start_position,end_position '
-    '{FULL_TABLE_ID} {SCHEMA_FILE_PATH}')
-
 def create_output_table(full_table_id, total_base_pairs, schema_file_path):
   # type: (str, int, str) -> None
   """Creates an integer range partitioned table using `bq mk table...` command.
@@ -353,7 +353,7 @@ def create_output_table(full_table_id, total_base_pairs, schema_file_path):
   """
   (partition_size, total_base_pairs_enlarged) = (
       bigquery_util.calculate_optimal_partition_size(total_base_pairs))
-  bq_command = BQ_CREATE_PARTITIONED_TABLE_COMMAND.format(
+  bq_command = _BQ_CREATE_PARTITIONED_TABLE_COMMAND.format(
       TOTAL_BASE_PAIRS=total_base_pairs_enlarged,
       PARTITION_SIZE=partition_size,
       FULL_TABLE_ID=full_table_id,

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -37,6 +37,7 @@ from gcp_variant_transforms.beam_io import vcf_estimate_io
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.beam_io import vcf_parser
 from gcp_variant_transforms.beam_io import vcfio
+from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.transforms import fusion_break
 from gcp_variant_transforms.transforms import merge_headers
 
@@ -329,3 +330,26 @@ def generate_unique_name(job_name):
   return '-'.join([job_name,
                    datetime.now().strftime('%Y%m%d-%H%M%S'),
                    str(uuid.uuid4())])
+
+
+
+BQ_CREATE_PARTITIONED_TABLE = (
+    'bq mk --table '
+    '--range_partitioning=start_position,0,{TOTAL_BASE_PAIRS},{PARTITION_SIZE} '
+    '--clustering_fields=start_position,end_position '
+    '{FULL_TABLE_ID} {SCHEMA_JSON}')
+
+def make_output_table_if_needed(known_args, full_table_id, total_base_pairs):
+  if not known_args.append:
+    (partition_size, total_base_pairs_enlarged) = (
+        bigquery_util.calculate_optimize_partition_size(total_base_pairs))
+    bq_command = BQ_CREATE_PARTITIONED_TABLE.format(
+        TOTAL_BASE_PAIRS=total_base_pairs_enlarged,
+        PARTITION_SIZE=partition_size,
+        FULL_TABLE_ID=full_table_id,
+        SCHEMA_JSON=known_args.schema_json)
+    result = os.system(bq_command)
+    if result != 0:
+      raise ValueError(
+          'Failed to create a bigquery table using "{}" command.'.format(
+              bq_make_command))

--- a/gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml
@@ -1,3 +1,8 @@
+# Every total_base_pairs value is set to 249,240,615 (max of all chromosomes)
+# so that all output tables will have the same integer range partitions.
+# This is required because in our integration tests we use wildcards to query
+# multiple tables simultaneously. For example:
+#         SELECT count(1) FROM `projoct_id:dataset_id:base_table_name__*`
 -  output_table:
      table_name_suffix: "chr1"
      regions:

--- a/gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml
@@ -1,0 +1,154 @@
+-  output_table:
+     table_name_suffix: "chr1"
+     regions:
+       - "chr1"
+       - "1"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr2"
+     regions:
+       - "chr2"
+       - "2"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr3"
+     regions:
+       - "chr3"
+       - "3"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr4"
+     regions:
+       - "chr4"
+       - "4"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr5"
+     regions:
+       - "chr5"
+       - "5"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr6"
+     regions:
+       - "chr6"
+       - "6"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr7"
+     regions:
+       - "chr7"
+       - "7"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr8"
+     regions:
+       - "chr8"
+       - "8"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr9"
+     regions:
+       - "chr9"
+       - "9"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr10"
+     regions:
+       - "chr10"
+       - "10"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr11"
+     regions:
+       - "chr11"
+       - "11"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr12"
+     regions:
+       - "chr12"
+       - "12"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr13"
+     regions:
+       - "chr13"
+       - "13"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr14"
+     regions:
+       - "chr14"
+       - "14"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr15"
+     regions:
+       - "chr15"
+       - "15"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr16"
+     regions:
+       - "chr16"
+       - "16"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr17"
+     regions:
+       - "chr17"
+       - "17"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr18"
+     regions:
+       - "chr18"
+       - "18"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr19"
+     regions:
+       - "chr19"
+       - "19"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr20"
+     regions:
+       - "chr20"
+       - "20"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr21"
+     regions:
+       - "chr21"
+       - "21"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chr22"
+     regions:
+       - "chr22"
+       - "22"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chrX"
+     regions:
+       - "chrX"
+       - "chrx"
+       - "X"
+       - "x"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "chrY"
+     regions:
+       - "chrY"
+       - "chry"
+       - "Y"
+       - "y"
+     total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "residual"
+     regions:
+       - "residual"
+     total_base_pairs: 249,240,615
+

--- a/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
@@ -119,7 +119,7 @@ class QueryAssertion(object):
 
   def run_assertion(self):
     query_job = self._client.query(self._query)
-    iterator = query_job.result(timeout=60)
+    iterator = query_job.result(timeout=180)
     rows = list(iterator)
     if len(rows) != 1:
       raise run_tests_common.TestCaseFailure(

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
@@ -8,8 +8,8 @@
     "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-64",
-    "max_num_workers": "64",
-    "num_workers": "20",
+    "max_num_workers": "96",
+    "num_workers": "32",
     "num_bigquery_write_shards": "2",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://genomics-public-data/1000-genomes/vcf/*.vcf",
     "infer_headers": "True",
     "allow_incompatible_records": "True",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-64",
     "max_num_workers": "64",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/option_optimize_for_large_inputs.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/large_tests/valid-70000-copies/**.vcf",
     "variant_merge_strategy": "MOVE_TO_CALLS",
     "optimize_for_large_inputs": true,
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-16",
     "max_num_workers": "20",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_no_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_no_merge.json
@@ -3,12 +3,12 @@
     "test_name": "platinum-no-merge",
     "table_name": "platinum_no_merge",
     "input_pattern": "gs://genomics-public-data/platinum-genomes/vcf/*.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-16",
     "max_num_workers": "20",
     "num_workers": "20",
-    "num_bigquery_write_shards": "20",
+    "num_bigquery_write_shards": "2",
     "assertion_configs": [
       {
         "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_no_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_no_merge.json
@@ -5,10 +5,9 @@
     "input_pattern": "gs://genomics-public-data/platinum-genomes/vcf/*.vcf",
     "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
-    "worker_machine_type": "n1-standard-16",
+    "worker_machine_type": "n1-standard-64",
     "max_num_workers": "20",
     "num_workers": "20",
-    "num_bigquery_write_shards": "2",
     "assertion_configs": [
       {
         "query": ["NUM_ROWS_QUERY"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_with_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/platinum_with_merge.json
@@ -3,7 +3,7 @@
     "test_name": "platinum-with-merge",
     "table_name": "platinum_with_merge",
     "input_pattern": "gs://genomics-public-data/platinum-genomes/vcf/*.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "variant_merge_strategy": "MOVE_TO_CALLS",
     "worker_machine_type": "n1-standard-16",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/test_non_splittable_gzip.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/test_non_splittable_gzip.json
@@ -3,7 +3,7 @@
     "test_name": "test-non-splittable-gzip",
     "table_name": "test_non_splittable_gzip",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/large_tests/non-splittable-gzip/**.bgz",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/gnomad_genomes_GRCh37_chrX_head2500.vcf",
     "annotation_fields": "CSQ",
     "vep_assembly": "GRCh37",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh38_chrX_head2500_run_vep_from_file.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh38_chrX_head2500_run_vep_from_file.json
@@ -5,7 +5,7 @@
     "input_file": "gs://gcp-variant-transforms-testfiles/small_tests/input_files/gnomad_input",
     "annotation_fields": "CSQ",
     "vep_assembly": "GRCh37",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
@@ -4,7 +4,7 @@
     "table_name": "platinum_NA12877_hg38_10K_lines_run_vep",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/platinum_NA12877_hg38_10K_lines_manual_vep_orig_output.vcf",
     "annotation_fields": "CSQ",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "infer_annotation_types": "True",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep_with_gc.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep_with_gc.json
@@ -4,7 +4,7 @@
     "table_name": "platinum_NA12877_hg38_10K_lines_run_vep_with_gc",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/platinum_NA12877_hg38_10K_lines_manual_vep_orig_output.vcf",
     "annotation_fields": "CSQ",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "infer_annotation_types": "True",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_no_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_no_merge.json
@@ -3,7 +3,7 @@
     "test_name": "test-1000-copies-of-valid-4-2-no-merge",
     "table_name": "test_1000_copies_of_valid_4_2_no_merge",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/medium_tests/valid-1000-copies/**.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-16",
     "max_num_workers": "20",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_with_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_with_merge.json
@@ -4,7 +4,7 @@
     "table_name": "test_1000_copies_of_valid_4_2_with_merge",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/medium_tests/valid-1000-copies/**.vcf",
     "variant_merge_strategy": "MOVE_TO_CALLS",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-16",
     "max_num_workers": "20",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding.json
@@ -4,7 +4,7 @@
     "table_name": "test_annotation_pipeline_from_file_with_sharding",
     "input_file": "gs://gcp-variant-transforms-testfiles/small_tests/input_files/combine_input",
     "vep_assembly": "GRCh37",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_without_sharding.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_without_sharding.json
@@ -4,7 +4,7 @@
     "table_name": "test_annotation_pipeline_from_file_without_sharding",
     "input_file": "gs://gcp-variant-transforms-testfiles/small_tests/input_files/combine_input",
     "vep_assembly": "GRCh37",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "run_annotation_pipeline": "True",
     "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_splittable_gzip.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_splittable_gzip.json
@@ -3,7 +3,7 @@
     "test_name": "test-splittable-gzip",
     "table_name": "test_splittable_gzip",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/medium_tests/splittable-gzip/**.bgz",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/combine_from_multiple_inputs.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/combine_from_multiple_inputs.json
@@ -4,7 +4,7 @@
     "table_name": "combine_from_multiple_inputs",
     "input_file": "gs://gcp-variant-transforms-testfiles/small_tests/input_files/combine_input",
     "allow_incompatible_records": "True",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/incompatible_field_value.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/incompatible_field_value.json
@@ -4,7 +4,7 @@
     "table_name": "incompatible_field_value",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/incompatible-field-value.vcf",
     "allow_incompatible_records": "True",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/infer_header_fields.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/infer_header_fields.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/infer-header-fields.vcf",
     "infer_headers": "True",
     "allow_incompatible_records": "True",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_filter_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_filter_to_calls.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/merge/*.vcf",
     "variant_merge_strategy": "MOVE_TO_CALLS",
     "copy_filter_to_calls": true,
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_quality_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_quality_to_calls.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/merge/*.vcf",
     "variant_merge_strategy": "MOVE_TO_CALLS",
     "copy_quality_to_calls": true,
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_info_keys_to_move_to_calls_regex.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_info_keys_to_move_to_calls_regex.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/merge/*.vcf",
     "variant_merge_strategy": "MOVE_TO_CALLS",
     "info_keys_to_move_to_calls_regex": "^NS$",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_move_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_move_to_calls.json
@@ -3,7 +3,7 @@
     "test_name": "merge-option-move-to-calls",
     "table_name": "merge_option_move_to_calls",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/merge/*.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "variant_merge_strategy": "MOVE_TO_CALLS",
     "assertion_configs": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_none.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_none.json
@@ -3,7 +3,7 @@
     "test_name": "merge-option-none",
     "table_name": "merge_option_none",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/merge/*.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_allow_malformed_records.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_allow_malformed_records.json
@@ -4,7 +4,7 @@
     "table_name": "option_allow_malformed_records",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/invalid-4.0-POS-empty.vcf",
     "allow_malformed_records": true,
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_allow_malformed_records_alternate_mismatch.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_allow_malformed_records_alternate_mismatch.json
@@ -4,7 +4,7 @@
     "table_name": "option_allow_malformed_records_alternate_mismatch",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/invalid-4.2-AF-mismatch.vcf",
     "allow_malformed_records": true,
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_null_numeric_value_replacement.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_null_numeric_value_replacement.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf",
     "null_numeric_value_replacement": 100000,
     "split_alternate_allele_info_fields": false,
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_representative_header_file.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_representative_header_file.json
@@ -4,7 +4,7 @@
     "table_name": "option_representative_header_file",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/invalid-4.0-AF-field-removed.vcf",
     "representative_header_file": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_split_alternate_allele_info_fields.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_split_alternate_allele_info_fields.json
@@ -4,7 +4,7 @@
     "table_name": "valid_4_2_split_alternate_allele_info_fields",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf",
     "split_alternate_allele_info_fields": false,
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_update_schema_on_append.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_update_schema_on_append.json
@@ -3,7 +3,7 @@
     "test_name": "option-update-schema-on-append-step-1",
     "table_name": "option_update_schema_on_append",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "assertion_configs": [
       {
@@ -24,7 +24,7 @@
     "test_name": "option-update-schema-on-append-step-2",
     "table_name": "option_update_schema_on_append",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "append": true,
     "update_schema": true,

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_NA12877_hg38_10K_lines.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_NA12877_hg38_10K_lines.json
@@ -4,7 +4,7 @@
     "table_name": "platinum_NA12877_hg38_10K_lines",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/platinum_NA12877_hg38_10K_lines_manual_vep_orig_output.vcf",
     "annotation_fields": "CSQ",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DataflowRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2.json
@@ -3,7 +3,7 @@
     "test_name": "valid-4-0-bz2",
     "table_name": "valid_4_0_bz2",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.bz2",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz.json
@@ -3,7 +3,7 @@
     "test_name": "valid-4-0-gz",
     "table_name": "valid_4_0_gz",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.gz",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1.json
@@ -3,7 +3,7 @@
     "test_name": "valid-4-1",
     "table_name": "valid_4_1",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.1-large.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2.json
@@ -3,7 +3,7 @@
     "test_name": "valid-4-2",
     "table_name": "valid_4_2",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_VEP.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_VEP.json
@@ -5,7 +5,7 @@
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2_VEP.vcf",
     "annotation_fields": "CSQ",
     "infer_annotation_types": "True",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz.json
@@ -3,7 +3,7 @@
     "test_name": "valid-4-2-gz",
     "table_name": "valid_4_2_gz",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.2.vcf.gz",
-    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_homo_sapiens.yaml",
     "runner": "DirectRunner",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/transforms/variant_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/variant_to_bigquery.py
@@ -137,7 +137,7 @@ class VariantToBigQuery(beam.PTransform):
                 self._output_table,
                 schema=self._schema,
                 create_disposition=(
-                    beam.io.BigQueryDisposition.CREATE_IF_NEEDED),
+                    beam.io.BigQueryDisposition.CREATE_NEVER),
                 write_disposition=(
                     beam.io.BigQueryDisposition.WRITE_APPEND))))
       return bq_writes
@@ -147,8 +147,8 @@ class VariantToBigQuery(beam.PTransform):
                   self._output_table,
                   schema=self._schema,
                   create_disposition=(
-                      beam.io.BigQueryDisposition.CREATE_IF_NEEDED),
+                      beam.io.BigQueryDisposition.CREATE_NEVER),
                   write_disposition=(
                       beam.io.BigQueryDisposition.WRITE_APPEND
                       if self._append
-                      else beam.io.BigQueryDisposition.WRITE_TRUNCATE))))
+                      else beam.io.BigQueryDisposition.WRITE_EMPTY))))

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -473,7 +473,7 @@ def run(argv=None):
         schema_converter.convert_table_schema_to_json_bq_schema(schema))
     with filesystems.FileSystems.create(schema_file) as file_to_write:
       file_to_write.write(schema_json)
-    known_args.schema_json = schema_json
+    known_args.schema_json = schema_file
 
     for i in range(num_shards):
       table_suffix = sharding.get_output_table_suffix(i)

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -473,11 +473,15 @@ def run(argv=None):
         schema_converter.convert_table_schema_to_json_bq_schema(schema))
     with filesystems.FileSystems.create(schema_file) as file_to_write:
       file_to_write.write(schema_json)
+    known_args.schema_json = schema_json
 
     for i in range(num_shards):
       table_suffix = sharding.get_output_table_suffix(i)
       table_name = sample_info_table_schema_generator.compose_table_name(
           known_args.output_table, table_suffix)
+      total_base_pairs = sharding.get_output_table_total_base_pairs(i)
+      pipeline_common.make_output_table_if_needed(
+        known_args, table_name, total_base_pairs)
       _ = (variants[i] | 'VariantToBigQuery' + table_suffix >>
            variant_to_bigquery.VariantToBigQuery(
                table_name,

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -480,8 +480,8 @@ def run(argv=None):
       table_name = sample_info_table_schema_generator.compose_table_name(
           known_args.output_table, table_suffix)
       total_base_pairs = sharding.get_output_table_total_base_pairs(i)
-      pipeline_common.make_output_table_if_needed(
-        known_args, table_name, total_base_pairs)
+      pipeline_common.create_output_table_if_needed(
+          known_args, table_name, total_base_pairs)
       _ = (variants[i] | 'VariantToBigQuery' + table_suffix >>
            variant_to_bigquery.VariantToBigQuery(
                table_name,

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -473,15 +473,16 @@ def run(argv=None):
         schema_converter.convert_table_schema_to_json_bq_schema(schema))
     with filesystems.FileSystems.create(schema_file) as file_to_write:
       file_to_write.write(schema_json)
-    known_args.schema_json = schema_file
 
     for i in range(num_shards):
       table_suffix = sharding.get_output_table_suffix(i)
       table_name = sample_info_table_schema_generator.compose_table_name(
           known_args.output_table, table_suffix)
-      total_base_pairs = sharding.get_output_table_total_base_pairs(i)
-      pipeline_common.create_output_table_if_needed(
-          known_args, table_name, total_base_pairs)
+      if not known_args.append:
+        pipeline_common.create_output_table(
+            table_name,
+            sharding.get_output_table_total_base_pairs(i),
+            schema_file)
       _ = (variants[i] | 'VariantToBigQuery' + table_suffix >>
            variant_to_bigquery.VariantToBigQuery(
                table_name,


### PR DESCRIPTION
This PR adds the ability to create integer range partitioned tables using `bq make table...` command.
It's rebased to #550 and will land after that PR.