### PR TITLE
Generate Sample Info table through avro file.

### DIFF
--- a/gcp_variant_transforms/data/schema/sample_info.json
+++ b/gcp_variant_transforms/data/schema/sample_info.json
@@ -21,6 +21,6 @@
     "description": "Ingestion datetime (up to current minute) of samples.",
     "mode": "NULLABLE",
     "name": "ingestion_datetime",
-    "type": "DATETIME"
+    "type": "TIMESTAMP"
   }
 ]

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -67,7 +67,7 @@ class TableFieldConstants(object):
   TYPE_RECORD = 'RECORD'
   TYPE_FLOAT = 'FLOAT'
   TYPE_BOOLEAN = 'BOOLEAN'
-  TYPE_DATETIME = 'DATETIME'
+  TYPE_TIMESTAMP = 'TIMESTAMP'
   MODE_NULLABLE = 'NULLABLE'
   MODE_REPEATED = 'REPEATED'
 
@@ -119,7 +119,8 @@ _BIG_QUERY_TYPE_TO_AVRO_TYPE_MAP = {
     TableFieldConstants.TYPE_STRING: 'string',
     TableFieldConstants.TYPE_FLOAT: 'double',
     TableFieldConstants.TYPE_BOOLEAN: 'boolean',
-    TableFieldConstants.TYPE_RECORD: 'record'
+    TableFieldConstants.TYPE_RECORD: 'record',
+    TableFieldConstants.TYPE_TIMESTAMP: 'long'
 }
 
 # A map to convert from BigQuery types to Python types.

--- a/gcp_variant_transforms/libs/sample_info_table_schema_generator.py
+++ b/gcp_variant_transforms/libs/sample_info_table_schema_generator.py
@@ -48,7 +48,7 @@ def generate_schema():
       description=('Full file path on GCS of the sample.')))
   schema.fields.append(bigquery.TableFieldSchema(
       name=INGESTION_DATETIME,
-      type=bigquery_util.TableFieldConstants.TYPE_DATETIME,
+      type=bigquery_util.TableFieldConstants.TYPE_TIMESTAMP,
       mode=bigquery_util.TableFieldConstants.MODE_NULLABLE,
       description=('Ingestion datetime (up to current minute) of samples.')))
 

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz.json
@@ -33,6 +33,25 @@
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
         "expected_result": {"sum_end": 2372633}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__sample_info`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": [
+          "SELECT sample_id FROM `{DATASET_ID}.{TABLE_ID}__sample_info` ",
+          "WHERE sample_name='NA00001'"
+        ],
+        "expected_result": {"sample_id": 1461155635506253861}
+      },
+      {
+        "query": [
+          "SELECT data_type FROM `{DATASET_ID}.INFORMATION_SCHEMA.COLUMNS` ",
+          "WHERE table_name = '{TABLE_ID}__sample_info' AND ",
+          "column_name='ingestion_datetime'"
+        ],
+        "expected_result": {"data_type": "TIMESTAMP"}
       }
     ]
   }

--- a/gcp_variant_transforms/transforms/sample_info_to_avro.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_avro.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/gcp_variant_transforms/transforms/sample_info_to_avro.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_avro.py
@@ -26,7 +26,6 @@ from gcp_variant_transforms.libs import sample_info_table_schema_generator
 from gcp_variant_transforms.libs import schema_converter
 
 SampleNameEncoding = vcf_parser.SampleNameEncoding
-_DATETIME_FORMAT = "%Y-%m-%d %H:%M:00.0"
 _SECS_IN_MIN = 60
 _MICROS_IN_SEC = 1000000
 
@@ -67,9 +66,7 @@ class SampleInfoToAvro(beam.PTransform):
     """Initializes the transform.
 
     Args:
-      output_path: The prefix of the output BigQuery table.
-      append: If true, existing records in output_table will not be
-        overwritten. New records will be appended to those that already exist.
+      output_path: The output path of the sample file in the avro directory.
       sample_name_encoding: If SampleNameEncoding.WITHOUT_FILE_PATH is supplied,
         sample_id would only use sample_name in to get a hashed name; otherwise
         both sample_name and file_name will be used.

--- a/gcp_variant_transforms/transforms/sample_info_to_avro_test.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_avro_test.py
@@ -29,8 +29,8 @@ from gcp_variant_transforms.transforms import sample_info_to_avro
 
 SAMPLE_LINE = (
     '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tSAMPLES\tSample1\tSample2')
-TIME_MOCK=1554426661.234567
-EXPECTED_TIMESTAMP=1554426660000000
+TIME_MOCK = 1554426661.234567
+EXPECTED_TIMESTAMP = 1554426660000000
 def mocked_get_now():
   return TIME_MOCK
 
@@ -40,7 +40,7 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
   @mock.patch('gcp_variant_transforms.transforms.sample_info_to_avro.'
               'time.time',
               side_effect=mocked_get_now)
-  def test_convert_sample_info_to_row(self, mocked_obj):
+  def test_convert_sample_info_to_row(self, _):
     vcf_header_1 = vcf_header_io.VcfHeader(
         samples=SAMPLE_LINE, file_path='gs://bucket1/dir1/file1.vcf')
     vcf_header_2 = vcf_header_io.VcfHeader(
@@ -87,7 +87,7 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
   @mock.patch('gcp_variant_transforms.transforms.sample_info_to_avro.'
               'time.time',
               side_effect=mocked_get_now)
-  def test_convert_sample_info_to_row_without_file_in_hash(self, mocked_obj):
+  def test_convert_sample_info_to_row_without_file_in_hash(self, _):
     vcf_header_1 = vcf_header_io.VcfHeader(samples=SAMPLE_LINE,
                                            file_path='file_1')
     vcf_header_2 = vcf_header_io.VcfHeader(samples=SAMPLE_LINE,

--- a/gcp_variant_transforms/transforms/sample_info_to_avro_test.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_avro_test.py
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC.
+# Copyright 2020 Google LLC.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,21 +29,23 @@ from gcp_variant_transforms.transforms import sample_info_to_avro
 
 SAMPLE_LINE = (
     '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tSAMPLES\tSample1\tSample2')
+TIME_MOCK=1554426661.234567
+EXPECTED_TIMESTAMP=1554426660000000
 def mocked_get_now():
-  return 1554426660000000
+  return TIME_MOCK
 
 
 class ConvertSampleInfoToRowTest(unittest.TestCase):
 
   @mock.patch('gcp_variant_transforms.transforms.sample_info_to_avro.'
-              'ConvertSampleInfoToRow._get_now_to_minute',
+              'time.time',
               side_effect=mocked_get_now)
   def test_convert_sample_info_to_row(self, mocked_obj):
     vcf_header_1 = vcf_header_io.VcfHeader(
         samples=SAMPLE_LINE, file_path='gs://bucket1/dir1/file1.vcf')
     vcf_header_2 = vcf_header_io.VcfHeader(
         samples=SAMPLE_LINE, file_path='gs://bucket1/dir1/file2.vcf')
-    current_minute = mocked_obj()
+    current_minute = EXPECTED_TIMESTAMP
 
     expected_rows = [
         {sample_info_table_schema_generator.SAMPLE_ID: 7715696391291253656,
@@ -83,14 +85,14 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
     pipeline.run()
 
   @mock.patch('gcp_variant_transforms.transforms.sample_info_to_avro.'
-              'ConvertSampleInfoToRow._get_now_to_minute',
+              'time.time',
               side_effect=mocked_get_now)
   def test_convert_sample_info_to_row_without_file_in_hash(self, mocked_obj):
     vcf_header_1 = vcf_header_io.VcfHeader(samples=SAMPLE_LINE,
                                            file_path='file_1')
     vcf_header_2 = vcf_header_io.VcfHeader(samples=SAMPLE_LINE,
                                            file_path='file_2')
-    current_minute = mocked_obj()
+    current_minute = EXPECTED_TIMESTAMP
 
     expected_rows = [
         {sample_info_table_schema_generator.SAMPLE_ID: 6365297890523177914,

--- a/gcp_variant_transforms/transforms/sample_info_to_avro_test.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_avro_test.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for `sample_info_to_bigquery` module."""
+"""Tests for `sample_info_to_avro` module."""
 
 import unittest
 
@@ -25,7 +25,7 @@ import mock
 from gcp_variant_transforms.beam_io import vcf_header_io
 from gcp_variant_transforms.beam_io.vcf_parser import SampleNameEncoding
 from gcp_variant_transforms.libs import sample_info_table_schema_generator
-from gcp_variant_transforms.transforms import sample_info_to_bigquery
+from gcp_variant_transforms.transforms import sample_info_to_avro
 
 SAMPLE_LINE = (
     '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tSAMPLES\tSample1\tSample2')
@@ -35,7 +35,7 @@ def mocked_get_now():
 
 class ConvertSampleInfoToRowTest(unittest.TestCase):
 
-  @mock.patch('gcp_variant_transforms.transforms.sample_info_to_bigquery.'
+  @mock.patch('gcp_variant_transforms.transforms.sample_info_to_avro.'
               'ConvertSampleInfoToRow._get_now_to_minute',
               side_effect=mocked_get_now)
   def test_convert_sample_info_to_row(self, mocked_obj):
@@ -76,13 +76,13 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
         pipeline
         | transforms.Create([vcf_header_1, vcf_header_2])
         | 'ConvertToRow'
-        >> transforms.ParDo(sample_info_to_bigquery.ConvertSampleInfoToRow(
+        >> transforms.ParDo(sample_info_to_avro.ConvertSampleInfoToRow(
             SampleNameEncoding.WITH_FILE_PATH), ))
 
     assert_that(bigquery_rows, equal_to(expected_rows))
     pipeline.run()
 
-  @mock.patch('gcp_variant_transforms.transforms.sample_info_to_bigquery.'
+  @mock.patch('gcp_variant_transforms.transforms.sample_info_to_avro.'
               'ConvertSampleInfoToRow._get_now_to_minute',
               side_effect=mocked_get_now)
   def test_convert_sample_info_to_row_without_file_in_hash(self, mocked_obj):
@@ -115,7 +115,7 @@ class ConvertSampleInfoToRowTest(unittest.TestCase):
         pipeline
         | transforms.Create([vcf_header_1, vcf_header_2])
         | 'ConvertToRow'
-        >> transforms.ParDo(sample_info_to_bigquery.ConvertSampleInfoToRow(
+        >> transforms.ParDo(sample_info_to_avro.ConvertSampleInfoToRow(
             SampleNameEncoding.WITHOUT_FILE_PATH), ))
 
     assert_that(bigquery_rows, equal_to(expected_rows))

--- a/gcp_variant_transforms/transforms/sample_info_to_avro_test.py
+++ b/gcp_variant_transforms/transforms/sample_info_to_avro_test.py
@@ -30,7 +30,7 @@ from gcp_variant_transforms.transforms import sample_info_to_avro
 SAMPLE_LINE = (
     '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tSAMPLES\tSample1\tSample2')
 def mocked_get_now():
-  return '2019-04-05 1:11'
+  return 1554426660000000
 
 
 class ConvertSampleInfoToRowTest(unittest.TestCase):

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -62,7 +62,7 @@ from gcp_variant_transforms.libs.variant_merge import move_to_calls_strategy
 from gcp_variant_transforms.libs.variant_merge import variant_merge_strategy  # pylint: disable=unused-import
 from gcp_variant_transforms.options import variant_transform_options
 from gcp_variant_transforms.transforms import annotate_files
-from gcp_variant_transforms.transforms import sample_info_to_bigquery
+from gcp_variant_transforms.transforms import sample_info_to_avro
 from gcp_variant_transforms.transforms import combine_sample_ids
 from gcp_variant_transforms.transforms import densify_variants
 from gcp_variant_transforms.transforms import extract_input_size
@@ -344,12 +344,11 @@ def _merge_headers(known_args, pipeline_args,
         p, pipeline_mode,
         known_args.all_patterns)
     _ = (headers
-         | 'SampleInfoToBigQuery'
-         >> sample_info_to_bigquery.SampleInfoToBigQuery(
+         | 'SampleInfoToAvro'
+         >> sample_info_to_avro.SampleInfoToAvro(
              avro_root_path +
                 sample_info_table_schema_generator.SAMPLE_INFO_TABLE_SUFFIX,
-             SampleNameEncoding[known_args.sample_name_encoding],
-             known_args.append))
+             SampleNameEncoding[known_args.sample_name_encoding]))
     if known_args.representative_header_file:
       return
     merged_header = pipeline_common.get_merged_headers(

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -549,9 +549,12 @@ def run(argv=None):
             bigquery_util.ColumnKeyConstants.START_POSITION, total_base_pairs)
         logging.info('Integer range partitioned table %s was created.',
                      table_name)
+    if not known_args.append:
+      bigquery_util.create_sample_info_table(known_args.output_table)
     suffixes.append(sample_info_table_schema_generator.SAMPLE_INFO_TABLE_SUFFIX)
-    load_avro = avro_util.LoadAvro(
-        avro_root_path, known_args.output_table, suffixes, False)
+    load_avro = bigquery_util.LoadAvro(avro_root_path,
+                                       known_args.output_table,
+                                       suffixes, not known_args.append)
     not_empty_variant_suffixes = load_avro.start_loading()
     logging.info('Following tables were loaded with at least 1 row:')
     for suffix in not_empty_variant_suffixes:


### PR DESCRIPTION
I looked into generating schema from one source for table and for the avro file, but avro converter needs TableSchema variable, while bq command needs actual json. We should discuss if it makes sense to combine them.

Also, all my attempts to store DATETIME in BQ failed, unfortunately. I don't think that's possible. I used TIMESTAMP approach, which is fine, because BQ automatically converts the output into readable datetime that has UTC timezone. The problem is that gnomad has those fields as datetime, so from now on there is going to be a disconnect.