### PR TITLE
Add a new integration test

### DIFF
--- a/gcp_variant_transforms/libs/partitioning_test.py
+++ b/gcp_variant_transforms/libs/partitioning_test.py
@@ -68,7 +68,8 @@ class FlattenCallColumnTest(unittest.TestCase):
     input_base_table = ('gcp-variant-transforms-test:'
                         'bq_to_vcf_integration_tests.'
                         'merge_option_move_to_calls')
-    self._flatter = partitioning.FlattenCallColumn(input_base_table, ['chr20'])
+    self._flatter = partitioning.FlattenCallColumn(
+        input_base_table, ['chr20'], False)
     # Set in mock_find_non_empty, ie mock of _find_one_non_empty_table()
     mock_find_non_empty.return_value = None
     self._flatter._schema_table_id = 'merge_option_move_to_calls__chr20'

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -239,7 +239,7 @@ class BigQueryWriteOptions(VariantTransformsOptions):
       raise ValueError('--output_table must have a value.')
     self._validate_output_tables(
         client, parsed_args.output_table,
-        parsed_args.sharding_config_path, parsed_args.append)
+        parsed_args.sharding_config_path, parsed_args.append, True)
 
     if parsed_args.sample_lookup_optimized_output_table:
       if (parsed_args.output_table ==
@@ -248,11 +248,11 @@ class BigQueryWriteOptions(VariantTransformsOptions):
                          'same as output_table.')
       self._validate_output_tables(
           client, parsed_args.sample_lookup_optimized_output_table,
-          parsed_args.sharding_config_path, parsed_args.append)
+          parsed_args.sharding_config_path, parsed_args.append, False)
 
   def _validate_output_tables(self, client,
                               output_table_base_name,
-                              sharding_config_path, append):
+                              sharding_config_path, append, is_main_output):
     if (output_table_base_name !=
         bigquery_util.get_table_base_name(output_table_base_name)):
       raise ValueError(('Output table cannot contain "{}". we reserve this '
@@ -264,8 +264,9 @@ class BigQueryWriteOptions(VariantTransformsOptions):
     bigquery_util.raise_error_if_dataset_not_exists(client, project_id,
                                                     dataset_id)
     all_output_tables = []
-    all_output_tables.append(
-        bigquery_util.compose_table_name(table_id, SAMPLE_INFO_TABLE_SUFFIX))
+    if is_main_output:
+      all_output_tables.append(
+          bigquery_util.compose_table_name(table_id, SAMPLE_INFO_TABLE_SUFFIX))
     sharding = variant_sharding.VariantSharding(sharding_config_path)
     num_shards = sharding.get_num_shards()
     # In case there is no residual in config we will ignore the last shard.

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_append_to_table_sample_optimized.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_append_to_table_sample_optimized.json
@@ -1,0 +1,247 @@
+[
+  {
+    "test_name": "samples-append-step-1",
+    "table_name": "samples_append",
+    "sample_lookup_optimized_output_table" : "{TABLE_NAME}_samples",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf",
+    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "runner": "DataflowRunner",
+    "assertion_configs": [
+      {
+        "query": ["NUM_OUTPUT_TABLES"],
+        "expected_result": {"num_tables": 51}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr19`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"num_rows": 4}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr20`"],
+        "expected_result": {"num_rows": 12}
+      }
+    ]
+  },
+  {
+    "test_name": "samples-append-step-2",
+    "table_name": "samples_append",
+    "sample_lookup_optimized_output_table" : "{TABLE_NAME}_samples",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0_all_chromosomes.vcf",
+    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "runner": "DataflowRunner",
+    "append": true,
+    "assertion_configs": [
+      {
+        "query": ["NUM_OUTPUT_TABLES"],
+        "expected_result": {"num_tables": 51}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr1`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr2`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr3`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr4`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr4`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr5`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr5`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr6`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr6`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr7`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr7`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr8`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr8`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr9`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr9`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr10`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr10`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr11`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr11`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr12`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr12`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr13`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr13`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr14`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr14`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr15`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr15`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr16`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr16`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr17`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr17`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr18`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr18`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
+        "expected_result": {"num_rows": 2}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr19`"],
+        "expected_result": {"num_rows": 6}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"num_rows": 8}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr20`"],
+        "expected_result": {"num_rows": 24}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr21`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr21`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr22`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr22`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chrX`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chrX`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chrY`"],
+        "expected_result": {"num_rows": 3}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
+        "expected_result": {"num_rows": 1}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__residual`"],
+        "expected_result": {"num_rows": 3}
+      }
+    ]
+  }
+]

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_update_schema_on_append.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_update_schema_on_append.json
@@ -2,7 +2,7 @@
   {
     "test_name": "option-update-schema-on-append-step-1",
     "table_name": "option_update_schema_on_append",
-    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0_all_chromosomes.vcf",
+    "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf",
     "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
     "runner": "DataflowRunner",
     "assertion_configs": [
@@ -11,104 +11,12 @@
         "expected_result": {"num_tables": 26}
       },
       {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr4`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr5`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr6`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr7`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr8`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr9`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr10`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr11`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr12`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr13`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr14`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr15`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr16`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr17`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr18`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
         "expected_result": {"num_rows": 1}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
         "expected_result": {"num_rows": 4}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr21`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr22`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chrX`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"num_rows": 1}
       }
     ]
   },
@@ -126,78 +34,6 @@
         "expected_result": {"num_tables": 26}
       },
       {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr4`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr5`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr6`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr7`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr8`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr9`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr10`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr11`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr12`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr13`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr14`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr15`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr16`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr17`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr18`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
         "expected_result": {"num_rows": 2}
       },
@@ -206,24 +42,12 @@
         "expected_result": {"num_rows": 14}
       },
       {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr21`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr22`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
-        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chrX`"],
-        "expected_result": {"num_rows": 1}
-      },
-      {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"num_rows": 2}
+        "expected_result": {"num_rows": 1}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"num_rows": 2}
+        "expected_result": {"num_rows": 1}
       }
     ]
   }

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -579,7 +579,7 @@ def run(argv=None):
 
   if known_args.sample_lookup_optimized_output_table:
     flatten_call_column = partitioning.FlattenCallColumn(
-        known_args.output_table, not_empty_variant_suffixes)
+        known_args.output_table, not_empty_variant_suffixes, known_args.append)
     try:
       flatten_schema_file = tempfile.mkstemp(suffix=_BQ_SCHEMA_FILE_SUFFIX)[1]
       if not flatten_call_column.get_flatten_table_schema(flatten_schema_file):


### PR DESCRIPTION
for validating `--append` logic with sample optimized tables.

Also modifiying a test (`option_update_schema_on_append`) that should have been included in #605  (which was the rollback of #596 ).
Also fixing how we validate the input flag `sample_lookup_optimized_output_table`.