### PR TITLE
Add a new sharding config with fixed partition range end values

### DIFF
--- a/gcp_variant_transforms/data/sharding_configs/homo_sapiens_fixed_partitions.yaml
+++ b/gcp_variant_transforms/data/sharding_configs/homo_sapiens_fixed_partitions.yaml
@@ -1,0 +1,154 @@
+-  output_table:
+     table_name_suffix: "chr1"
+     regions:
+       - "chr1"
+       - "1"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr2"
+     regions:
+       - "chr2"
+       - "2"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr3"
+     regions:
+       - "chr3"
+       - "3"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr4"
+     regions:
+       - "chr4"
+       - "4"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr5"
+     regions:
+       - "chr5"
+       - "5"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr6"
+     regions:
+       - "chr6"
+       - "6"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr7"
+     regions:
+       - "chr7"
+       - "7"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr8"
+     regions:
+       - "chr8"
+       - "8"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr9"
+     regions:
+       - "chr9"
+       - "9"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr10"
+     regions:
+       - "chr10"
+       - "10"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr11"
+     regions:
+       - "chr11"
+       - "11"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr12"
+     regions:
+       - "chr12"
+       - "12"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr13"
+     regions:
+       - "chr13"
+       - "13"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr14"
+     regions:
+       - "chr14"
+       - "14"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr15"
+     regions:
+       - "chr15"
+       - "15"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr16"
+     regions:
+       - "chr16"
+       - "16"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr17"
+     regions:
+       - "chr17"
+       - "17"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr18"
+     regions:
+       - "chr18"
+       - "18"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr19"
+     regions:
+       - "chr19"
+       - "19"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr20"
+     regions:
+       - "chr20"
+       - "20"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr21"
+     regions:
+       - "chr21"
+       - "21"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chr22"
+     regions:
+       - "chr22"
+       - "22"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chrX"
+     regions:
+       - "chrX"
+       - "chrx"
+       - "X"
+       - "x"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "chrY"
+     regions:
+       - "chrY"
+       - "chry"
+       - "Y"
+       - "y"
+     partition_range_end: 249,240,615
+-  output_table:
+     table_name_suffix: "residual"
+     regions:
+       - "residual"
+     partition_range_end: 249,240,615
+


### PR DESCRIPTION
This was a feedback by one of our users who wanted to define a view on all of their output tables. If tables have different partition range ends then that is not possible. Similarly, running a query with wildcard on table name would fail.

This sharding config would resolve that issue. The down side is higher query cost for smaller chromosomes, especially chromosome 19, 20, 21, 22, and Y.