### PR TITLE
Add a method to create composite sample name

### DIFF
--- a/gcp_variant_transforms/libs/hashing_util.py
+++ b/gcp_variant_transforms/libs/hashing_util.py
@@ -38,14 +38,16 @@ def generate_sample_id(sample_name, file_path=''):
   The hash code generated is in the range [0, pow(2, 63)).
   """
   if file_path:
-    strings = [make_composite_sample_name(sample_name, file_path)]
+    strings = [create_composite_sample_name(sample_name, file_path)]
   else:
     strings = [sample_name]
   return _generate_unsigned_hash_code(strings, max_hash_value=pow(2, 63))
 
-def make_composite_sample_name(sample_name, file_path):
+def create_composite_sample_name(sample_name, file_path):
   # type: (str, str) -> str
+  """Replaces special chr in file_path with _ concatenates sample_name to it."""
   if not sample_name or not file_path:
-    raise ValueError('Both input args are expected to be not empty strings,')
-  simplified_file_path = re.sub(r'\W+', '_', file_path)
+    raise ValueError(
+        'Both sample_name and file_path are expected to be not empty strings.')
+  simplified_file_path = re.sub(r'\W', '_', file_path)
   return '_'.join([simplified_file_path, sample_name])

--- a/gcp_variant_transforms/libs/hashing_util.py
+++ b/gcp_variant_transforms/libs/hashing_util.py
@@ -15,6 +15,7 @@
 """Generates hashing code for string."""
 
 import json
+import re
 import sys
 from typing import List  # pylint: disable=unused-import
 
@@ -36,5 +37,15 @@ def generate_sample_id(sample_name, file_path=''):
 
   The hash code generated is in the range [0, pow(2, 63)).
   """
-  strings = [file_path, sample_name] if file_path else [sample_name]
+  if file_path:
+    strings = [make_composite_sample_name(sample_name, file_path)]
+  else:
+    strings = [sample_name]
   return _generate_unsigned_hash_code(strings, max_hash_value=pow(2, 63))
+
+def make_composite_sample_name(sample_name, file_path):
+  # type: (str, str) -> str
+  if not sample_name or not file_path:
+    raise ValueError('Both input args are expected to be not empty strings,')
+  simplified_file_path = re.sub(r'\W+', '_', file_path)
+  return '_'.join([simplified_file_path, sample_name])

--- a/gcp_variant_transforms/libs/hashing_util_test.py
+++ b/gcp_variant_transforms/libs/hashing_util_test.py
@@ -38,17 +38,18 @@ class HashingUtilTest(unittest.TestCase):
     self.assertEqual(hash_code, 110)
 
   def test_generate_sample_id_with_file_path(self):
-    hash_code = hashing_util.generate_sample_id('Sample1', 'file_1')
-    self.assertEqual(hash_code, 1603149767211015963)
-
-    hash_code = hashing_util.generate_sample_id('Sample2', 'file_1')
-    self.assertEqual(hash_code, 7039455832764509387)
-
-    hash_code = hashing_util.generate_sample_id('Sample1', 'file_2')
-    self.assertEqual(hash_code, 4840534050208649594)
-
-    hash_code = hashing_util.generate_sample_id('Sample2', 'file_2')
-    self.assertEqual(hash_code, 7113221774487715893)
+    hash_code = hashing_util.generate_sample_id('Sample1',
+                                                'gs://bucket1/dir1/file1.vcf')
+    self.assertEqual(hash_code, 5752442450131469410)
+    hash_code = hashing_util.generate_sample_id('Sample2',
+                                                'gs://bucket1/dir1/file1.vcf')
+    self.assertEqual(hash_code, 1388221315142578173)
+    hash_code = hashing_util.generate_sample_id('Sample1',
+                                                'gs://bucket1/dir1/file2.vcf')
+    self.assertEqual(hash_code, 5863016777357401414)
+    hash_code = hashing_util.generate_sample_id('Sample2',
+                                                'gs://bucket1/dir1/file2.vcf')
+    self.assertEqual(hash_code, 4022774909923525788)
 
   def test_generate_sample_id_without_file_path(self):
     hash_code = hashing_util.generate_sample_id('Sample1')
@@ -56,3 +57,21 @@ class HashingUtilTest(unittest.TestCase):
 
     hash_code = hashing_util.generate_sample_id('Sample2')
     self.assertEqual(hash_code, 8341768597576477893)
+
+  def test_make_composite_sample_name(self):
+    composite_names = {
+        'gs_bucket1_dir1_file1_vcf_sample1':
+            ('sample1', 'gs://bucket1/dir1/file1.vcf'),
+        'gs_bucket1_dir1_file1_vcf_gz_sample1':
+            ('sample1', 'gs://bucket1/dir1/file1.vcf.gz'),
+        'gs_BUCKET1_DIR1_FILE1_vcf_sample1':
+            ('sample1', 'gs://BUCKET1/DIR1/FILE1.vcf'),
+        'gs_bucket_1_dir_1_file_1_vcf_sample1':
+            ('sample1', 'gs://bucket-1/dir-1/file-1.vcf'),
+        'gs_bucket1_dir1_file1_vcf_sample-@~!*&1':
+            ('sample-@~!*&1', 'gs://bucket1/dir1/file1.vcf'),
+    }
+    for expected_name, inputs in composite_names.items():
+      self.assertEqual(expected_name,
+                       hashing_util.make_composite_sample_name(inputs[0],
+                                                               inputs[1]))

--- a/gcp_variant_transforms/libs/hashing_util_test.py
+++ b/gcp_variant_transforms/libs/hashing_util_test.py
@@ -40,16 +40,16 @@ class HashingUtilTest(unittest.TestCase):
   def test_generate_sample_id_with_file_path(self):
     hash_code = hashing_util.generate_sample_id('Sample1',
                                                 'gs://bucket1/dir1/file1.vcf')
-    self.assertEqual(hash_code, 5752442450131469410)
+    self.assertEqual(hash_code, 7715696391291253656)
     hash_code = hashing_util.generate_sample_id('Sample2',
                                                 'gs://bucket1/dir1/file1.vcf')
-    self.assertEqual(hash_code, 1388221315142578173)
+    self.assertEqual(hash_code, 5682150464643626236)
     hash_code = hashing_util.generate_sample_id('Sample1',
                                                 'gs://bucket1/dir1/file2.vcf')
-    self.assertEqual(hash_code, 5863016777357401414)
+    self.assertEqual(hash_code, 668336000922978678)
     hash_code = hashing_util.generate_sample_id('Sample2',
                                                 'gs://bucket1/dir1/file2.vcf')
-    self.assertEqual(hash_code, 4022774909923525788)
+    self.assertEqual(hash_code, 5498327443813165683)
 
   def test_generate_sample_id_without_file_path(self):
     hash_code = hashing_util.generate_sample_id('Sample1')
@@ -58,20 +58,20 @@ class HashingUtilTest(unittest.TestCase):
     hash_code = hashing_util.generate_sample_id('Sample2')
     self.assertEqual(hash_code, 8341768597576477893)
 
-  def test_make_composite_sample_name(self):
+  def test_create_composite_sample_name(self):
     composite_names = {
-        'gs_bucket1_dir1_file1_vcf_sample1':
+        'gs___bucket1_dir1_file1_vcf_sample1':
             ('sample1', 'gs://bucket1/dir1/file1.vcf'),
-        'gs_bucket1_dir1_file1_vcf_gz_sample1':
+        'gs___bucket1_dir1_file1_vcf_gz_sample1':
             ('sample1', 'gs://bucket1/dir1/file1.vcf.gz'),
-        'gs_BUCKET1_DIR1_FILE1_vcf_sample1':
+        'gs___BUCKET1_DIR1_FILE1_vcf_sample1':
             ('sample1', 'gs://BUCKET1/DIR1/FILE1.vcf'),
-        'gs_bucket_1_dir_1_file_1_vcf_sample1':
+        'gs___bucket_1_dir_1_file_1_vcf_sample1':
             ('sample1', 'gs://bucket-1/dir-1/file-1.vcf'),
-        'gs_bucket1_dir1_file1_vcf_sample-@~!*&1':
+        'gs___bucket1_dir1_file1_vcf_sample-@~!*&1':
             ('sample-@~!*&1', 'gs://bucket1/dir1/file1.vcf'),
     }
     for expected_name, inputs in composite_names.items():
       self.assertEqual(expected_name,
-                       hashing_util.make_composite_sample_name(inputs[0],
-                                                               inputs[1]))
+                       hashing_util.create_composite_sample_name(inputs[0],
+                                                                 inputs[1]))

--- a/gcp_variant_transforms/transforms/sample_info_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_bigquery.py
@@ -42,11 +42,10 @@ class ConvertSampleInfoToRow(beam.DoFn):
     # type: (vcf_header_io.VcfHeader, bool) -> Dict[str, Union[int, str]]
     current_minute = self._get_now_to_minute()
     for sample in vcf_header.samples:
-      if self._sample_name_encoding == SampleNameEncoding.WITHOUT_FILE_PATH:
-        sample_id = hashing_util.generate_sample_id(sample)
-      else:
-        sample_id = hashing_util.generate_sample_id(
-            sample, vcf_header.file_path)
+      if self._sample_name_encoding == SampleNameEncoding.WITH_FILE_PATH:
+        sample = hashing_util.make_composite_sample_name(sample,
+                                                         vcf_header.file_path)
+      sample_id = hashing_util.generate_sample_id(sample)
 
       row = {
           sample_info_table_schema_generator.SAMPLE_ID: sample_id,

--- a/gcp_variant_transforms/transforms/sample_info_to_bigquery.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_bigquery.py
@@ -43,8 +43,8 @@ class ConvertSampleInfoToRow(beam.DoFn):
     current_minute = self._get_now_to_minute()
     for sample in vcf_header.samples:
       if self._sample_name_encoding == SampleNameEncoding.WITH_FILE_PATH:
-        sample = hashing_util.make_composite_sample_name(sample,
-                                                         vcf_header.file_path)
+        sample = hashing_util.create_composite_sample_name(sample,
+                                                           vcf_header.file_path)
       sample_id = hashing_util.generate_sample_id(sample)
 
       row = {

--- a/gcp_variant_transforms/transforms/sample_info_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_bigquery_test.py
@@ -46,27 +46,27 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
     current_minute = mocked_obj()
 
     expected_rows = [
-        {sample_info_table_schema_generator.SAMPLE_ID: 5752442450131469410,
+        {sample_info_table_schema_generator.SAMPLE_ID: 7715696391291253656,
          sample_info_table_schema_generator.SAMPLE_NAME: (
-             'gs_bucket1_dir1_file1_vcf_Sample1'),
+             'gs___bucket1_dir1_file1_vcf_Sample1'),
          sample_info_table_schema_generator.FILE_PATH: (
              'gs://bucket1/dir1/file1.vcf'),
          sample_info_table_schema_generator.INGESTION_DATETIME: current_minute},
-        {sample_info_table_schema_generator.SAMPLE_ID: 1388221315142578173,
+        {sample_info_table_schema_generator.SAMPLE_ID: 5682150464643626236,
          sample_info_table_schema_generator.SAMPLE_NAME: (
-             'gs_bucket1_dir1_file1_vcf_Sample2'),
+             'gs___bucket1_dir1_file1_vcf_Sample2'),
          sample_info_table_schema_generator.FILE_PATH: (
              'gs://bucket1/dir1/file1.vcf'),
          sample_info_table_schema_generator.INGESTION_DATETIME: current_minute},
-        {sample_info_table_schema_generator.SAMPLE_ID: 5863016777357401414,
+        {sample_info_table_schema_generator.SAMPLE_ID: 668336000922978678,
          sample_info_table_schema_generator.SAMPLE_NAME: (
-             'gs_bucket1_dir1_file2_vcf_Sample1'),
+             'gs___bucket1_dir1_file2_vcf_Sample1'),
          sample_info_table_schema_generator.FILE_PATH: (
              'gs://bucket1/dir1/file2.vcf'),
          sample_info_table_schema_generator.INGESTION_DATETIME: current_minute},
-        {sample_info_table_schema_generator.SAMPLE_ID: 4022774909923525788,
+        {sample_info_table_schema_generator.SAMPLE_ID: 5498327443813165683,
          sample_info_table_schema_generator.SAMPLE_NAME: (
-             'gs_bucket1_dir1_file2_vcf_Sample2'),
+             'gs___bucket1_dir1_file2_vcf_Sample2'),
          sample_info_table_schema_generator.FILE_PATH: (
              'gs://bucket1/dir1/file2.vcf'),
          sample_info_table_schema_generator.INGESTION_DATETIME: current_minute},

--- a/gcp_variant_transforms/transforms/sample_info_to_bigquery_test.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_bigquery_test.py
@@ -39,28 +39,36 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
               'ConvertSampleInfoToRow._get_now_to_minute',
               side_effect=mocked_get_now)
   def test_convert_sample_info_to_row(self, mocked_obj):
-    vcf_header_1 = vcf_header_io.VcfHeader(samples=SAMPLE_LINE,
-                                           file_path='file_1')
-    vcf_header_2 = vcf_header_io.VcfHeader(samples=SAMPLE_LINE,
-                                           file_path='file_2')
+    vcf_header_1 = vcf_header_io.VcfHeader(
+        samples=SAMPLE_LINE, file_path='gs://bucket1/dir1/file1.vcf')
+    vcf_header_2 = vcf_header_io.VcfHeader(
+        samples=SAMPLE_LINE, file_path='gs://bucket1/dir1/file2.vcf')
     current_minute = mocked_obj()
 
     expected_rows = [
-        {sample_info_table_schema_generator.SAMPLE_ID: 1603149767211015963,
-         sample_info_table_schema_generator.SAMPLE_NAME: 'Sample1',
-         sample_info_table_schema_generator.FILE_PATH: 'file_1',
+        {sample_info_table_schema_generator.SAMPLE_ID: 5752442450131469410,
+         sample_info_table_schema_generator.SAMPLE_NAME: (
+             'gs_bucket1_dir1_file1_vcf_Sample1'),
+         sample_info_table_schema_generator.FILE_PATH: (
+             'gs://bucket1/dir1/file1.vcf'),
          sample_info_table_schema_generator.INGESTION_DATETIME: current_minute},
-        {sample_info_table_schema_generator.SAMPLE_ID: 7039455832764509387,
-         sample_info_table_schema_generator.SAMPLE_NAME: 'Sample2',
-         sample_info_table_schema_generator.FILE_PATH: 'file_1',
+        {sample_info_table_schema_generator.SAMPLE_ID: 1388221315142578173,
+         sample_info_table_schema_generator.SAMPLE_NAME: (
+             'gs_bucket1_dir1_file1_vcf_Sample2'),
+         sample_info_table_schema_generator.FILE_PATH: (
+             'gs://bucket1/dir1/file1.vcf'),
          sample_info_table_schema_generator.INGESTION_DATETIME: current_minute},
-        {sample_info_table_schema_generator.SAMPLE_ID: 4840534050208649594,
-         sample_info_table_schema_generator.SAMPLE_NAME: 'Sample1',
-         sample_info_table_schema_generator.FILE_PATH: 'file_2',
+        {sample_info_table_schema_generator.SAMPLE_ID: 5863016777357401414,
+         sample_info_table_schema_generator.SAMPLE_NAME: (
+             'gs_bucket1_dir1_file2_vcf_Sample1'),
+         sample_info_table_schema_generator.FILE_PATH: (
+             'gs://bucket1/dir1/file2.vcf'),
          sample_info_table_schema_generator.INGESTION_DATETIME: current_minute},
-        {sample_info_table_schema_generator.SAMPLE_ID: 7113221774487715893,
-         sample_info_table_schema_generator.SAMPLE_NAME: 'Sample2',
-         sample_info_table_schema_generator.FILE_PATH: 'file_2',
+        {sample_info_table_schema_generator.SAMPLE_ID: 4022774909923525788,
+         sample_info_table_schema_generator.SAMPLE_NAME: (
+             'gs_bucket1_dir1_file2_vcf_Sample2'),
+         sample_info_table_schema_generator.FILE_PATH: (
+             'gs://bucket1/dir1/file2.vcf'),
          sample_info_table_schema_generator.INGESTION_DATETIME: current_minute},
     ]
     pipeline = test_pipeline.TestPipeline()


### PR DESCRIPTION
based on VCF file_path and sample_name in the VCF header.

This change will make our sample_info_table to have one-to-one relation between sample_name and sample_id. This will make the logic of BQ_to_VCF more straightforward, both for VT users and VT developers.