### PR TITLE
Move compose_table_name() to bigquery_util module

### DIFF
--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -33,6 +33,9 @@ _MAX_BQ_NUM_PARTITIONS = 4000
 _TOTAL_BASE_PAIRS_SIG_DIGITS = 4
 _PARTITION_SIZE_SIG_DIGITS = 1
 
+TABLE_SUFFIX = 'sample_info'
+TABLE_SUFFIX_SEPARATOR = '__'
+
 
 class ColumnKeyConstants(object):
   """Constants for column names in the BigQuery schema."""
@@ -352,3 +355,8 @@ def calculate_optimal_partition_size(total_base_pairs):
       math.pow(10, _PARTITION_SIZE_SIG_DIGITS))
   return (partition_size_round_up,
           partition_size_round_up * (_MAX_BQ_NUM_PARTITIONS - 1))
+
+
+def compose_table_name(base_name, suffix):
+  # type: (str, List[str]) -> str
+  return TABLE_SUFFIX_SEPARATOR.join([base_name, suffix])

--- a/gcp_variant_transforms/libs/sample_info_table_schema_generator.py
+++ b/gcp_variant_transforms/libs/sample_info_table_schema_generator.py
@@ -22,13 +22,6 @@ SAMPLE_ID = 'sample_id'
 SAMPLE_NAME = 'sample_name'
 FILE_PATH = 'file_path'
 INGESTION_DATETIME = 'ingestion_datetime'
-TABLE_SUFFIX = 'sample_info'
-TABLE_SUFFIX_SEPARATOR = '__'
-
-
-def compose_table_name(base_name, suffix):
-  # type: (str, List[str]) -> str
-  return TABLE_SUFFIX_SEPARATOR.join([base_name, suffix])
 
 
 def generate_schema():

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -22,7 +22,6 @@ from oauth2client.client import GoogleCredentials
 from gcp_variant_transforms.beam_io import vcf_parser
 from gcp_variant_transforms.libs import bigquery_sanitizer
 from gcp_variant_transforms.libs import bigquery_util
-from gcp_variant_transforms.libs import sample_info_table_schema_generator
 from gcp_variant_transforms.libs import variant_sharding
 
 
@@ -153,8 +152,7 @@ class BigQueryWriteOptions(VariantTransformsOptions):
               'output_table_ + {} will be created. This table contains a '
               'unique sample_id for each sample read from the VCF file. This '
               'sample_id can be used to distinguish between sample names. '
-              '[EXPERIMENTAL]'
-             ).format(sample_info_table_schema_generator.TABLE_SUFFIX))
+              '[EXPERIMENTAL]').format(bigquery_util.TABLE_SUFFIX))
 
     parser.add_argument(
         '--sample_name_encoding',
@@ -234,9 +232,8 @@ class BigQueryWriteOptions(VariantTransformsOptions):
                                                       dataset_id)
       all_output_tables = []
       if parsed_args.generate_sample_info_table:
-        all_output_tables.append(
-            sample_info_table_schema_generator.compose_table_name(
-                table_id, sample_info_table_schema_generator.TABLE_SUFFIX))
+        all_output_tables.append(bigquery_util.compose_table_name(
+            table_id, bigquery_util.TABLE_SUFFIX))
       sharding = variant_sharding.VariantSharding(
           parsed_args.sharding_config_path)
       num_shards = sharding.get_num_shards()
@@ -245,9 +242,8 @@ class BigQueryWriteOptions(VariantTransformsOptions):
         num_shards -= 1
       for i in range(num_shards):
         table_suffix = sharding.get_output_table_suffix(i)
-        all_output_tables.append(
-            sample_info_table_schema_generator.compose_table_name(
-                table_id, table_suffix))
+        all_output_tables.append(bigquery_util.compose_table_name(table_id,
+                                                                  table_suffix))
 
       for output_table in all_output_tables:
         if parsed_args.append:

--- a/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
@@ -54,7 +54,7 @@ from apache_beam.io import filesystems
 # pylint: disable=no-name-in-module,import-error
 from google.cloud import bigquery
 
-from gcp_variant_transforms.libs import sample_info_table_schema_generator
+from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.testing.integration import run_tests_common
 
 _TOOL_NAME = 'vcf_to_bq'
@@ -177,8 +177,7 @@ class QueryFormatter(object):
     # That's why we use the given table_name as table_suffix.
     self._table_id = table_id
     self._dataset_table_wildcard = '{}.{}{}*'.format(
-        self._dataset_id, self._table_id,
-        sample_info_table_schema_generator.TABLE_SUFFIX_SEPARATOR)
+        self._dataset_id, self._table_id, bigquery_util.TABLE_SUFFIX_SEPARATOR)
 
   def format_query(self, query):
     # type: (List[str]) -> str

--- a/gcp_variant_transforms/transforms/sample_info_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_bigquery.py
@@ -20,8 +20,9 @@ import apache_beam as beam
 
 from gcp_variant_transforms.beam_io import vcf_header_io  # pylint: disable=unused-import
 from gcp_variant_transforms.beam_io import vcf_parser
-from gcp_variant_transforms.libs import sample_info_table_schema_generator
+from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs import hashing_util
+from gcp_variant_transforms.libs import sample_info_table_schema_generator
 
 SampleNameEncoding = vcf_parser.SampleNameEncoding
 _DATETIME_FORMAT = "%Y-%m-%d %H:%M:00.0"
@@ -71,8 +72,8 @@ class SampleInfoToBigQuery(beam.PTransform):
         sample_id would only use sample_name in to get a hashed name; otherwise
         both sample_name and file_name will be used.
     """
-    self._output_table = sample_info_table_schema_generator.compose_table_name(
-        output_table_prefix, sample_info_table_schema_generator.TABLE_SUFFIX)
+    self._output_table = bigquery_util.compose_table_name(
+        output_table_prefix, bigquery_util.TABLE_SUFFIX)
     self._append = append
     self._sample_name_encoding = sample_name_encoding
     self._schema = sample_info_table_schema_generator.generate_schema()

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -49,7 +49,6 @@ from gcp_variant_transforms.beam_io import vcf_parser
 from gcp_variant_transforms.libs import bigquery_util
 from gcp_variant_transforms.libs import metrics_util
 from gcp_variant_transforms.libs import processed_variant
-from gcp_variant_transforms.libs import sample_info_table_schema_generator
 from gcp_variant_transforms.libs import schema_converter
 from gcp_variant_transforms.libs import vcf_header_parser
 from gcp_variant_transforms.libs import variant_sharding
@@ -460,8 +459,8 @@ def run(argv=None):
   if known_args.update_schema_on_append:
     for i in range(num_shards):
       table_suffix = sharding.get_output_table_suffix(i)
-      table_name = sample_info_table_schema_generator.compose_table_name(
-          known_args.output_table, table_suffix)
+      table_name = bigquery_util.compose_table_name(known_args.output_table,
+                                                    table_suffix)
       bigquery_util.update_bigquery_schema_on_append(schema.fields, table_name)
 
   beam_pipeline_options = pipeline_options.PipelineOptions(pipeline_args)
@@ -486,8 +485,8 @@ def run(argv=None):
   if known_args.output_table:
     for i in range(num_shards):
       table_suffix = sharding.get_output_table_suffix(i)
-      table_name = sample_info_table_schema_generator.compose_table_name(
-          known_args.output_table, table_suffix)
+      table_name = bigquery_util.compose_table_name(known_args.output_table,
+                                                    table_suffix)
       if not known_args.append:
         pipeline_common.create_output_table(
             table_name,
@@ -509,7 +508,7 @@ def run(argv=None):
     # also imports to BigQuery. Then import those Avro outputs using the bq
     # tool and verify that the two tables are identical.
     for i in range(num_shards):
-      avro_path = sample_info_table_schema_generator.compose_table_name(
+      avro_path = bigquery_util.compose_table_name(
           known_args.output_avro_path, sharding.get_output_table_suffix(i))
       _ = (
           variants[i] | 'VariantToAvro' >>


### PR DESCRIPTION
In preparation for #558  where we are dealing with circular import between `bigquery_util` and `sample_info_table_schema_generator` we move `compose_table_name()`.