### PR TITLE
Use SSD for large workers

### DIFF
--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
@@ -8,6 +8,7 @@
     "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-32",
+    "worker_disk_type": "compute.googleapis.com/projects//zones//diskTypes/pd-ssd",
     "max_num_workers": "200",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_with_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_with_merge.json
@@ -7,6 +7,7 @@
     "runner": "DataflowRunner",
     "variant_merge_strategy": "MOVE_TO_CALLS",
     "worker_machine_type": "n1-standard-16",
+    "worker_disk_type": "compute.googleapis.com/projects//zones//diskTypes/pd-ssd",
     "max_num_workers": "20",
     "assertion_configs": [
       {

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_no_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_no_merge.json
@@ -6,6 +6,7 @@
     "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-16",
+    "worker_disk_type": "compute.googleapis.com/projects//zones//diskTypes/pd-ssd",
     "max_num_workers": "20",
     "num_workers": "20",
     "assertion_configs": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_with_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_with_merge.json
@@ -7,6 +7,7 @@
     "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
     "runner": "DataflowRunner",
     "worker_machine_type": "n1-standard-16",
+    "worker_disk_type": "compute.googleapis.com/projects//zones//diskTypes/pd-ssd",
     "max_num_workers": "20",
     "num_workers": "20",
     "assertion_configs": [


### PR DESCRIPTION
Following our advice in docs/large_inputs.md we should use SSD for tests that use large workers (16 or 32 core machines).