### PR TITLE
Large threshold reduce to 500

### DIFF
--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -44,7 +44,7 @@ from gcp_variant_transforms.transforms import merge_headers
 # If the # of files matching the input file_pattern exceeds this value, then
 # headers will be merged in beam.
 _SMALL_DATA_THRESHOLD = 100
-_LARGE_DATA_THRESHOLD = 50000
+_LARGE_DATA_THRESHOLD = 500
 
 _DATAFLOW_RUNNER_ARG_VALUE = 'DataflowRunner'
 SampleNameEncoding = vcf_parser.SampleNameEncoding

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -65,7 +65,7 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
     with mock.patch.object(FileSystems, 'match', return_value=[match]):
       self.assertEqual(self._get_pipeline_mode(args), PipelineModes.MEDIUM)
 
-    match = match_result(list(range(50000)))
+    match = match_result(list(range(500)))
     with mock.patch.object(FileSystems, 'match', return_value=[match]):
       self.assertEqual(self._get_pipeline_mode(args), PipelineModes.MEDIUM)
 


### PR DESCRIPTION
Reduce the _LARGE_DATA_THRESHOLD from 50,000 to 500.
After deprecating  `--optimize_for_large_inputs` we need to modify this threshold to be more conservative about what we call large.