### PR TITLE
pin pysam version to < 0.16.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ PYSAM_DEPENDENCY_COMMANDS = [
      'zlib1g-dev']
 ]
 
-PYSAM_INSTALLATION_COMMAND = ['pip', 'install', 'pysam>=0.15.3']
+PYSAM_INSTALLATION_COMMAND = ['pip', 'install', 'pysam<0.16.0']
 
 REQUIRED_PACKAGES = [
     'cython>=0.28.1',


### PR DESCRIPTION
Due to issues related to this integration test:
`test_allow_malformed_records`

It seems pysam gets stock in some kind of halt state when it parses that malformed VCF file (which is missing `start_position` value in one of its lines).