### PR TITLE
Fix a bug in variant_sharding module.

### DIFF
--- a/gcp_variant_transforms/libs/variant_sharding.py
+++ b/gcp_variant_transforms/libs/variant_sharding.py
@@ -117,6 +117,7 @@ class VariantSharding(object):
     self._total_base_pairs = []
 
     self._parse_config(config_file_path)
+    assert len(self._table_name_suffixes) == len(self._total_base_pairs)
 
   def _is_residual_shard(self, regions):
     # type: (List[str]) -> bool
@@ -242,13 +243,13 @@ class VariantSharding(object):
       if self._is_residual_shard(regions):
         self._residual_index = shard_index
         self._should_keep_residual = True
-        continue
-      for r in regions:
-        ref_name, start, end = genomic_region_parser.parse_genomic_region(r)
-        if self._use_interval_tree:
-          self._region_to_shard[ref_name].add_region(start, end, shard_index)
-        else:
-          self._region_to_shard[ref_name] = shard_index
+      else:
+        for r in regions:
+          ref_name, start, end = genomic_region_parser.parse_genomic_region(r)
+          if self._use_interval_tree:
+            self._region_to_shard[ref_name].add_region(start, end, shard_index)
+          else:
+            self._region_to_shard[ref_name] = shard_index
       # Store num_base_pairs
       total_base_pairs = output_table.get(_TOTAL_BASE_PAIRS)
       if not isinstance(total_base_pairs, int):

--- a/gcp_variant_transforms/libs/variant_sharding_test.py
+++ b/gcp_variant_transforms/libs/variant_sharding_test.py
@@ -108,6 +108,23 @@ class VariantShardingTest(unittest.TestCase):
     self.assertEqual(sharder.get_output_table_suffix(6), 'chr3_02')
     self.assertEqual(sharder.get_output_table_suffix(7), 'all_remaining')
 
+  def test_config_get_total_base_pairs(self):
+    sharder = variant_sharding.VariantSharding(
+        'gcp_variant_transforms/testing/data/sharding_configs/'
+        'residual_at_end.yaml')
+    self.assertEqual(sharder.get_num_shards(), 8)
+    for i in range(sharder.get_num_shards()):
+      self.assertTrue(sharder.should_keep_shard(i))
+
+    self.assertEqual(sharder.get_output_table_total_base_pairs(0), 1000000)
+    self.assertEqual(sharder.get_output_table_total_base_pairs(1), 2000000)
+    self.assertEqual(sharder.get_output_table_total_base_pairs(2), 249240615)
+    self.assertEqual(sharder.get_output_table_total_base_pairs(3), 243189284)
+    self.assertEqual(sharder.get_output_table_total_base_pairs(4), 191044274)
+    self.assertEqual(sharder.get_output_table_total_base_pairs(5), 500000)
+    self.assertEqual(sharder.get_output_table_total_base_pairs(6), 1000000)
+    self.assertEqual(sharder.get_output_table_total_base_pairs(7), 249240615)
+
   def test_config_non_existent_shard_name(self):
     sharder = variant_sharding.VariantSharding(
         'gcp_variant_transforms/testing/data/sharding_configs/'


### PR DESCRIPTION
The `total_base_pairs` was not recorded for the `residual` shard. Also added a unit test to validate the correct functionality.