### PR TITLE
Annotation pipeline and 1_based coordinate

### DIFF
--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding_1_based.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding_1_based.json
@@ -1,7 +1,7 @@
 [
   {
-    "test_name": "test-annotation-pipeline-from-file-with-sharding",
-    "table_name": "test_annotation_pipeline_from_file_with_sharding",
+    "test_name": "test-annotation-pipeline-from-file-with-sharding-1-based",
+    "table_name": "test_annotation_pipeline_from_file_with_sharding_1_based",
     "input_file": "gs://gcp-variant-transforms-testfiles/small_tests/input_files/combine_input",
     "use_1_based_coordinate": "True",
     "vep_assembly": "GRCh37",

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding_1_based.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding_1_based.json
@@ -1,0 +1,96 @@
+[
+  {
+    "test_name": "test-annotation-pipeline-from-file-with-sharding",
+    "table_name": "test_annotation_pipeline_from_file_with_sharding",
+    "input_file": "gs://gcp-variant-transforms-testfiles/small_tests/input_files/combine_input",
+    "use_1_based_coordinate": "True",
+    "vep_assembly": "GRCh37",
+    "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
+    "runner": "DataflowRunner",
+    "run_annotation_pipeline": "True",
+    "annotation_output_dir": "gs://integration_test_runs/temp/vep_output/{TABLE_NAME}",
+    "shard_variants": "True",
+    "infer_headers": "True",
+    "num_workers": 2,
+    "assertion_configs": [
+      {
+        "query": ["NUM_OUTPUT_TABLES"],
+        "expected_result": {"num_tables": 26}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
+        "expected_result": {"num_rows": 9882}
+      },
+      {
+        "query": [
+          "SELECT COUNT(0) AS num_annotation_sets ",
+          "FROM `{DATASET_ID}.{TABLE_ID}__chr1` AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
+        ],
+        "expected_result": {"num_annotation_sets": 8424}
+      },
+      {
+        "query": [
+          "SELECT SUM(start_position * number_of_annotations) AS hash_sum ",
+          "FROM ( ",
+          "  SELECT start_position, reference_bases, A.alt, ",
+          "         COUNT(0) AS number_of_annotations ",
+          "  FROM `{DATASET_ID}.{TABLE_ID}__chr1` AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT",
+          "  GROUP BY 1, 2, 3",
+          ")"
+        ],
+        "expected_result": {"hash_sum": 6772970420}
+      },
+      {
+        "query": [
+          "SELECT COUNT(DISTINCT CSQ_VT.Feature) AS num_features ",
+          "FROM `{DATASET_ID}.{TABLE_ID}__chr1` AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
+        ],
+        "expected_result": {"num_features": 405}
+      },
+      {
+        "query": [
+          "SELECT COUNT(DISTINCT CSQ_VT.SYMBOL) AS num_symbol ",
+          "FROM `{DATASET_ID}.{TABLE_ID}__chr1` AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
+        ],
+        "expected_result": {"num_symbol": 89}
+      },
+      {
+        "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
+        "expected_result": {"num_rows": 7}
+      },
+      {
+        "query": [
+          "SELECT COUNT(0) AS num_annotation_sets ",
+          "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
+        ],
+        "expected_result": {"num_annotation_sets": 25}
+      },
+      {
+        "query": [
+          "SELECT SUM(start_position * number_of_annotations) AS hash_sum ",
+          "FROM ( ",
+          "  SELECT start_position, reference_bases, A.alt, ",
+          "         COUNT(0) AS number_of_annotations ",
+          "  FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT",
+          "  GROUP BY 1, 2, 3",
+          ")"
+        ],
+        "expected_result": {"hash_sum": 42634508}
+      },
+      {
+        "query": [
+          "SELECT COUNT(DISTINCT CSQ_VT.Feature) AS num_features ",
+          "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
+        ],
+        "expected_result": {"num_features": 12}
+      },
+      {
+        "query": [
+          "SELECT COUNT(DISTINCT CSQ_VT.SYMBOL) AS num_symbol ",
+          "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS T, T.alternate_bases AS A, A.CSQ_VT AS CSQ_VT"
+        ],
+        "expected_result": {"num_symbol": 3}
+      }
+    ]
+  }
+]


### PR DESCRIPTION
To accommodate the use of `use_1_based_coordinate` flag.
We also duplicated one of our integration tests to verify this change is working.
This PR will be proceeded by #633 