### PR TITLE
Don't hash sample names on shard variants.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -62,6 +62,7 @@ class SampleNameEncoding(enum.Enum):
   """An Enum specifying the way we encode sample_name."""
   WITHOUT_FILE_PATH = 0
   WITH_FILE_PATH = 1
+  NONE = 2
 
 
 class Variant(object):
@@ -619,8 +620,13 @@ class PySamParser(VcfParser):
       if self._sample_name_encoding == SampleNameEncoding.WITH_FILE_PATH:
         sample_id = hashing_util.generate_sample_id(sample_name,
                                                     self._file_name)
-      else:
+      elif self._sample_name_encoding == SampleNameEncoding.WITHOUT_FILE_PATH:
         sample_id = hashing_util.generate_sample_id(sample_name)
+      elif self._sample_name_encoding == SampleNameEncoding.NONE:
+        sample_id = sample_name
+      else:
+        raise ValueError('Unknown Sample Name Encoding supplied: {}'.format(
+            self._sample_name_encoding))
       self._encoded_sample_names[sample_name] = sample_id
     return sample_id
 

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -174,7 +174,7 @@ class BigQueryWriteOptions(VariantTransformsOptions):
     parser.add_argument(
         '--sample_name_encoding',
         default=vcf_parser.SampleNameEncoding.WITHOUT_FILE_PATH.name,
-        choices=[encoding.name for encoding in vcf_parser.SampleNameEncoding],
+        choices=['WITHOUT_FILE_PATH', 'WITH_FILE_PATH'],
         help=('Choose the way sample ID should be hashed. if `{}` is supplied, '
               'sample_id will be hash value of [sample_name] (default); '
               'alternatively, if `{}` is supplied, sample_id will be hashed '


### PR DESCRIPTION
Also adds an option to not hash samples if we wish to, although that option is currently disabled.