### PR TITLE
Store sample ID as int hash, instead of string hex.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -184,7 +184,7 @@ class VariantCall(object):
   """
 
   def __init__(self, sample_id=None, genotype=None, phaseset=None, info=None):
-    # type: (str, List[int], str, Dict[str, Any]) -> None
+    # type: (int, List[int], str, Dict[str, Any]) -> None
     """Initialize the :class:`VariantCall` object.
 
     Args:
@@ -614,10 +614,10 @@ class PySamParser(VcfParser):
     sample_id = self._encoded_sample_names.get(sample_name)
     if not sample_id:
       if self._sample_name_encoding == SampleNameEncoding.WITH_FILE_PATH:
-        sample_id = hex(hashing_util.generate_sample_id(
-            sample_name, self._file_name))
+        sample_id = hashing_util.generate_sample_id(
+            sample_name, self._file_name)
       else:
-        sample_id = hex(hashing_util.generate_sample_id(sample_name))
+        sample_id = hashing_util.generate_sample_id(sample_name)
       self._encoded_sample_names[sample_name] = sample_id
     return sample_id
 

--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -614,8 +614,8 @@ class PySamParser(VcfParser):
     sample_id = self._encoded_sample_names.get(sample_name)
     if not sample_id:
       if self._sample_name_encoding == SampleNameEncoding.WITH_FILE_PATH:
-        sample_id = hashing_util.generate_sample_id(
-            sample_name, self._file_name)
+        sample_id = hashing_util.generate_sample_id(sample_name,
+                                                    self._file_name)
       else:
         sample_id = hashing_util.generate_sample_id(sample_name)
       self._encoded_sample_names[sample_name] = sample_id

--- a/gcp_variant_transforms/libs/bigquery_vcf_data_converter_test.py
+++ b/gcp_variant_transforms/libs/bigquery_vcf_data_converter_test.py
@@ -155,12 +155,12 @@ def _get_big_query_row():
           unicode(ColumnKeyConstants.FILTER): [unicode('PASS')],
           unicode(ColumnKeyConstants.CALLS): [
               {unicode(ColumnKeyConstants.CALLS_SAMPLE_ID): (
-                  unicode(hash_name('Sample1'))),
+                  hash_name('Sample1')),
                unicode(ColumnKeyConstants.CALLS_GENOTYPE): [0, 1],
                unicode(ColumnKeyConstants.CALLS_PHASESET): unicode('*'),
                unicode('GQ'): 20, unicode('FIR'): [10, 20]},
               {unicode(ColumnKeyConstants.CALLS_SAMPLE_ID): (
-                  unicode(hash_name('Sample2'))),
+                  hash_name('Sample2')),
                unicode(ColumnKeyConstants.CALLS_GENOTYPE): [1, 0],
                unicode(ColumnKeyConstants.CALLS_PHASESET): None,
                unicode('GQ'): 10, unicode('FB'): True}

--- a/gcp_variant_transforms/libs/schema_converter.py
+++ b/gcp_variant_transforms/libs/schema_converter.py
@@ -125,7 +125,7 @@ def generate_schema_from_header_fields(
       description='One record for each call.')
   calls_record.fields.append(bigquery.TableFieldSchema(
       name=bigquery_util.ColumnKeyConstants.CALLS_SAMPLE_ID,
-      type=bigquery_util.TableFieldConstants.TYPE_STRING,
+      type=bigquery_util.TableFieldConstants.TYPE_INTEGER,
       mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description='Name of the call.'))
   calls_record.fields.append(bigquery.TableFieldSchema(

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_filter_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_filter_to_calls.json
@@ -25,7 +25,7 @@
           "SELECT COUNT(0) AS num_rows ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x1447114f17e91025L' ",
+          "AND call.sample_id = 1461155635506253861 ",
           "AND 'q10' IN UNNEST (call.filter)"
         ],
         "expected_result": {"num_rows": 1}
@@ -35,7 +35,7 @@
           "SELECT COUNT(0) AS num_rows ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x7588a624d89b0eb2L' ",
+          "AND call.sample_id = 8469201776453291698 ",
           "AND 'q10' IN UNNEST (call.filter)"
         ],
         "expected_result": {"num_rows": 1}
@@ -45,7 +45,7 @@
           "SELECT COUNT(0) AS num_rows ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x276d7d35dbcc18a6L' ",
+          "AND call.sample_id = 2841064610214975654 ",
           "AND 'PASS' IN UNNEST (call.filter)"
         ],
         "expected_result": {"num_rows": 1}
@@ -55,7 +55,7 @@
           "SELECT COUNT(0) AS num_rows ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x65101f53be02557dL' ",
+          "AND call.sample_id = 7282355041988662653 ",
           "AND 'PASS' IN UNNEST (call.filter)"
         ],
         "expected_result": {"num_rows": 1}

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_quality_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_quality_to_calls.json
@@ -25,7 +25,7 @@
           "SELECT call.quality AS quality ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x1447114f17e91025L'"
+          "AND call.sample_id = 1461155635506253861"
         ],
         "expected_result": {"quality": 10.0}
       },
@@ -34,7 +34,7 @@
           "SELECT call.quality AS quality ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x7588a624d89b0eb2L'"
+          "AND call.sample_id = 8469201776453291698"
         ],
         "expected_result": {"quality": 10.0}
       },
@@ -43,7 +43,7 @@
           "SELECT call.quality AS quality ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x276d7d35dbcc18a6L'"
+          "AND call.sample_id = 2841064610214975654"
         ],
         "expected_result": {"quality": 29.0}
       },
@@ -52,7 +52,7 @@
           "SELECT call.quality AS quality ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x65101f53be02557dL'"
+          "AND call.sample_id = 7282355041988662653"
         ],
         "expected_result": {"quality": 30.0}
       }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_info_keys_to_move_to_calls_regex.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_info_keys_to_move_to_calls_regex.json
@@ -25,7 +25,7 @@
           "SELECT call.NS AS NS ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x1447114f17e91025L'"
+          "AND call.sample_id = 1461155635506253861"
         ],
         "expected_result": {"NS": 2}
       },
@@ -34,7 +34,7 @@
           "SELECT call.NS AS NS ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x7588a624d89b0eb2L'"
+          "AND call.sample_id = 8469201776453291698"
         ],
         "expected_result": {"NS": 2}
       },
@@ -43,7 +43,7 @@
           "SELECT call.NS AS NS ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x276d7d35dbcc18a6L'"
+          "AND call.sample_id = 2841064610214975654"
         ],
         "expected_result": {"NS": 1}
       },
@@ -52,7 +52,7 @@
           "SELECT call.NS AS NS ",
           "FROM `{TABLE_NAME}` AS t, t.call as call ",
           "WHERE start_position = 14369 ",
-          "AND call.sample_id ='0x65101f53be02557dL'"
+          "AND call.sample_id = 7282355041988662653"
         ],
         "expected_result": {"NS": 1}
       }

--- a/gcp_variant_transforms/testing/testdata_util.py
+++ b/gcp_variant_transforms/testing/testdata_util.py
@@ -23,7 +23,7 @@ from gcp_variant_transforms.libs import hashing_util
 __all__ = ['get_full_file_path', 'get_full_dir']
 
 def hash_name(sample_name, file_name=''):
-  return hex(hashing_util.generate_sample_id(sample_name, file_name))
+  return hashing_util.generate_sample_id(sample_name, file_name)
 
 
 def get_full_file_path(file_name):

--- a/gcp_variant_transforms/transforms/bigquery_to_variant_test.py
+++ b/gcp_variant_transforms/transforms/bigquery_to_variant_test.py
@@ -40,12 +40,12 @@ class BigQueryToVariantTest(unittest.TestCase):
            unicode(ColumnKeyConstants.FILTER): ['PASS'],
            unicode(ColumnKeyConstants.CALLS): [
                {unicode(ColumnKeyConstants.CALLS_SAMPLE_ID): (
-                   unicode(hash_name('Sample1'))),
+                   hash_name('Sample1')),
                 unicode(ColumnKeyConstants.CALLS_GENOTYPE): [0, 1],
                 unicode(ColumnKeyConstants.CALLS_PHASESET): unicode('*'),
                 unicode('GQ'): 20, unicode('FIR'): [10, 20]},
                {unicode(ColumnKeyConstants.CALLS_SAMPLE_ID): (
-                   unicode(hash_name('Sample2'))),
+                   hash_name('Sample2')),
                 unicode(ColumnKeyConstants.CALLS_GENOTYPE): [1, 0],
                 unicode(ColumnKeyConstants.CALLS_PHASESET): None,
                 unicode('GQ'): 10, unicode('FB'): True}

--- a/gcp_variant_transforms/transforms/combine_sample_ids.py
+++ b/gcp_variant_transforms/transforms/combine_sample_ids.py
@@ -39,7 +39,7 @@ class SampleIdsCombiner(beam.PTransform):
     self._preserve_sample_order = preserve_sample_order
 
   def _get_sample_ids(self, variant):
-    # type: (vcf_parser.Variant) -> Tuple[str]
+    # type: (vcf_parser.Variant) -> Tuple[int]
     """Returns the sample ids of all calls for the variant."""
     sample_ids = [call.sample_id for call in variant.calls]
     if len(sample_ids) != len(set(sample_ids)):
@@ -48,7 +48,7 @@ class SampleIdsCombiner(beam.PTransform):
     return tuple(sample_ids)
 
   def _extract_unique_sample_ids(self, sample_ids):
-    # type: (List[Tuple[str]]) -> List[str]
+    # type: (List[Tuple[int]]) -> List[int]
     """Extracts unique sample ids from all variants.
 
     Returns:

--- a/gcp_variant_transforms/transforms/densify_variants.py
+++ b/gcp_variant_transforms/transforms/densify_variants.py
@@ -28,7 +28,7 @@ class DensifyVariants(beam.PTransform):
   """Densifys each Variant's calls to contain data for `all_sample_ids`."""
 
   def __init__(self, all_sample_ids):
-    # type: (List[str]) -> None
+    # type: (List[int]) -> None
     """Initializes a `DensifyVariants` object.
 
     Args:
@@ -38,7 +38,7 @@ class DensifyVariants(beam.PTransform):
     self._all_sample_ids = all_sample_ids
 
   def _densify_variants(self, variant, all_sample_ids):
-    # type: (vcf_parser.Variant, List[str]) -> vcf_parser.Variant
+    # type: (vcf_parser.Variant, List[int]) -> vcf_parser.Variant
     """Cherry-picks calls for the variant.
 
     The calls are in the same order as the `all_sample_ids`.

--- a/gcp_variant_transforms/transforms/extract_input_size.py
+++ b/gcp_variant_transforms/transforms/extract_input_size.py
@@ -52,8 +52,8 @@ class GetSampleMap(beam.PTransform):
   the sum of values will give us estimated value count.
   """
   def _get_sample_ids(self, estimate):
-    # type: (vcf_parser.Variant) -> Tuple[str]
-    """Returns the names of all calls for the variant."""
+    # type: (vcf_parser.Variant) -> Tuple[int]
+    """Returns the ids of all calls for the variant."""
     return tuple(
         zip(estimate.samples,
             [estimate.estimated_variant_count] * len(estimate.samples)))


### PR DESCRIPTION
Also fixed an error where multiple sample tables are being created, one for each chromosome.

DirectRunner test passed, running integration tests now.