### PR TITLE
Fix incompatible httplib2 versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ REQUIRED_PACKAGES = [
     # Note that adding 'google-api-python-client>=1.6' causes some dependency
     # mismatch issues. This is fatal if using 'setup.py install', but works on
     # 'pip install .' as it ignores conflicting versions. See Issue #71.
-    'google-api-python-client>=1.6',
+    'google-api-python-client>=1.6,<1.7.12',
     'intervaltree>=2.1.0,<2.2.0',
     'mmh3<2.6',
     # Refer to issue #528


### PR DESCRIPTION
Our build is broken due to this error message:
```
pkg_resources.ContextualVersionConflict: (httplib2 0.17.0 (/home/travis/build/googlegenomics/gcp-variant-transforms/.eggs/httplib2-0.17.0-py2.7.egg), Requirement.parse('httplib2<=0.12.0,>=0.8'), set(['apache-beam']))
Coverage.py warning: No data was collected. (no-data-collected)
```
For more info please refer to https://github.com/googlegenomics/gcp-variant-transforms/issues/71#issuecomment-598369063