### PR TITLE
Adding sub network and private address as options to the gcp-variant-transforms container

### DIFF
--- a/docker/pipelines_runner.sh
+++ b/docker/pipelines_runner.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 #################################################
 function parse_args {
   # getopt command is only for checking arguments.
-  getopt -o '' -l project:,temp_location:,docker_image:,region:,zone:,network:,subnetwork:,privateAddress: -- "$@"
+  getopt -o '' -l project:,temp_location:,docker_image:,region:,subnetwork:,privateAddress: -- "$@"
   while [[ "$#" -gt 0 ]]; do
     case "$1" in
       --project)
@@ -39,14 +39,6 @@ function parse_args {
 
       --region)
         region="$2"
-        ;;
-
-      --zone)
-        zone="$2"
-        ;;
-
-      --network)
-        network="$2"
         ;;
 
       --subnetwork)
@@ -76,8 +68,6 @@ function main {
   vt_docker_image="${vt_docker_image:-gcr.io/cloud-lifesciences/gcp-variant-transforms}"
   region="${region:-$(gcloud config get-value compute/region)}"
   temp_location="${temp_location:-''}"
-  zone="${zone:-}"
-  network="${network:-}"
   subnetwork="${subnetwork:-}"
   privateAddress="${privateAddress:-}"
   extra_args=""
@@ -94,30 +84,20 @@ function main {
     exit 1
   fi
 
-  if [[ ! -v command ]]; then
-    echo "Please specify a command to run Variant Transforms."
-    exit 1
-  fi
-
   # Build up the extra args is they are provided
-  if [[ ! -z "${zone}" ]]; then
-    echo "Adding --zone=${zone} to extra_args"
-    extra_args="${extra_args} --zone=${zone}"
-  fi
-
-  if [[ ! -z "${network}" ]]; then
-    echo "Adding --network=${network} to extra_args"
-    extra_args="${extra_args} --network=${network}"
-  fi
-
   if [[ ! -z "${subnetwork}" ]]; then
-    echo "Adding --subnetwork=${subnetwork} to extra_args"
-    extra_args="${extra_args} --subnetwork=${subnetwork}"
+    echo "Adding --subnetwork ${subnetwork} to extra_args"
+    extra_args="${extra_args} --subnetwork ${subnetwork}"
   fi
 
   if [[ ! -z "${privateAddress}"  && "${privateAddress}" == "true" ]]; then
     echo "Adding --private-address to extra_args"
     extra_args="${extra_args} --private-address"
+  fi
+
+  if [[ ! -v command ]]; then
+    echo "Please specify a command to run Variant Transforms."
+    exit 1
   fi
 
   pipelines --project "${google_cloud_project}" run \

--- a/docker/pipelines_runner.sh
+++ b/docker/pipelines_runner.sh
@@ -85,14 +85,14 @@ function main {
     exit 1
   fi
 
-  # Build up the extra args is they are provided
+  # Build up the optional args if they are provided
   if [[ ! -z "${subnetwork}" ]]; then
     echo "Adding --subnetwork ${subnetwork} to optional_args"
     pt_optional_args="${pt_optional_args} --subnetwork projects/${project}/regions/${region}/subnetworks/${subnetwork}"
     df_optional_args="${df_optional_args} --subnetwork https://www.googleapis.com/compute/v1/projects/${project}/regions/${region}/subnetworks/${subnetwork}"
   fi
 
-  if [[ ! -z "${use_public_ips}"  && "${use_public_ips}" == "true" ]]; then
+  if [[ ! -z "${use_public_ips}"  && "${use_public_ips}" == "false" ]]; then
     echo "Adding --private-address and --no_use_public_ips to optional_args"
     pt_optional_args="${pt_optional_args} --private-address"
     df_optional_args="${df_optional_args} --no_use_public_ips"

--- a/docker/pipelines_runner.sh
+++ b/docker/pipelines_runner.sh
@@ -88,8 +88,8 @@ function main {
   # Build up the optional args if they are provided
   if [[ ! -z "${subnetwork}" ]]; then
     echo "Adding --subnetwork ${subnetwork} to optional_args"
-    pt_optional_args="${pt_optional_args} --subnetwork projects/${project}/regions/${region}/subnetworks/${subnetwork}"
-    df_optional_args="${df_optional_args} --subnetwork https://www.googleapis.com/compute/v1/projects/${project}/regions/${region}/subnetworks/${subnetwork}"
+    pt_optional_args="${pt_optional_args} --subnetwork projects/${google_cloud_project}/regions/${region}/subnetworks/${subnetwork}"
+    df_optional_args="${df_optional_args} --subnetwork https://www.googleapis.com/compute/v1/projects/${google_cloud_project}/regions/${region}/subnetworks/${subnetwork}"
   fi
 
   if [[ ! -z "${use_public_ips}"  && "${use_public_ips}" == "false" ]]; then

--- a/docker/pipelines_runner.sh
+++ b/docker/pipelines_runner.sh
@@ -73,7 +73,7 @@ function main {
   parse_args "$@"
 
   google_cloud_project="${google_cloud_project:-$(gcloud config get-value project)}"
-  vt_docker_image="${vt_docker_image:-gcr.io/cloud-lifesciences/gcp-variant-transforms:${COMMIT_SHA}}"
+  vt_docker_image="${vt_docker_image:-gcr.io/cloud-lifesciences/gcp-variant-transforms}"
   region="${region:-$(gcloud config get-value compute/region)}"
   temp_location="${temp_location:-''}"
   zone="${zone:-}"
@@ -130,7 +130,7 @@ function main {
     --machine-type "g1-small" \
     --pvm-attempts 0 \
     --attempts 1 \
-    --disk-size 10 "${extra_args}"
+    --disk-size 10 ${extra_args}
 }
 
 main "$@"


### PR DESCRIPTION
In this PR, we've added optional parameters for for sub network and private addresses only.  These are needed launch jobs in projects that have custom networks and don't allow for public IPs.