### PR TITLE
Replace RemoveDuplicates with Distinct

### DIFF
--- a/gcp_variant_transforms/transforms/combine_sample_ids.py
+++ b/gcp_variant_transforms/transforms/combine_sample_ids.py
@@ -67,13 +67,13 @@ class SampleIdsCombiner(beam.PTransform):
     if self._preserve_sample_order:
       return (pcoll
               | 'GetSampleIds' >> beam.Map(self._get_sample_ids)
-              | 'RemoveDuplicates' >> beam.RemoveDuplicates()
+              | 'RemoveDuplicates' >> beam.Distinct()
               | 'Combine' >> beam.combiners.ToList()
               | 'ExtractUniqueSampleIds'
               >> beam.ParDo(self._extract_unique_sample_ids))
     else:
       return (pcoll
               | 'GetSampleIds' >> beam.FlatMap(self._get_sample_ids)
-              | 'RemoveDuplicates' >> beam.RemoveDuplicates()
+              | 'RemoveDuplicates' >> beam.Distinct()
               | 'Combine' >> beam.combiners.ToList()
               | 'SortSampleIds' >> beam.ParDo(sorted))


### PR DESCRIPTION
While running bq_to_vcf we get the following message:
```
BeamDeprecationWarning: RemoveDuplicates is deprecated since 2.12. Use Distinct instead.
```