### PR TITLE
Modify how we send subnetwork to pipelines-tools

### DIFF
--- a/docker/pipelines_runner.sh
+++ b/docker/pipelines_runner.sh
@@ -104,7 +104,7 @@ function main {
 
   if [[ ! -z "${subnetwork}" ]]; then
     echo "Adding --subnetwork ${subnetwork} to optional_args"
-    pt_optional_args="${pt_optional_args} --subnetwork projects/${google_cloud_project}/regions/${region}/subnetworks/${subnetwork}"
+    pt_optional_args="${pt_optional_args} --subnetwork ${subnetwork}"
     df_optional_args="${df_optional_args} --subnetwork https://www.googleapis.com/compute/v1/projects/${google_cloud_project}/regions/${region}/subnetworks/${subnetwork}"
   fi
 


### PR DESCRIPTION
It seems pipelines-tools only need subnetwork value and it generates the correct format itself:

`projects/${google_cloud_project}/regions/${region}/subnetworks/${subnetwork}`