### PR TITLE
Fix two bugs in Avro loading jobs

### DIFF
--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -383,14 +383,15 @@ def get_table_base_name(table_name):
 class LoadAvro(object):
   def __init__(self,
                avro_root_path,  # type: str
-               table_base_name,  # type: str
+               output_table,  # type: str
                suffixes,  # type: List[str]
                total_base_pairs  # type: List[int]
               ):
     assert len(suffixes) == len(total_base_pairs)
 
     self._avro_root_path = avro_root_path
-    self._table_base_name = table_base_name.replace(':', '.')
+    project_id, dataset_id, table_id = parse_table_reference(output_table)
+    self._table_base_name = '{}.{}.{}'.format(project_id, dataset_id, table_id)
     self._suffixes = suffixes
     self._total_base_pairs = total_base_pairs
 
@@ -398,7 +399,7 @@ class LoadAvro(object):
     self._suffixes_to_load_jobs = {}  # type: Dict[str, bigquery.job.LoadJob]
     self._remaining_load_jobs = self._suffixes
 
-    self._client = bigquery.Client()
+    self._client = bigquery.Client(project=project_id)
 
   def start_loading(self):
     # We run _MAX_NUM_CONCURRENT_BQ_LOAD_JOBS load jobs in parallel.

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -34,6 +34,7 @@ python -m gcp_variant_transforms.vcf_to_bq \
 from __future__ import absolute_import
 
 import argparse  # pylint: disable=unused-import
+from datetime import datetime
 import logging
 import sys
 import tempfile
@@ -402,7 +403,9 @@ def _get_avro_root_path(beam_pipeline_options):
       pipeline_options.GoogleCloudOptions)
   return filesystems.FileSystems.join(google_cloud_options.temp_location,
                                       _AVRO_FOLDER,
-                                      google_cloud_options.job_name, '')
+                                      google_cloud_options.job_name,
+                                      datetime.now().strftime('%Y%m%d_%H%M%S'),
+                                      '')
 
 
 def run(argv=None):


### PR DESCRIPTION
We encountered these two issues when Verily team tested our docker image:
 + Since many runs might have the same job_id we better make unique directories for each run
 + Python API fails randomly is the project is not set when initiating a Client