### PR TITLE
Add a flag to allow users to keep AVRO files

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -118,12 +118,16 @@ class BigQueryWriteOptions(VariantTransformsOptions):
     parser.add_argument('--output_table',
                         default='',
                         help='BigQuery table to store the results.')
-
+    parser.add_argument(
+        '--output_avro_path',
+        default='',
+        help=('This flag is deprecated and will be removed in the next '
+              'release, instead use --keep_intermediate_avro_files flag.'))
     parser.add_argument(
         '--keep_intermediate_avro_files',
         type='bool', default=False, nargs='?', const=True,
-        help=('If set to True, the intermediate AVRO files will be kept. They '	
-              'are stored in your temp directory (set by --temp_location) '	
+        help=('If set to True, the intermediate AVRO files will be kept. They '
+              'are stored in your temp directory (set by --temp_location) '
               'under gs://[YOUR-TEMP-DIRECTORY]/avro/JOB_NAME/'))
     parser.add_argument(
         '--sharding_config_path',

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -120,6 +120,12 @@ class BigQueryWriteOptions(VariantTransformsOptions):
                         help='BigQuery table to store the results.')
 
     parser.add_argument(
+        '--keep_intermediate_avro_files',
+        type='bool', default=False, nargs='?', const=True,
+        help=('If set to True, the intermediate AVRO files will be kept. They '	
+              'are stored in your temp directory (set by --temp_location) '	
+              'under gs://[YOUR-TEMP-DIRECTORY]/avro/JOB_NAME/'))
+    parser.add_argument(
         '--sharding_config_path',
         default=('gcp_variant_transforms/data/sharding_configs/'
                  'homo_sapiens_default.yaml'),

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -541,9 +541,13 @@ def run(argv=None):
     raise e
   else:
     logging.warning('All AVRO files were successfully loaded to BigQuery.')
-    if bigquery_util.delete_gcs_files(avro_root_path) != 0:
-      logging.error('Deletion of intermediate AVRO files located at "%s" has '
-                    'failed.', avro_root_path)
+    if known_args.keep_intermediate_avro_files:
+      logging.info('Since "--keep_intermediate_avro_files" flag is set, the '
+                   'AVRO files are kept and stored at: %s', avro_root_path)
+    else:
+      if bigquery_util.delete_gcs_files(avro_root_path) != 0:
+        logging.error('Deletion of intermediate AVRO files located at "%s" has '
+                      'failed.', avro_root_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
AVRO files could be an effective solution as a ready-to-load-into-BQ.

Storing AVRo file in GCS costs a fraction of BQ's storage cost. Also AVRO files compression makes them significantly smaller than their corresponding BQ tables.