### PR TITLE
Rename a field in sharding config file

### DIFF
--- a/gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml
+++ b/gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml
@@ -3,133 +3,133 @@
      regions:
        - "chr1"
        - "1"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615
 -  output_table:
      table_name_suffix: "chr2"
      regions:
        - "chr2"
        - "2"
-     total_base_pairs: 243,189,284
+     partition_range_end: 243,189,284
 -  output_table:
      table_name_suffix: "chr3"
      regions:
        - "chr3"
        - "3"
-     total_base_pairs: 198,233,091
+     partition_range_end: 198,233,091
 -  output_table:
      table_name_suffix: "chr4"
      regions:
        - "chr4"
        - "4"
-     total_base_pairs: 191,044,274
+     partition_range_end: 191,044,274
 -  output_table:
      table_name_suffix: "chr5"
      regions:
        - "chr5"
        - "5"
-     total_base_pairs: 181,478,212
+     partition_range_end: 181,478,212
 -  output_table:
      table_name_suffix: "chr6"
      regions:
        - "chr6"
        - "6"
-     total_base_pairs: 171,053,767
+     partition_range_end: 171,053,767
 -  output_table:
      table_name_suffix: "chr7"
      regions:
        - "chr7"
        - "7"
-     total_base_pairs: 159,335,971
+     partition_range_end: 159,335,971
 -  output_table:
      table_name_suffix: "chr8"
      regions:
        - "chr8"
        - "8"
-     total_base_pairs: 146,303,973
+     partition_range_end: 146,303,973
 -  output_table:
      table_name_suffix: "chr9"
      regions:
        - "chr9"
        - "9"
-     total_base_pairs: 141,149,922
+     partition_range_end: 141,149,922
 -  output_table:
      table_name_suffix: "chr10"
      regions:
        - "chr10"
        - "10"
-     total_base_pairs: 135,524,745
+     partition_range_end: 135,524,745
 -  output_table:
      table_name_suffix: "chr11"
      regions:
        - "chr11"
        - "11"
-     total_base_pairs: 135,076,620
+     partition_range_end: 135,076,620
 -  output_table:
      table_name_suffix: "chr12"
      regions:
        - "chr12"
        - "12"
-     total_base_pairs: 133,841,700
+     partition_range_end: 133,841,700
 -  output_table:
      table_name_suffix: "chr13"
      regions:
        - "chr13"
        - "13"
-     total_base_pairs: 115,109,876
+     partition_range_end: 115,109,876
 -  output_table:
      table_name_suffix: "chr14"
      regions:
        - "chr14"
        - "14"
-     total_base_pairs: 107,289,538
+     partition_range_end: 107,289,538
 -  output_table:
      table_name_suffix: "chr15"
      regions:
        - "chr15"
        - "15"
-     total_base_pairs: 102,521,390
+     partition_range_end: 102,521,390
 -  output_table:
      table_name_suffix: "chr16"
      regions:
        - "chr16"
        - "16"
-     total_base_pairs: 90,294,745
+     partition_range_end: 90,294,745
 -  output_table:
      table_name_suffix: "chr17"
      regions:
        - "chr17"
        - "17"
-     total_base_pairs: 83,247,376
+     partition_range_end: 83,247,376
 -  output_table:
      table_name_suffix: "chr18"
      regions:
        - "chr18"
        - "18"
-     total_base_pairs: 80,263,277
+     partition_range_end: 80,263,277
 -  output_table:
      table_name_suffix: "chr19"
      regions:
        - "chr19"
        - "19"
-     total_base_pairs: 59,118,975
+     partition_range_end: 59,118,975
 -  output_table:
      table_name_suffix: "chr20"
      regions:
        - "chr20"
        - "20"
-     total_base_pairs: 64,334,162
+     partition_range_end: 64,334,162
 -  output_table:
      table_name_suffix: "chr21"
      regions:
        - "chr21"
        - "21"
-     total_base_pairs: 48,119,890
+     partition_range_end: 48,119,890
 -  output_table:
      table_name_suffix: "chr22"
      regions:
        - "chr22"
        - "22"
-     total_base_pairs: 51,244,528
+     partition_range_end: 51,244,528
 -  output_table:
      table_name_suffix: "chrX"
      regions:
@@ -137,7 +137,7 @@
        - "chrx"
        - "X"
        - "x"
-     total_base_pairs: 156,030,808
+     partition_range_end: 156,030,808
 -  output_table:
      table_name_suffix: "chrY"
      regions:
@@ -145,10 +145,10 @@
        - "chry"
        - "Y"
        - "y"
-     total_base_pairs: 57,227,415
+     partition_range_end: 57,227,415
 -  output_table:
      table_name_suffix: "residual"
      regions:
        - "residual"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615
 

--- a/gcp_variant_transforms/libs/variant_sharding_test.py
+++ b/gcp_variant_transforms/libs/variant_sharding_test.py
@@ -108,7 +108,7 @@ class VariantShardingTest(unittest.TestCase):
     self.assertEqual(sharder.get_output_table_suffix(6), 'chr3_02')
     self.assertEqual(sharder.get_output_table_suffix(7), 'all_remaining')
 
-  def test_config_get_total_base_pairs(self):
+  def test_config_get_partition_range_end(self):
     sharder = variant_sharding.VariantSharding(
         'gcp_variant_transforms/testing/data/sharding_configs/'
         'residual_at_end.yaml')
@@ -116,14 +116,14 @@ class VariantShardingTest(unittest.TestCase):
     for i in range(sharder.get_num_shards()):
       self.assertTrue(sharder.should_keep_shard(i))
 
-    self.assertEqual(sharder.get_output_table_total_base_pairs(0), 1000000)
-    self.assertEqual(sharder.get_output_table_total_base_pairs(1), 2000000)
-    self.assertEqual(sharder.get_output_table_total_base_pairs(2), 249240615)
-    self.assertEqual(sharder.get_output_table_total_base_pairs(3), 243189284)
-    self.assertEqual(sharder.get_output_table_total_base_pairs(4), 191044274)
-    self.assertEqual(sharder.get_output_table_total_base_pairs(5), 500000)
-    self.assertEqual(sharder.get_output_table_total_base_pairs(6), 1000000)
-    self.assertEqual(sharder.get_output_table_total_base_pairs(7), 249240615)
+    self.assertEqual(sharder.get_output_table_partition_range_end(0), 1000000)
+    self.assertEqual(sharder.get_output_table_partition_range_end(1), 2000000)
+    self.assertEqual(sharder.get_output_table_partition_range_end(2), 249240615)
+    self.assertEqual(sharder.get_output_table_partition_range_end(3), 243189284)
+    self.assertEqual(sharder.get_output_table_partition_range_end(4), 191044274)
+    self.assertEqual(sharder.get_output_table_partition_range_end(5), 500000)
+    self.assertEqual(sharder.get_output_table_partition_range_end(6), 1000000)
+    self.assertEqual(sharder.get_output_table_partition_range_end(7), 249240615)
 
   def test_config_non_existent_shard_name(self):
     sharder = variant_sharding.VariantSharding(
@@ -225,16 +225,16 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "chr01_part1"',
         '     regions:',
         '       - "chr1:0-1,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "all_remaining"',
         '     regions:',
         '       - "residual"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "missing_region"',
         '     regions:',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -249,7 +249,7 @@ class VariantShardingTest(unittest.TestCase):
         '-  output_table:',
         '     regions:',
         '       - "chr1:0-1,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -262,7 +262,7 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "          "',
         '     regions:',
         '       - "chr1:0-1,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -278,17 +278,17 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "all_remaining"',
         '     regions:',
         '       - "residual"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "chr01"',
         '     regions:',
         '       - "chr1"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "all_remaining_2"',
         '     regions:',
         '       - "residual"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -304,12 +304,12 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "chr01_part1"',
         '     regions:',
         '       - "chr1:0-1,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "chr01_part2_overlapping"',
         '     regions:',
         '       - "chr1:999,999-2,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError, 'Wrong sharding config file, regions must be unique*'):
@@ -322,12 +322,12 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "chr01_full"',
         '     regions:',
         '       - "chr1"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "chr01_part_overlapping"',
         '     regions:',
         '       - "chr1:1,000,000-2,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError, 'Wrong sharding config file, regions must be unique*'):
@@ -340,12 +340,12 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "chr01_part"',
         '     regions:',
         '       - "chr1:1,000,000-2,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "chr01_full_overlapping"',
         '     regions:',
         '       - "chr1"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError, 'Wrong sharding config file, regions must be unique*'):
@@ -358,17 +358,17 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "chr01_full"',
         '     regions:',
         '       - "chr1"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "chr02_part"',
         '     regions:',
         '       - "chr2:1,000,000-2,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "chr01_full_redundant"',
         '     regions:',
         '       - "chr1"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError, 'Wrong sharding config file, regions must be unique*'):
@@ -383,17 +383,17 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "duplicate_name"',
         '     regions:',
         '       - "chr1:0-1,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "all_remaining"',
         '     regions:',
         '       - "residual"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
         '-  output_table:',
         '     table_name_suffix: "duplicate_name"',
         '     regions:',
         '       - "chr1:1,000,000-2,000,000"',
-        '     total_base_pairs: 999999999',
+        '     partition_range_end: 999999999',
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -410,7 +410,7 @@ class VariantShardingTest(unittest.TestCase):
         '     regions:',
         '       - "chr1"',
         '       - "1"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -424,7 +424,7 @@ class VariantShardingTest(unittest.TestCase):
         '     regions:',
         '       - "chr1"',
         '       - "1"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -436,7 +436,7 @@ class VariantShardingTest(unittest.TestCase):
     missing_chrom_values = [
         '-  output_table:',
         '     table_name_suffix: "chr1"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -449,7 +449,7 @@ class VariantShardingTest(unittest.TestCase):
         '-  output_table:',
         '     table_name_suffix: "chr1"',
         '     regions:',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -458,7 +458,7 @@ class VariantShardingTest(unittest.TestCase):
           tempdir.create_temp_file(suffix='.yaml',
                                    lines='\n'.join(missing_filters)))
 
-    missing_total_base_pairs = [
+    missing_partition_range_end = [
         '-  output_table:',
         '     table_name_suffix: "chr1"',
         '     regions:',
@@ -467,10 +467,10 @@ class VariantShardingTest(unittest.TestCase):
     ]
     with self.assertRaisesRegexp(
         ValueError,
-        'Wrong sharding config file, total_base_pairs field missing.'):
+        'Wrong sharding config file, partition_range_end field missing.'):
       _ = variant_sharding.VariantSharding(
-          tempdir.create_temp_file(suffix='.yaml',
-                                   lines='\n'.join(missing_total_base_pairs)))
+          tempdir.create_temp_file(
+              suffix='.yaml', lines='\n'.join(missing_partition_range_end)))
 
   def test_config_failed_wrong_fields(self):
     tempdir = temp_dir.TempDir()
@@ -480,7 +480,7 @@ class VariantShardingTest(unittest.TestCase):
         '     regions:',
         '       - "chr1"',
         '       - "1"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -496,7 +496,7 @@ class VariantShardingTest(unittest.TestCase):
         '     regions:',
         '       - "chr1"',
         '       - "1"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -511,12 +511,12 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "chr1"',
         '     regions:',
         '       - "chr1"',
-        '     total_base_pairs: 249240615',
+        '     partition_range_end: 249240615',
         '-  output_table:',
         '     table_name_suffix: "chr1"',
         '     regions:',
         '       - "chr2"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -532,7 +532,7 @@ class VariantShardingTest(unittest.TestCase):
         '     regions:',
         '       - "chr1"',
         '       - " "',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -548,7 +548,7 @@ class VariantShardingTest(unittest.TestCase):
         '     regions:',
         '       - "dup_value"',
         '       - "dup_value"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -562,12 +562,12 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "chr1"',
         '     regions:',
         '       - "dup_value"',
-        '     total_base_pairs: 249240615',
+        '     partition_range_end: 249240615',
         '-  output_table:',
         '     table_name_suffix: "chr2"',
         '     regions:',
         '       - "dup_value"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -581,12 +581,12 @@ class VariantShardingTest(unittest.TestCase):
         '     table_name_suffix: "residual1"',
         '     regions:',
         '       - "residual"',
-        '     total_base_pairs: 249240615',
+        '     partition_range_end: 249240615',
         '-  output_table:',
         '     table_name_suffix: "residual2"',
         '     regions:',
         '       - "residual"',
-        '     total_base_pairs: 249240615'
+        '     partition_range_end: 249240615'
     ]
     with self.assertRaisesRegexp(
         ValueError,
@@ -595,32 +595,32 @@ class VariantShardingTest(unittest.TestCase):
           tempdir.create_temp_file(suffix='.yaml',
                                    lines='\n'.join(duplicate_residual)))
 
-    not_int_total_base_pairs = [
+    not_int_partition_range_end = [
         '-  output_table:',
         '     table_name_suffix: "chr1"',
         '     regions:',
         '       - "chr1"',
         '       - "1"',
-        '     total_base_pairs: "not int"'
+        '     partition_range_end: "not int"'
     ]
     with self.assertRaisesRegexp(
         ValueError,
         'Wrong sharding config file, each output table needs an integer for *'):
       _ = variant_sharding.VariantSharding(
-          tempdir.create_temp_file(suffix='.yaml',
-                                   lines='\n'.join(not_int_total_base_pairs)))
+          tempdir.create_temp_file(
+              suffix='.yaml', lines='\n'.join(not_int_partition_range_end)))
 
-    not_pos_total_base_pairs = [
+    not_pos_partition_range_end = [
         '-  output_table:',
         '     table_name_suffix: "chr1"',
         '     regions:',
         '       - "chr1"',
         '       - "1"',
-        '     total_base_pairs: -10'
+        '     partition_range_end: -10'
     ]
     with self.assertRaisesRegexp(
         ValueError,
         'Wrong sharding config file, each output table needs an integer for *'):
       _ = variant_sharding.VariantSharding(
-          tempdir.create_temp_file(suffix='.yaml',
-                                   lines='\n'.join(not_pos_total_base_pairs)))
+          tempdir.create_temp_file(
+              suffix='.yaml', lines='\n'.join(not_pos_partition_range_end)))

--- a/gcp_variant_transforms/testing/data/sharding_configs/integration_with_residual.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/integration_with_residual.yaml
@@ -2,25 +2,25 @@
      table_name_suffix: "empty"
      regions:
        - "nonexistence_chromosome"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615
 -  output_table:
      table_name_suffix: "chr01"
      regions:
        - "chr1"
        - "1"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615
 -  output_table:
      table_name_suffix: "chr02"
      regions:
        - "chr2"
        - "2"
-     total_base_pairs: 243,189,284
+     partition_range_end: 243,189,284
 -  output_table:
      table_name_suffix: "chr03"
      regions:
        - "chr3"
        - "3"
-     total_base_pairs: 197,961,643
+     partition_range_end: 197,961,643
 -  output_table:
      table_name_suffix: "chr04_05"
      regions:
@@ -28,7 +28,7 @@
        - "4"
        - "chr5"
        - "5"
-     total_base_pairs: 191,044,274
+     partition_range_end: 191,044,274
 -  output_table:
      table_name_suffix: "chr06_07_08_09"
      regions:
@@ -40,23 +40,23 @@
        - "8"
        - "chr9"
        - "9"
-     total_base_pairs: 171,053,767
+     partition_range_end: 171,053,767
 -  output_table:
      table_name_suffix: "chr19_10M"
      regions:
        - "chr19:0-10,000,000"
-     total_base_pairs: 10,000,000
+     partition_range_end: 10,000,000
 -  output_table:
      table_name_suffix: "chr19_20M"
      regions:
        - "chr19:10,000,000-20,000,000"
-     total_base_pairs: 20,000,000
+     partition_range_end: 20,000,000
 -  output_table:
      table_name_suffix: "chrX"
      regions:
        - "chrX"
        - "x"
-     total_base_pairs: 155,260,473
+     partition_range_end: 155,260,473
 -  output_table:
      table_name_suffix: "chrY_M"
      regions:
@@ -64,9 +64,9 @@
        - "y"
        - "chrM"
        - "m"
-     total_base_pairs: 57,227,415
+     partition_range_end: 57,227,415
 -  output_table:
      table_name_suffix: "all_remaining"
      regions:
        - "residual"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615

--- a/gcp_variant_transforms/testing/data/sharding_configs/integration_without_residual.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/integration_without_residual.yaml
@@ -2,34 +2,34 @@
      table_name_suffix: "empty"
      regions:
        - "nonexistence_chromosome"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615
 -  output_table:
      table_name_suffix: "chr19_1M"
      regions:
        - "chr19:0-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000
 -  output_table:
      table_name_suffix: "chr05_1M"
      regions:
        - "chr5:0-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000
 -  output_table:
      table_name_suffix: "chr07_1M"
      regions:
        - "chr7:0-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000
 -  output_table:
      table_name_suffix: "chr01_100M"
      regions:
        - "chr1:0-100,000,000"
-     total_base_pairs: 100,000,000
+     partition_range_end: 100,000,000
 -  output_table:
      table_name_suffix: "chr01_200M"
      regions:
        - "chr1:100,000,000-200,000,000"
-     total_base_pairs: 200,000,000
+     partition_range_end: 200,000,000
 -  output_table:
      table_name_suffix: "chr01_remaining"
      regions:
        - "chr1:200,000,000-999,999,999"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615

--- a/gcp_variant_transforms/testing/data/sharding_configs/residual_at_end.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/residual_at_end.yaml
@@ -2,17 +2,17 @@
      table_name_suffix: "chr01_part1"
      regions:
        - "chr1:0-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000
 -  output_table:
      table_name_suffix: "chr01_part2"
      regions:
        - "chr1:1,000,000-2,000,000"
-     total_base_pairs: 2,000,000
+     partition_range_end: 2,000,000
 -  output_table:
      table_name_suffix: "chr01_part3"
      regions:
        - "chr1:2,000,000-999,999,999"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615
 -  output_table:
      table_name_suffix: "chrom02"
      regions:
@@ -20,26 +20,26 @@
        - "chr2_alternate_name1"
        - "chr2_ALteRNate_NAME2"
        - "2"
-     total_base_pairs: 243,189,284
+     partition_range_end: 243,189,284
 -  output_table:
      table_name_suffix: "chrom04_05_part_06"
      regions:
        - "chr4"
        - "chr5"
        - "chr6:1,000,000-2,000,000"
-     total_base_pairs: 191,044,274
+     partition_range_end: 191,044,274
 -  output_table:
      table_name_suffix: "chr3_01"
      regions:
        - "3:0-500,000"
-     total_base_pairs: 500,000
+     partition_range_end: 500,000
 -  output_table:
      table_name_suffix: "chr3_02"
      regions:
        - "3:500,000-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000
 -  output_table:
      table_name_suffix: "all_remaining"
      regions:
        - "residual"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615

--- a/gcp_variant_transforms/testing/data/sharding_configs/residual_in_middle.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/residual_in_middle.yaml
@@ -2,24 +2,24 @@
      table_name_suffix: "chr01_part1"
      regions:
        - "chr1:0-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000
 -  output_table:
      table_name_suffix: "all_remaining"
      regions:
        - "residual"
-     total_base_pairs: 249,240,615
+     partition_range_end: 249,240,615
 -  output_table:
      table_name_suffix: "chr01_part2"
      regions:
        - "chr1:1,000,000-2,000,000"
-     total_base_pairs: 2,000,000
+     partition_range_end: 2,000,000
 -  output_table:
      table_name_suffix: "chrom02"
      regions:
        - "chr2"
-     total_base_pairs: 243,189,284
+     partition_range_end: 243,189,284
 -  output_table:
      table_name_suffix: "chr3_02"
      regions:
        - "3:500,000-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000

--- a/gcp_variant_transforms/testing/data/sharding_configs/residual_missing.yaml
+++ b/gcp_variant_transforms/testing/data/sharding_configs/residual_missing.yaml
@@ -2,19 +2,19 @@
      table_name_suffix: "chr01_part1"
      regions:
        - "chr1:0-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000
 -  output_table:
      table_name_suffix: "chr01_part2"
      regions:
        - "chr1:1,000,000-2,000,000"
-     total_base_pairs: 2,000,000
+     partition_range_end: 2,000,000
 -  output_table:
      table_name_suffix: "chrom02"
      regions:
        - "chr2"
-     total_base_pairs: 243,189,284
+     partition_range_end: 243,189,284
 -  output_table:
      table_name_suffix: "chr3_02"
      regions:
        - "3:500,000-1,000,000"
-     total_base_pairs: 1,000,000
+     partition_range_end: 1,000,000

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -537,13 +537,14 @@ def run(argv=None):
   try:
     for i in range(num_shards):
       suffixes.append(sharding.get_output_table_suffix(i))
-      total_base_pairs = sharding.get_output_table_total_base_pairs(i)
+      partition_range_end = sharding.get_output_table_partition_range_end(i)
       if not known_args.append:
         table_name = bigquery_util.compose_table_name(known_args.output_table,
                                                       suffixes[i])
         partitioning.create_bq_table(
             table_name, schema_file,
-            bigquery_util.ColumnKeyConstants.START_POSITION, total_base_pairs)
+            bigquery_util.ColumnKeyConstants.START_POSITION,
+            partition_range_end)
         logging.info('Integer range partitioned table %s was created.',
                      table_name)
     if not known_args.append:


### PR DESCRIPTION
Per request of one of our customers, we rename the `total_base_pairs` to `partition_range_end` to make it more clear we use that number for integer range partitioning of output tables.