### PR TITLE
Add integeration tests for sample opt tables

### DIFF
--- a/gcp_variant_transforms/testing/data/sharding_configs/integration_with_residual.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/integration_with_residual.yaml
@@ -63,7 +63,7 @@
 -  output_table:
      table_name_suffix: "empty"
      regions:
-       - "does not match to any reference_name value"
+       - "nonexistence_chromosome"
      total_base_pairs: 249,240,615
 -  output_table:
      table_name_suffix: "all_remaining"

--- a/gcp_variant_transforms/testing/data/sharding_configs/integration_with_residual.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/integration_with_residual.yaml
@@ -61,6 +61,11 @@
        - "m"
      total_base_pairs: 57,227,415
 -  output_table:
+     table_name_suffix: "empty"
+     regions:
+       - "does not match to any reference_name value"
+     total_base_pairs: 249,240,615
+-  output_table:
      table_name_suffix: "all_remaining"
      regions:
        - "residual"

--- a/gcp_variant_transforms/testing/data/sharding_configs/integration_without_residual.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/integration_without_residual.yaml
@@ -28,3 +28,8 @@
      regions:
        - "chr1:200,000,000-999,999,999"
      total_base_pairs: 249,240,615
+-  output_table:
+     table_name_suffix: "empty"
+     regions:
+       - "does not match to any reference_name value"
+     total_base_pairs: 249,240,615

--- a/gcp_variant_transforms/testing/data/sharding_configs/integration_without_residual.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/integration_without_residual.yaml
@@ -31,5 +31,5 @@
 -  output_table:
      table_name_suffix: "empty"
      regions:
-       - "does not match to any reference_name value"
+       - "nonexistence_chromosome"
      total_base_pairs: 249,240,615

--- a/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
+++ b/gcp_variant_transforms/testing/integration/run_vcf_to_bq_tests.py
@@ -87,7 +87,7 @@ class VcfToBQTestCase(run_tests_common.TestCaseInterface):
     for k, v in kwargs.iteritems():
       value = v
       if isinstance(v, basestring):
-        value = v.format(TABLE_NAME=dataset_table)
+        value = v.format(TABLE_NAME=full_table_id)
       args.append('--{} {}'.format(k, value))
     self.run_test_command = run_tests_common.form_command(
         context.project,
@@ -168,8 +168,10 @@ class QueryFormatter(object):
 
   class _QueryMacros(enum.Enum):
     NUM_OUTPUT_TABLES = (
-        'SELECT COUNT(0) AS num_tables FROM `{DATASET_ID}.__TABLES_SUMMARY__`'
-        ' WHERE STARTS_WITH(table_id, "{TABLE_ID}' +
+        'SELECT COUNT(0) AS num_tables FROM `{DATASET_ID}.__TABLES_SUMMARY__` '
+        'WHERE STARTS_WITH(table_id, "{TABLE_ID}' +
+        bigquery_util.TABLE_SUFFIX_SEPARATOR + '") '
+        'OR STARTS_WITH(table_id, "{TABLE_ID}_samples' +
         bigquery_util.TABLE_SUFFIX_SEPARATOR + '")')
 
   def __init__(self, dataset_id, table_id):

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_partition_with_residual.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_partition_with_residual.json
@@ -2,6 +2,7 @@
   {
     "test_name": "platinum-partition-with-residual",
     "table_name": "platinum_partition_with_residual",
+    "sample_lookup_optimized_output_table" : "{TABLE_NAME}_samples",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/platinum_3k_rnd_lines/*.vcf",
     "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_with_residual.yaml",
     "runner": "DataflowRunner",
@@ -9,7 +10,7 @@
     "assertion_configs": [
       {
         "query": ["NUM_OUTPUT_TABLES"],
-        "expected_result": {"num_tables": 11}
+        "expected_result": {"num_tables": 21}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr01`"],
@@ -49,6 +50,46 @@
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__all_remaining`"],
+        "expected_result": {"num_rows": 6821}
+      },
+       {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01`"],
+        "expected_result": {"num_rows": 1376}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr02`"],
+        "expected_result": {"num_rows": 1383}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr03`"],
+        "expected_result": {"num_rows": 1101}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr04_05`"],
+        "expected_result": {"num_rows": 2136}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr06_07_08_09`"],
+        "expected_result": {"num_rows": 3656}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr19_10M`"],
+        "expected_result": {"num_rows": 94}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr19_20M`"],
+        "expected_result": {"num_rows": 76}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chrX`"],
+        "expected_result": {"num_rows": 1201}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chrY_M`"],
+        "expected_result": {"num_rows": 156}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__all_remaining`"],
         "expected_result": {"num_rows": 6821}
       }
     ]

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_partition_without_residual.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_partition_without_residual.json
@@ -2,6 +2,7 @@
   {
     "test_name": "platinum-partition-without-residual",
     "table_name": "platinum_partition_without_residual",
+    "sample_lookup_optimized_output_table" : "{TABLE_NAME}_samples",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/platinum_3k_rnd_lines/*.vcf",
     "sharding_config_path": "gcp_variant_transforms/testing/data/sharding_configs/integration_without_residual.yaml",
     "runner": "DataflowRunner",
@@ -9,7 +10,7 @@
     "assertion_configs": [
       {
         "query": ["NUM_OUTPUT_TABLES"],
-        "expected_result": {"num_tables": 7}
+        "expected_result": {"num_tables": 13}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr01_100M`"],
@@ -56,6 +57,53 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19_1M`"],
+        "expected_result": {"sum_start": 6797226}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_100M`"],
+        "expected_result": {"num_rows": 609}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_100M`"],
+        "expected_result": {"sum_start": 29658080117}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_200M`"],
+        "expected_result": {"num_rows": 502}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_200M`"],
+        "expected_result": {"sum_start": 77243594896}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_remaining`"],
+        "expected_result": {"num_rows": 265}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_remaining`"],
+        "expected_result": {"sum_start": 59577867998}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr05_1M`"],
+        "expected_result": {"num_rows": 14}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr05_1M`"],
+        "expected_result": {"sum_start": 6013500}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr07_1M`"],
+        "expected_result": {"num_rows": 10}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr07_1M`"],
+        "expected_result": {"sum_start": 4180562}
+      },      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr19_1M`"],
+        "expected_result": {"num_rows": 11}
+      },
+      {
+        "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr19_1M`"],
         "expected_result": {"sum_start": 6797226}
       }
     ]


### PR DESCRIPTION
We modify the following two tests to verify the sample lookup optimal output tables:
 * platinum_partition_with_residual
 * platinum_partition_without_residual

We also modify the sharding config files so that both include a shard that does not match to any row. We expect these empty output tables to be deletes after we added that functionality in #596