### PR TITLE
Add an option to apply 1-based inclusive start position format.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -265,7 +265,7 @@ class VcfParser(object):
       splittable_bgzf=False,  # type: bool
       pre_infer_headers=False,  # type: bool
       sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
-      use_1_based_format=False,  # type: bool
+      use_1_based_coordinate=False,  # type: bool
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -276,7 +276,7 @@ class VcfParser(object):
     self._allow_malformed_records = allow_malformed_records
     self._pre_infer_headers = pre_infer_headers
     self._sample_name_encoding = sample_name_encoding
-    self._use_1_based_format = use_1_based_format
+    self._use_1_based_coordinate = use_1_based_coordinate
 
     if splittable_bgzf:
       text_source = bgzf.BGZFBlockSource(
@@ -431,7 +431,7 @@ class PySamParser(VcfParser):
       splittable_bgzf=False,  # type: bool
       pre_infer_headers=False,  # type: bool
       sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
-      use_1_based_format=False,  # type: bool
+      use_1_based_coordinate=False,  # type: bool
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -444,7 +444,7 @@ class PySamParser(VcfParser):
                                       splittable_bgzf,
                                       pre_infer_headers,
                                       sample_name_encoding,
-                                      use_1_based_format,
+                                      use_1_based_coordinate,
                                       **kwargs)
     # These members will be properly initiated in _init_parent_process().
     self._vcf_reader = None
@@ -547,7 +547,7 @@ class PySamParser(VcfParser):
     self._verify_start_end(record)
     return Variant(
         reference_name=record.chrom.encode('utf-8'),
-        start=record.pos if self._use_1_based_format else record.start,
+        start=record.pos if self._use_1_based_coordinate else record.start,
         end=record.stop,
         reference_bases=self._convert_field(record.ref),
         alternate_bases=list(record.alts) if record.alts else [],

--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -265,6 +265,7 @@ class VcfParser(object):
       splittable_bgzf=False,  # type: bool
       pre_infer_headers=False,  # type: bool
       sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
+      use_1_based_format=False,  # type: bool
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -275,6 +276,7 @@ class VcfParser(object):
     self._allow_malformed_records = allow_malformed_records
     self._pre_infer_headers = pre_infer_headers
     self._sample_name_encoding = sample_name_encoding
+    self._use_1_based_format = use_1_based_format
 
     if splittable_bgzf:
       text_source = bgzf.BGZFBlockSource(
@@ -429,6 +431,7 @@ class PySamParser(VcfParser):
       splittable_bgzf=False,  # type: bool
       pre_infer_headers=False,  # type: bool
       sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
+      use_1_based_format=False,  # type: bool
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -441,6 +444,7 @@ class PySamParser(VcfParser):
                                       splittable_bgzf,
                                       pre_infer_headers,
                                       sample_name_encoding,
+                                      use_1_based_format,
                                       **kwargs)
     # These members will be properly initiated in _init_parent_process().
     self._vcf_reader = None
@@ -448,7 +452,6 @@ class PySamParser(VcfParser):
     self._original_info_list = None
     self._process_pid = None
     self._encoded_sample_names = {}
-    self._sample_name_encoding = sample_name_encoding
 
   def send_kill_signal_to_child(self):
     self._to_child.write('\n')
@@ -544,7 +547,7 @@ class PySamParser(VcfParser):
     self._verify_start_end(record)
     return Variant(
         reference_name=record.chrom.encode('utf-8'),
-        start=record.start,
+        start=record.pos if self._use_1_based_format else record.start,
         end=record.stop,
         reference_bases=self._convert_field(record.ref),
         alternate_bases=list(record.alts) if record.alts else [],

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -192,7 +192,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
       allow_malformed_records=False,  # type: bool
       pre_infer_headers=False,  # type: bool
       sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
-      use_1_based_format=False  # type: bool
+      use_1_based_coordinate=False  # type: bool
       ):
     # type: (...) -> None
     super(_VcfSource, self).__init__(file_pattern,
@@ -204,7 +204,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
     self._allow_malformed_records = allow_malformed_records
     self._pre_infer_headers = pre_infer_headers
     self._sample_name_encoding = sample_name_encoding
-    self._use_1_based_format = use_1_based_format
+    self._use_1_based_coordinate = use_1_based_coordinate
 
 
   def read_records(self,
@@ -221,7 +221,7 @@ class _VcfSource(filebasedsource.FileBasedSource):
         representative_header_lines=self._representative_header_lines,
         pre_infer_headers=self._pre_infer_headers,
         sample_name_encoding=self._sample_name_encoding,
-        use_1_based_format=self._use_1_based_format,
+        use_1_based_coordinate=self._use_1_based_coordinate,
         buffer_size=self._buffer_size,
         skip_header_lines=0)
 
@@ -239,7 +239,7 @@ class ReadFromBGZF(beam.PTransform):
                allow_malformed_records,
                pre_infer_headers,
                sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,
-               use_1_based_format=False
+               use_1_based_coordinate=False
               ):
     # type: (List[str], List[str], bool, bool, int, bool) -> None
     """Initializes the transform.
@@ -260,7 +260,7 @@ class ReadFromBGZF(beam.PTransform):
     self._allow_malformed_records = allow_malformed_records
     self._pre_infer_headers = pre_infer_headers
     self._sample_name_encoding = sample_name_encoding
-    self._use_1_based_format = use_1_based_format
+    self._use_1_based_coordinate = use_1_based_coordinate
 
   def _read_records(self, (file_path, block)):
     # type: (Tuple[str, Block]) -> Iterable(Variant)
@@ -274,7 +274,7 @@ class ReadFromBGZF(beam.PTransform):
         splittable_bgzf=True,
         pre_infer_headers=self._pre_infer_headers,
         sample_name_encoding=self._sample_name_encoding,
-        use_1_based_format=self._use_1_based_format)
+        use_1_based_coordinate=self._use_1_based_coordinate)
 
     for record in record_iterator:
       yield record
@@ -306,7 +306,7 @@ class ReadFromVcf(PTransform):
       allow_malformed_records=False,  # type: bool
       pre_infer_headers=False,  # type: bool
       sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
-      use_1_based_format=False,  # type: bool
+      use_1_based_coordinate=False,  # type: bool
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -338,7 +338,7 @@ class ReadFromVcf(PTransform):
         allow_malformed_records=allow_malformed_records,
         pre_infer_headers=pre_infer_headers,
         sample_name_encoding=sample_name_encoding,
-        use_1_based_format=use_1_based_format)
+        use_1_based_coordinate=use_1_based_coordinate)
 
   def expand(self, pvalue):
     return pvalue.pipeline | Read(self._source)
@@ -348,14 +348,14 @@ def _create_vcf_source(
     file_pattern=None, representative_header_lines=None, compression_type=None,
     allow_malformed_records=None, pre_infer_headers=False,
     sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,
-    use_1_based_format=False):
+    use_1_based_coordinate=False):
   return _VcfSource(file_pattern=file_pattern,
                     representative_header_lines=representative_header_lines,
                     compression_type=compression_type,
                     allow_malformed_records=allow_malformed_records,
                     pre_infer_headers=pre_infer_headers,
                     sample_name_encoding=sample_name_encoding,
-                    use_1_based_format=use_1_based_format)
+                    use_1_based_coordinate=use_1_based_coordinate)
 
 
 class ReadAllFromVcf(PTransform):
@@ -380,7 +380,7 @@ class ReadAllFromVcf(PTransform):
       allow_malformed_records=False,  # type: bool
       pre_infer_headers=False,  # type: bool
       sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
-      use_1_based_format=False,  # type: bool
+      use_1_based_coordinate=False,  # type: bool
       **kwargs  # type: **str
       ):
     # type: (...) -> None
@@ -412,7 +412,7 @@ class ReadAllFromVcf(PTransform):
         allow_malformed_records=allow_malformed_records,
         pre_infer_headers=pre_infer_headers,
         sample_name_encoding=sample_name_encoding,
-        use_1_based_format=use_1_based_format)
+        use_1_based_coordinate=use_1_based_coordinate)
     self._read_all_files = filebasedsource.ReadAllFiles(
         True,  # splittable
         CompressionTypes.AUTO, desired_bundle_size,

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -255,7 +255,7 @@ class ReadFromBGZF(beam.PTransform):
       sample_name_encoding: specify how we want to encode sample_name mainly
         to deal with same sample_name used across multiple VCF files.
       use_1_based_coordinate: specify whether the coordinates should be stored
-        in BQ needs on a 0 based exclusive (default) or 1 based inclusive basis.
+        in BQ using 0 based exclusive (default) or 1 based inclusive coordinate.
     """
     self._input_files = input_files
     self._representative_header_lines = representative_header_lines
@@ -330,7 +330,7 @@ class ReadFromVcf(PTransform):
       sample_name_encoding: specify how we want to encode sample_name mainly
         to deal with same sample_name used across multiple VCF files.
       use_1_based_coordinate: specify whether the coordinates should be stored
-        in BQ needs on a 0 based exclusive (default) or 1 based inclusive basis.
+        in BQ using 0 based exclusive (default) or 1 based inclusive coordinate.
     """
     super(ReadFromVcf, self).__init__(**kwargs)
 
@@ -408,7 +408,7 @@ class ReadAllFromVcf(PTransform):
       sample_name_encoding: specify how we want to encode sample_name mainly
         to deal with same sample_name used across multiple VCF files.
       use_1_based_coordinate: specify whether the coordinates should be stored
-        in BQ needs on a 0 based exclusive (default) or 1 based inclusive basis.
+        in BQ using 0 based exclusive (default) or 1 based inclusive coordinate.
     """
     super(ReadAllFromVcf, self).__init__(**kwargs)
     source_from_file = partial(

--- a/gcp_variant_transforms/beam_io/vcfio.py
+++ b/gcp_variant_transforms/beam_io/vcfio.py
@@ -254,6 +254,8 @@ class ReadFromBGZF(beam.PTransform):
         exact data for variants and calls, without type matching.
       sample_name_encoding: specify how we want to encode sample_name mainly
         to deal with same sample_name used across multiple VCF files.
+      use_1_based_coordinate: specify whether the coordinates should be stored
+        in BQ needs on a 0 based exclusive (default) or 1 based inclusive basis.
     """
     self._input_files = input_files
     self._representative_header_lines = representative_header_lines
@@ -326,7 +328,9 @@ class ReadFromVcf(PTransform):
       pre_infer_headers: If true, drop headers and make sure PySam return the
         exact data for variants and calls, without type matching.
       sample_name_encoding: specify how we want to encode sample_name mainly
-        to deal with same sample_name used across multiple VCF files
+        to deal with same sample_name used across multiple VCF files.
+      use_1_based_coordinate: specify whether the coordinates should be stored
+        in BQ needs on a 0 based exclusive (default) or 1 based inclusive basis.
     """
     super(ReadFromVcf, self).__init__(**kwargs)
 
@@ -402,7 +406,9 @@ class ReadAllFromVcf(PTransform):
       pre_infer_headers: If true, drop headers and make sure PySam return the
         exact data for variants and calls, without type matching.
       sample_name_encoding: specify how we want to encode sample_name mainly
-        to deal with same sample_name used across multiple VCF files
+        to deal with same sample_name used across multiple VCF files.
+      use_1_based_coordinate: specify whether the coordinates should be stored
+        in BQ needs on a 0 based exclusive (default) or 1 based inclusive basis.
     """
     super(ReadAllFromVcf, self).__init__(**kwargs)
     source_from_file = partial(

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -305,7 +305,7 @@ class VcfSourceTest(unittest.TestCase):
           VcfSource(file_name,
                     representative_header_lines=None,
                     sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,
-                    use_1_based_format=True))
+                    use_1_based_coordinate=True))
 
     self.assertEqual(1, len(read_data))
     self.assertEqual(variant, read_data[0])

--- a/gcp_variant_transforms/beam_io/vcfio_test.py
+++ b/gcp_variant_transforms/beam_io/vcfio_test.py
@@ -72,7 +72,7 @@ VCF_LINE_3 = (
     '19	12	.	C	<SYMBOLIC>	49	q10	AF=0.5	GT:PS:GQ	0|1:1:45	.:.:.\n')
 GVCF_LINE = '19	1234	.	C	<NON_REF>	50	.	END=1236	GT:GQ	0/0:99\n'
 
-def _get_sample_variant_1(file_name=''):
+def _get_sample_variant_1(file_name='', use_1_based_coordinate=False):
   """Get first sample variant.
 
   Features:
@@ -82,7 +82,8 @@ def _get_sample_variant_1(file_name=''):
     utf-8 encoded
   """
   variant = vcfio.Variant(
-      reference_name='20', start=1233, end=1234, reference_bases='C',
+      reference_name='20', start=1234 if use_1_based_coordinate else 1233,
+      end=1234, reference_bases='C',
       alternate_bases=['A', 'T'], names=['rs123', 'rs2'], quality=50,
       filters=['PASS'], info={'AF': [0.5, 0.1], 'NS': 1, 'SVTYPE': ['BÑD']})
   variant.calls.append(
@@ -154,30 +155,6 @@ def _get_sample_non_variant():
                         info={'GQ': 99}))
 
   return non_variant
-
-def _get_sample_variant_1_based():
-  """Get first sample variant.
-
-  Features:
-    multiple alternates
-    not phased
-    multiple names
-    utf-8 encoded
-  """
-  variant = vcfio.Variant(
-      reference_name='20', start=1234, end=1234, reference_bases='C',
-      alternate_bases=['A', 'T'], names=['rs123', 'rs2'], quality=50,
-      filters=['PASS'], info={'AF': [0.5, 0.1], 'NS': 1, 'SVTYPE': ['BÑD']})
-  variant.calls.append(
-      vcfio.VariantCall(
-          sample_id=hash_name('Sample1', ''), genotype=[0, 0],
-          info={'GQ': 48}))
-  variant.calls.append(
-      vcfio.VariantCall(
-          sample_id=hash_name('Sample2', ''), genotype=[1, 0],
-          info={'GQ': 20}))
-
-  return variant
 
 
 class VcfSourceTest(unittest.TestCase):
@@ -296,7 +273,7 @@ class VcfSourceTest(unittest.TestCase):
           content, _SAMPLE_HEADER_LINES))
 
   def test_single_file_1_based_verify_details(self):
-    variant = _get_sample_variant_1_based()
+    variant = _get_sample_variant_1(use_1_based_coordinate=True)
     read_data = None
     with TempDir() as tempdir:
       file_name = tempdir.create_temp_file(

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -103,6 +103,12 @@ class VcfReadOptions(VariantTransformsOptions):
               'of the the header fields do not match the field values. Note: '
               'setting this flag or `--infer_annotation_types` incurs a '
               'performance penalty of an extra pass over all variants.'))
+    parser.add_argument(
+        '--use_1_based_format',
+        type='bool', default=False, nargs='?', const=True,
+        help=('If true, start position will be 1 based, and end position will '
+              'be inclusive. Otherwise, by default the records will stored in '
+              'a 1 based, exclusive format.'))
 
   def validate(self, parsed_args):
     # type: (argparse.Namespace) -> None

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -104,7 +104,7 @@ class VcfReadOptions(VariantTransformsOptions):
               'setting this flag or `--infer_annotation_types` incurs a '
               'performance penalty of an extra pass over all variants.'))
     parser.add_argument(
-        '--use_1_based_format',
+        '--use_1_based_coordinate',
         type='bool', default=False, nargs='?', const=True,
         help=('If true, start position will be 1 based, and end position will '
               'be inclusive. Otherwise, by default the records will stored in '

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -107,8 +107,8 @@ class VcfReadOptions(VariantTransformsOptions):
         '--use_1_based_coordinate',
         type='bool', default=False, nargs='?', const=True,
         help=('If true, start position will be 1 based, and end position will '
-              'be inclusive. Otherwise, by default the records will stored in '
-              'a 1 based, exclusive format.'))
+              'be inclusive. Otherwise, by default the records will be stored '
+              'with 0 based coordinates, with exclusive end position.'))
 
   def validate(self, parsed_args):
     # type: (argparse.Namespace) -> None

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -219,7 +219,8 @@ def read_variants(
     allow_malformed_records,  # type: bool
     representative_header_lines=None,  # type: List[str]
     pre_infer_headers=False,  # type: bool
-    sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH  # type: int
+    sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
+    use_1_based_format=False # type: bool
     ):
   # type: (...) -> pvalue.PCollection
   """Returns a PCollection of Variants by reading VCFs."""
@@ -233,7 +234,8 @@ def read_variants(
                                     representative_header_lines,
                                     allow_malformed_records,
                                     pre_infer_headers,
-                                    sample_name_encoding))
+                                    sample_name_encoding.
+                                    use_1_based_format))
 
   if pipeline_mode == PipelineModes.LARGE:
     variants = (pipeline
@@ -243,7 +245,8 @@ def read_variants(
                     compression_type=compression_type,
                     allow_malformed_records=allow_malformed_records,
                     pre_infer_headers=pre_infer_headers,
-                    sample_name_encoding=sample_name_encoding))
+                    sample_name_encoding=sample_name_encoding,
+                    use_1_based_format=use_1_based_format))
   else:
     variants = pipeline | 'ReadFromVcf' >> vcfio.ReadFromVcf(
         all_patterns[0],
@@ -251,7 +254,8 @@ def read_variants(
         compression_type=compression_type,
         allow_malformed_records=allow_malformed_records,
         pre_infer_headers=pre_infer_headers,
-        sample_name_encoding=sample_name_encoding)
+        sample_name_encoding=sample_name_encoding,
+        use_1_based_format=use_1_based_format)
 
   if compression_type == filesystem.CompressionTypes.GZIP:
     variants |= 'FusionBreak' >> fusion_break.FusionBreak()

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -220,7 +220,7 @@ def read_variants(
     representative_header_lines=None,  # type: List[str]
     pre_infer_headers=False,  # type: bool
     sample_name_encoding=SampleNameEncoding.WITHOUT_FILE_PATH,  # type: int
-    use_1_based_format=False # type: bool
+    use_1_based_coordinate=False # type: bool
     ):
   # type: (...) -> pvalue.PCollection
   """Returns a PCollection of Variants by reading VCFs."""
@@ -234,8 +234,8 @@ def read_variants(
                                     representative_header_lines,
                                     allow_malformed_records,
                                     pre_infer_headers,
-                                    sample_name_encoding.
-                                    use_1_based_format))
+                                    sample_name_encoding,
+                                    use_1_based_coordinate))
 
   if pipeline_mode == PipelineModes.LARGE:
     variants = (pipeline
@@ -246,7 +246,7 @@ def read_variants(
                     allow_malformed_records=allow_malformed_records,
                     pre_infer_headers=pre_infer_headers,
                     sample_name_encoding=sample_name_encoding,
-                    use_1_based_format=use_1_based_format))
+                    use_1_based_coordinate=use_1_based_coordinate))
   else:
     variants = pipeline | 'ReadFromVcf' >> vcfio.ReadFromVcf(
         all_patterns[0],
@@ -255,7 +255,7 @@ def read_variants(
         allow_malformed_records=allow_malformed_records,
         pre_infer_headers=pre_infer_headers,
         sample_name_encoding=sample_name_encoding,
-        use_1_based_format=use_1_based_format)
+        use_1_based_coordinate=use_1_based_coordinate)
 
   if compression_type == filesystem.CompressionTypes.GZIP:
     variants |= 'FusionBreak' >> fusion_break.FusionBreak()

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -240,13 +240,13 @@ class CommonPipelineTest(unittest.TestCase):
     assert_that(variants, asserts.count_equals_to(5))
     pipeline.run()
 
-  def test_read_variants_use_1_based_format(self):
+  def test_read_variants_use_1_based_coordinate(self):
     pipeline = test_pipeline.TestPipeline()
     all_patterns = [testdata_util.get_full_file_path('valid-4.0.vcf')]
     variants = pipeline_common.read_variants(pipeline,
                                              all_patterns,
                                              PipelineModes.SMALL,
                                              False,
-                                             use_1_based_format=True)
+                                             use_1_based_coordinate=True)
     assert_that(variants, asserts.count_equals_to(5))
     pipeline.run()

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -240,22 +240,13 @@ class CommonPipelineTest(unittest.TestCase):
     assert_that(variants, asserts.count_equals_to(5))
     pipeline.run()
 
-  def test_read_variants_pysam(self):
+  def test_read_variants_use_1_based_format(self):
     pipeline = test_pipeline.TestPipeline()
     all_patterns = [testdata_util.get_full_file_path('valid-4.0.vcf')]
     variants = pipeline_common.read_variants(pipeline,
                                              all_patterns,
                                              PipelineModes.SMALL,
-                                             False)
-    assert_that(variants, asserts.count_equals_to(5))
-    pipeline.run()
-
-  def test_read_variants_large_mode_pysam(self):
-    pipeline = test_pipeline.TestPipeline()
-    all_patterns = [testdata_util.get_full_file_path('valid-4.0.vcf')]
-    variants = pipeline_common.read_variants(pipeline,
-                                             all_patterns,
-                                             PipelineModes.LARGE,
-                                             False)
+                                             False,
+                                             use_1_based_format=True)
     assert_that(variants, asserts.count_equals_to(5))
     pipeline.run()

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_1_based.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_1_based.json
@@ -39,7 +39,7 @@
       {
         "query": [
           "SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20` ",
-          "WHERE start_position = 14369"
+          "WHERE start_position = 14370"
         ],
         "expected_result": {"num_rows": 1}
       }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_1_based.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_1_based.json
@@ -1,0 +1,48 @@
+[
+  {
+    "test_name": "merge-option-one-based",
+    "table_name": "merge_option_one_based",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/merge/*.vcf",
+    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "use_1_based_coordinate": true,
+    "runner": "DirectRunner",
+    "variant_merge_strategy": "MOVE_TO_CALLS",
+    "assertion_configs": [
+      {
+        "query": ["NUM_OUTPUT_TABLES"],
+        "expected_result": {"num_tables": 26}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
+        "expected_result": {"sum_start": 1234567}
+      },
+      {
+        "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
+        "expected_result": {"sum_end": 1234570}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"sum_start": 48990}
+      },
+      {
+        "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"sum_end": 48990}
+      },
+      {
+        "query": [
+          "SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20` ",
+          "WHERE start_position = 14369"
+        ],
+        "expected_result": {"num_rows": 1}
+      }
+    ]
+  }
+]

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz_1_based.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz_1_based.json
@@ -1,0 +1,40 @@
+[
+  {
+    "test_name": "valid-4-0-gz-one-based",
+    "table_name": "valid_4_0_gz_one_based",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.gz",
+    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "use_1_based_coordinate": true,
+    "runner": "DirectRunner",
+    "assertion_configs": [
+      {
+        "query": ["NUM_OUTPUT_TABLES"],
+        "expected_result": {"num_tables": 26}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
+        "expected_result": {"sum_start": 1234567}
+      },
+      {
+        "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
+        "expected_result": {"sum_end": 1234570}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"num_rows": 4}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"sum_start": 2372633}
+      },
+      {
+        "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"sum_end": 2372633}
+      }
+    ]
+  }
+]

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -113,7 +113,7 @@ def _read_variants(all_patterns,  # type: List[str]
       representative_header_lines,
       pre_infer_headers=pre_infer_headers,
       sample_name_encoding=SampleNameEncoding[known_args.sample_name_encoding],
-      use_1_based_format=known_args.use_1_based_format)
+      use_1_based_coordinate=known_args.use_1_based_coordinate)
 
 
 def _get_variant_merge_strategy(known_args  # type: argparse.Namespace

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -97,7 +97,7 @@ def _read_variants(all_patterns,  # type: List[str]
                    pipeline,  # type: beam.Pipeline
                    known_args,  # type: argparse.Namespace
                    pipeline_mode,  # type: int
-                   pre_infer_headers=False  # type: bool
+                   pre_infer_headers=False,  # type: bool
                   ):
   # type: (...) -> pvalue.PCollection
   """Helper method for returning a PCollection of Variants from VCFs."""
@@ -112,7 +112,8 @@ def _read_variants(all_patterns,  # type: List[str]
       known_args.allow_malformed_records,
       representative_header_lines,
       pre_infer_headers=pre_infer_headers,
-      sample_name_encoding=SampleNameEncoding[known_args.sample_name_encoding])
+      sample_name_encoding=SampleNameEncoding[known_args.sample_name_encoding],
+      use_1_based_format=known_args.use_1_based_format)
 
 
 def _get_variant_merge_strategy(known_args  # type: argparse.Namespace

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -97,7 +97,7 @@ def _read_variants(all_patterns,  # type: List[str]
                    pipeline,  # type: beam.Pipeline
                    known_args,  # type: argparse.Namespace
                    pipeline_mode,  # type: int
-                   pre_infer_headers=False,  # type: bool
+                   pre_infer_headers=False  # type: bool
                   ):
   # type: (...) -> pvalue.PCollection
   """Helper method for returning a PCollection of Variants from VCFs."""

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -107,8 +107,7 @@ def run(argv=None):
                                                all_patterns,
                                                pipeline_mode,
                                                allow_malformed_records=True,
-                                               pre_infer_headers=True,
-                                               use_1_based_coordinate=False)
+                                               pre_infer_headers=True)
       malformed_records = variants | filter_variants.ExtractMalformedVariants()
       inferred_headers, merged_headers = (_get_inferred_headers(variants,
                                                                 merged_headers))

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -107,7 +107,8 @@ def run(argv=None):
                                                all_patterns,
                                                pipeline_mode,
                                                allow_malformed_records=True,
-                                               pre_infer_headers=True)
+                                               pre_infer_headers=True,
+                                               use_1_based_format=False)
       malformed_records = variants | filter_variants.ExtractMalformedVariants()
       inferred_headers, merged_headers = (_get_inferred_headers(variants,
                                                                 merged_headers))

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -108,7 +108,7 @@ def run(argv=None):
                                                pipeline_mode,
                                                allow_malformed_records=True,
                                                pre_infer_headers=True,
-                                               use_1_based_format=False)
+                                               use_1_based_coordinate=False)
       malformed_records = variants | filter_variants.ExtractMalformedVariants()
       inferred_headers, merged_headers = (_get_inferred_headers(variants,
                                                                 merged_headers))


### PR DESCRIPTION
We may need to contact Mayo to verify if end-pos should be inclusive. Apparently there are a bunch of formats:
https://arnaudceol.wordpress.com/2014/09/18/chromosome-coordinate-systems-0-based-1-based/

However, 1-based inclusive seems to be the most common one.