### PR TITLE
Change the default value of use_1_based_coordinate to False

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -105,11 +105,10 @@ class VcfReadOptions(VariantTransformsOptions):
               'performance penalty of an extra pass over all variants.'))
     parser.add_argument(
         '--use_1_based_coordinate',
-        type='bool', default=True, nargs='?', const=True,
-        help=('If true, start position will be 1-based, and end position will '
-              'be inclusive. Otherwise, the records will be stored in 0-based '
-              'coordinates, with exclusive end position. For more information '
-              'please refer to www.biostars.org/p/84686/'))
+        type='bool', default=False, nargs='?', const=True,
+        help=('If true, start position will be 1 based, and end position will '
+              'be inclusive. Otherwise, by default the records will be stored '
+              'with 0 based coordinates, with exclusive end position.'))
 
   def validate(self, parsed_args):
     # type: (argparse.Namespace) -> None

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -106,9 +106,10 @@ class VcfReadOptions(VariantTransformsOptions):
     parser.add_argument(
         '--use_1_based_coordinate',
         type='bool', default=False, nargs='?', const=True,
-        help=('If true, start position will be 1 based, and end position will '
-              'be inclusive. Otherwise, by default the records will be stored '
-              'with 0 based coordinates, with exclusive end position.'))
+        help=('If true, start position will be 1-based, and end position will '
+              'be inclusive. Otherwise, the records will be stored in 0-based '
+              'coordinates (default), with exclusive end position. For more '
+              'information please refer to www.biostars.org/p/84686/'))
 
   def validate(self, parsed_args):
     # type: (argparse.Namespace) -> None

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/huge_tests/test_1000_genomes.json
@@ -21,7 +21,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
-        "expected_result": {"sum_start": 751907105253770}
+        "expected_result": {"sum_start": 751907099239378}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
@@ -33,7 +33,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
-        "expected_result": {"sum_start": 793122312390064}
+        "expected_result": {"sum_start": 793122305774880}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
@@ -45,7 +45,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
-        "expected_result": {"sum_start": 538227065351004}
+        "expected_result": {"sum_start": 538227059824096}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
@@ -57,7 +57,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr4`"],
-        "expected_result": {"sum_start": 517336800711834}
+        "expected_result": {"sum_start": 517336795238304}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr4`"],
@@ -69,7 +69,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr5`"],
-        "expected_result": {"sum_start": 456439292386152}
+        "expected_result": {"sum_start": 456439287325718}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr5`"],
@@ -81,7 +81,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr6`"],
-        "expected_result": {"sum_start": 412018132740998}
+        "expected_result": {"sum_start": 412018127892148}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr6`"],
@@ -93,7 +93,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr7`"],
-        "expected_result": {"sum_start": 342272558134564}
+        "expected_result": {"sum_start": 342272553704102}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr7`"],
@@ -105,7 +105,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr8`"],
-        "expected_result": {"sum_start": 300642751672486}
+        "expected_result": {"sum_start": 300642747304808}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr8`"],
@@ -117,7 +117,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr9`"],
-        "expected_result": {"sum_start": 231608081585546}
+        "expected_result": {"sum_start": 231608078280770}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr9`"],
@@ -129,7 +129,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr10`"],
-        "expected_result": {"sum_start": 253789504018298}
+        "expected_result": {"sum_start": 253789500252972}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr10`"],
@@ -141,7 +141,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr11`"],
-        "expected_result": {"sum_start": 256396597621086}
+        "expected_result": {"sum_start": 256396593831270}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr11`"],
@@ -153,7 +153,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr12`"],
-        "expected_result": {"sum_start": 245707035186020}
+        "expected_result": {"sum_start": 245707031530008}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr12`"],
@@ -165,7 +165,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr13`"],
-        "expected_result": {"sum_start": 184996597530522}
+        "expected_result": {"sum_start": 184996594784522}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr13`"],
@@ -177,7 +177,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr14`"],
-        "expected_result": {"sum_start": 161133807726988}
+        "expected_result": {"sum_start": 161133805210480}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr14`"],
@@ -189,7 +189,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr15`"],
-        "expected_result": {"sum_start": 143122132351758}
+        "expected_result": {"sum_start": 143122130090650}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr15`"],
@@ -201,7 +201,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr16`"],
-        "expected_result": {"sum_start": 114391509614422}
+        "expected_result": {"sum_start": 114391507193184}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr16`"],
@@ -213,7 +213,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr17`"],
-        "expected_result": {"sum_start": 86578006029134}
+        "expected_result": {"sum_start": 86578003935668}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr17`"],
@@ -225,7 +225,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr18`"],
-        "expected_result": {"sum_start": 88079279443822}
+        "expected_result": {"sum_start": 88079277266182}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr18`"],
@@ -237,7 +237,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 48834766050406}
+        "expected_result": {"sum_start": 48834764418176}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -249,7 +249,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 54374277761466}
+        "expected_result": {"sum_start": 54374276051134}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -261,7 +261,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr21`"],
-        "expected_result": {"sum_start": 32398647118070}
+        "expected_result": {"sum_start": 32398646080140}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr21`"],
@@ -273,7 +273,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr22`"],
-        "expected_result": {"sum_start": 34479343935160}
+        "expected_result": {"sum_start": 34479342946504}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr22`"],
@@ -285,7 +285,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrX`"],
-        "expected_result": {"sum_start": 227484012336528}
+        "expected_result": {"sum_start": 227484009361574}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrX`"],
@@ -297,7 +297,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 328078219388}
+        "expected_result": {"sum_start": 328078200660}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -309,7 +309,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 25260721}
+        "expected_result": {"sum_start": 25257887}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/test_non_splittable_gzip.temp_deleted_json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/large_tests/test_non_splittable_gzip.temp_deleted_json
@@ -12,7 +12,7 @@
       },
       {
         "query": ["SUM_START_QUERY"],
-        "expected_result": {"sum_start": 32190612702539}
+        "expected_result": {"sum_start": 32190612292607}
       },
       {
         "query": ["SUM_END_QUERY"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh37_chrX_head2500_run_vep.json
@@ -44,7 +44,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 17184716457}
+        "expected_result": {"hash_sum": 17184695290}
       },
       {
         "query": [
@@ -56,7 +56,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 17180730516}
+        "expected_result": {"hash_sum": 17180709457}
       },
       {
         "query": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh38_chrX_head2500_run_vep_from_file.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/gnomad_genomes_GRCh38_chrX_head2500_run_vep_from_file.json
@@ -44,7 +44,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 17184716457}
+        "expected_result": {"hash_sum": 17184695290}
       },
       {
         "query": [
@@ -56,7 +56,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 17180730516}
+        "expected_result": {"hash_sum": 17180709457}
       },
       {
         "query": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep.json
@@ -45,7 +45,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 143375343108}
+        "expected_result": {"hash_sum": 143375297338}
       },
       {
         "query": [
@@ -57,7 +57,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 143375343108}
+        "expected_result": {"hash_sum": 143375297338}
       },
       {
         "query": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep_with_gc.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_NA12877_hg38_10K_lines_run_vep_with_gc.json
@@ -45,7 +45,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 143375343108}
+        "expected_result": {"hash_sum": 143375297338}
       },
       {
         "query": [
@@ -57,7 +57,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 143375343108}
+        "expected_result": {"hash_sum": 143375297338}
       },
       {
         "query": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_no_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_no_merge.json
@@ -16,7 +16,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
-        "expected_result": {"sum_start": 2932145002523549}
+        "expected_result": {"sum_start": 2932144978501378}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
@@ -28,7 +28,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
-        "expected_result": {"sum_start": 2953428860821187}
+        "expected_result": {"sum_start": 2953428836386527}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
@@ -40,7 +40,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
-        "expected_result": {"sum_start": 1892873654063051}
+        "expected_result": {"sum_start": 1892873634919601}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
@@ -52,7 +52,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 9717889}
+        "expected_result": {"sum_start": 9716663}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_with_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/platinum_with_merge.json
@@ -20,7 +20,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
-        "expected_result": {"sum_start": 2469581032808147}
+        "expected_result": {"sum_start": 2469581012601456}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
@@ -32,7 +32,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
-        "expected_result": {"sum_start": 2506042589162349}
+        "expected_result": {"sum_start": 2506042568449967}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr2`"],
@@ -44,7 +44,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
-        "expected_result": {"sum_start": 1605674422198391}
+        "expected_result": {"sum_start": 1605674406003590}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr3`"],
@@ -56,7 +56,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 5056702}
+        "expected_result": {"sum_start": 5056035}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_no_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_no_merge.json
@@ -20,7 +20,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370000}
+        "expected_result": {"sum_start": 14369000}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -32,7 +32,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 23000241000}
+        "expected_result": {"sum_start": 23000231000}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -44,7 +44,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330000}
+        "expected_result": {"sum_start": 17329000}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -56,7 +56,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 1000}
+        "expected_result": {"sum_start": 0}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_with_merge.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_1000_copies_of_valid_4_2_with_merge.json
@@ -21,7 +21,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370}
+        "expected_result": {"sum_start": 14369}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -33,7 +33,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 23000241}
+        "expected_result": {"sum_start": 23000231}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -45,7 +45,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330}
+        "expected_result": {"sum_start": 17329}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -57,7 +57,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 1}
+        "expected_result": {"sum_start": 0}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding.json
@@ -37,7 +37,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 6772970420}
+        "expected_result": {"hash_sum": 6772961996}
       },
       {
         "query": [
@@ -74,7 +74,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 42634508}
+        "expected_result": {"hash_sum": 42634483}
       },
       {
         "query": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding_1_based.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_with_sharding_1_based.json
@@ -1,9 +1,9 @@
 [
   {
-    "test_name": "test-annotation-pipeline-from-file-with-sharding-zero",
-    "table_name": "test_annotation_pipeline_from_file_with_sharding_zero",
+    "test_name": "test-annotation-pipeline-from-file-with-sharding-1-based",
+    "table_name": "test_annotation_pipeline_from_file_with_sharding_1_based",
     "input_file": "gs://gcp-variant-transforms-testfiles/small_tests/input_files/combine_input",
-    "use_1_based_coordinate": "False",
+    "use_1_based_coordinate": "True",
     "vep_assembly": "GRCh37",
     "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
     "runner": "DataflowRunner",
@@ -38,7 +38,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 6772961996}
+        "expected_result": {"hash_sum": 6772970420}
       },
       {
         "query": [
@@ -75,7 +75,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 42634483}
+        "expected_result": {"hash_sum": 42634508}
       },
       {
         "query": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_without_sharding.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_annotation_pipeline_from_file_without_sharding.json
@@ -37,7 +37,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 6772970420}
+        "expected_result": {"hash_sum": 6772961996}
       },
       {
         "query": [
@@ -74,7 +74,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 42634508}
+        "expected_result": {"hash_sum": 42634483}
       },
       {
         "query": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_splittable_gzip.temp_deleted_json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/medium_tests/test_splittable_gzip.temp_deleted_json
@@ -12,7 +12,7 @@
       },
       {
         "query": ["SUM_START_QUERY"],
-        "expected_result": {"sum_start": 32190612702539}
+        "expected_result": {"sum_start": 32190612292607}
       },
       {
         "query": ["SUM_END_QUERY"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/combine_from_multiple_inputs.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/combine_from_multiple_inputs.json
@@ -17,7 +17,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
-        "expected_result": {"sum_start": 5434967210}
+        "expected_result": {"sum_start": 5434957328}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -25,7 +25,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370}
+        "expected_result": {"sum_start": 14369}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -33,7 +33,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 23000241}
+        "expected_result": {"sum_start": 23000231}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -41,7 +41,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330}
+        "expected_result": {"sum_start": 17329}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
@@ -49,7 +49,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 1}
+        "expected_result": {"sum_start": 0}
       }
     ]
   }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_1_based.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_1_based.json
@@ -1,10 +1,10 @@
 [
   {
-    "test_name": "merge-option-zero-based",
-    "table_name": "merge_option_zero_based",
+    "test_name": "merge-option-one-based",
+    "table_name": "merge_option_one_based",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/merge/*.vcf",
     "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
-    "use_1_based_coordinate": "False",
+    "use_1_based_coordinate": true,
     "runner": "DirectRunner",
     "variant_merge_strategy": "MOVE_TO_CALLS",
     "assertion_configs": [
@@ -18,7 +18,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234566}
+        "expected_result": {"sum_start": 1234567}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -30,7 +30,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 48987}
+        "expected_result": {"sum_start": 48990}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -39,7 +39,7 @@
       {
         "query": [
           "SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20` ",
-          "WHERE start_position = 14369"
+          "WHERE start_position = 14370"
         ],
         "expected_result": {"num_rows": 1}
       }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_filter_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_filter_to_calls.json
@@ -18,7 +18,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234567}
+        "expected_result": {"sum_start": 1234566}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -30,7 +30,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 48990}
+        "expected_result": {"sum_start": 48987}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -40,7 +40,7 @@
         "query": [
           "SELECT COUNT(0) AS num_rows ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 1461155635506253861 ",
           "AND 'q10' IN UNNEST (call.filter)"
         ],
@@ -50,7 +50,7 @@
         "query": [
           "SELECT COUNT(0) AS num_rows ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 8469201776453291698 ",
           "AND 'q10' IN UNNEST (call.filter)"
         ],
@@ -60,7 +60,7 @@
         "query": [
           "SELECT COUNT(0) AS num_rows ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 2841064610214975654 ",
           "AND 'PASS' IN UNNEST (call.filter)"
         ],
@@ -70,7 +70,7 @@
         "query": [
           "SELECT COUNT(0) AS num_rows ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 7282355041988662653 ",
           "AND 'PASS' IN UNNEST (call.filter)"
         ],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_quality_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_copy_quality_to_calls.json
@@ -18,7 +18,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234567}
+        "expected_result": {"sum_start": 1234566}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -30,7 +30,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 48990}
+        "expected_result": {"sum_start": 48987}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -40,7 +40,7 @@
         "query": [
           "SELECT call.quality AS quality ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 1461155635506253861"
         ],
         "expected_result": {"quality": 10.0}
@@ -49,7 +49,7 @@
         "query": [
           "SELECT call.quality AS quality ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 8469201776453291698"
         ],
         "expected_result": {"quality": 10.0}
@@ -58,7 +58,7 @@
         "query": [
           "SELECT call.quality AS quality ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 2841064610214975654"
         ],
         "expected_result": {"quality": 29.0}
@@ -67,7 +67,7 @@
         "query": [
           "SELECT call.quality AS quality ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 7282355041988662653"
         ],
         "expected_result": {"quality": 30.0}

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_info_keys_to_move_to_calls_regex.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_info_keys_to_move_to_calls_regex.json
@@ -18,7 +18,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234567}
+        "expected_result": {"sum_start": 1234566}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -30,7 +30,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 48990}
+        "expected_result": {"sum_start": 48987}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -40,7 +40,7 @@
         "query": [
           "SELECT call.NS AS NS ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 1461155635506253861"
         ],
         "expected_result": {"NS": 2}
@@ -49,7 +49,7 @@
         "query": [
           "SELECT call.NS AS NS ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 8469201776453291698"
         ],
         "expected_result": {"NS": 2}
@@ -58,7 +58,7 @@
         "query": [
           "SELECT call.NS AS NS ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 2841064610214975654"
         ],
         "expected_result": {"NS": 1}
@@ -67,7 +67,7 @@
         "query": [
           "SELECT call.NS AS NS ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.call as call ",
-          "WHERE start_position = 14370 ",
+          "WHERE start_position = 14369 ",
           "AND call.sample_id = 7282355041988662653"
         ],
         "expected_result": {"NS": 1}

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_move_to_calls.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_move_to_calls.json
@@ -17,7 +17,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234567}
+        "expected_result": {"sum_start": 1234566}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -29,7 +29,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 48990}
+        "expected_result": {"sum_start": 48987}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -38,7 +38,7 @@
       {
         "query": [
           "SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20` ",
-          "WHERE start_position = 14370"
+          "WHERE start_position = 14369"
         ],
         "expected_result": {"num_rows": 1}
       }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_none.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/merge_option_none.json
@@ -16,7 +16,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 2469134}
+        "expected_result": {"sum_start": 2469132}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -28,7 +28,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 77730}
+        "expected_result": {"sum_start": 77725}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -37,7 +37,7 @@
       {
         "query": [
           "SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr20` ",
-          "WHERE start_position = 14370"
+          "WHERE start_position = 14369"
         ],
         "expected_result": {"num_rows": 3}
       }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_allow_malformed_records.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_allow_malformed_records.json
@@ -17,7 +17,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234567}
+        "expected_result": {"sum_start": 1234566}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -29,7 +29,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 2358263}
+        "expected_result": {"sum_start": 2358260}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_allow_malformed_records_alternate_mismatch.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_allow_malformed_records_alternate_mismatch.json
@@ -17,7 +17,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370}
+        "expected_result": {"sum_start": 14369}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -29,7 +29,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 23000241}
+        "expected_result": {"sum_start": 23000231}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -41,7 +41,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330}
+        "expected_result": {"sum_start": 17329}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -53,7 +53,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 1}
+        "expected_result": {"sum_start": 0}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
@@ -63,7 +63,7 @@
         "query": [
           "SELECT alternate_bases.AF AS AF ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` t, t.alternate_bases as alternate_bases ",
-          "WHERE reference_name = '20' and start_position = 17330"
+          "WHERE reference_name = '20' and start_position = 17329"
         ],
         "expected_result": {"AF": 0.017}
       },
@@ -71,7 +71,7 @@
         "query": [
           "SELECT SUM(alternate_bases.AF) AS AF_sum ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` t, t.alternate_bases as alternate_bases ",
-          "WHERE reference_name = '20' and start_position = 1234567"
+          "WHERE reference_name = '20' and start_position = 1234566"
         ],
         "expected_result": {"AF_sum": 0.1}
       },
@@ -79,7 +79,7 @@
         "query": [
           "SELECT COUNT(IFNULL(alternate_bases.AF, 0)) AS AF_count ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` t, t.alternate_bases as alternate_bases ",
-          "WHERE reference_name = '20' and start_position = 1234567"
+          "WHERE reference_name = '20' and start_position = 1234566"
         ],
         "expected_result": {"AF_count": 2}
       }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_null_numeric_value_replacement.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_null_numeric_value_replacement.json
@@ -18,7 +18,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370}
+        "expected_result": {"sum_start": 14369}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -30,7 +30,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 23000241}
+        "expected_result": {"sum_start": 23000231}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -42,7 +42,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330}
+        "expected_result": {"sum_start": 17329}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -54,7 +54,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 1}
+        "expected_result": {"sum_start": 0}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_representative_header_file.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_representative_header_file.json
@@ -17,7 +17,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234567}
+        "expected_result": {"sum_start": 1234566}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -29,7 +29,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 2372633}
+        "expected_result": {"sum_start": 2372629}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_split_alternate_allele_info_fields.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/option_split_alternate_allele_info_fields.json
@@ -17,7 +17,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370}
+        "expected_result": {"sum_start": 14369}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -33,7 +33,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 23000241}
+        "expected_result": {"sum_start": 23000231}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -49,7 +49,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330}
+        "expected_result": {"sum_start": 17329}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -65,7 +65,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 1}
+        "expected_result": {"sum_start": 0}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_NA12877_hg38_10K_lines.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_NA12877_hg38_10K_lines.json
@@ -32,7 +32,7 @@
           "  GROUP BY 1, 2, 3",
           ")"
         ],
-        "expected_result": {"hash_sum": 143375343108}
+        "expected_result": {"hash_sum": 143375297338}
       },
       {
         "query": [

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_partition_without_residual.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/platinum_partition_without_residual.json
@@ -18,7 +18,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr01_100M`"],
-        "expected_result": {"sum_start": 29658080726}
+        "expected_result": {"sum_start": 29658080117}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr01_200M`"],
@@ -26,7 +26,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr01_200M`"],
-        "expected_result": {"sum_start": 77243595398}
+        "expected_result": {"sum_start": 77243594896}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr01_remaining`"],
@@ -34,7 +34,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr01_remaining`"],
-        "expected_result": {"sum_start": 59577868263}
+        "expected_result": {"sum_start": 59577867998}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr05_1M`"],
@@ -42,7 +42,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr05_1M`"],
-        "expected_result": {"sum_start": 6013514}
+        "expected_result": {"sum_start": 6013500}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr07_1M`"],
@@ -50,14 +50,14 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr07_1M`"],
-        "expected_result": {"sum_start": 4180572}
+        "expected_result": {"sum_start": 4180562}
       },      {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}__chr19_1M`"],
         "expected_result": {"num_rows": 11}
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19_1M`"],
-        "expected_result": {"sum_start": 6797237}
+        "expected_result": {"sum_start": 6797226}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_100M`"],
@@ -65,7 +65,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_100M`"],
-        "expected_result": {"sum_start": 29658080726}
+        "expected_result": {"sum_start": 29658080117}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_200M`"],
@@ -73,7 +73,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_200M`"],
-        "expected_result": {"sum_start": 77243595398}
+        "expected_result": {"sum_start": 77243594896}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_remaining`"],
@@ -81,7 +81,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr01_remaining`"],
-        "expected_result": {"sum_start": 59577868263}
+        "expected_result": {"sum_start": 59577867998}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr05_1M`"],
@@ -89,7 +89,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr05_1M`"],
-        "expected_result": {"sum_start": 6013514}
+        "expected_result": {"sum_start": 6013500}
       },
       {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr07_1M`"],
@@ -97,14 +97,14 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr07_1M`"],
-        "expected_result": {"sum_start": 4180572}
+        "expected_result": {"sum_start": 4180562}
       },      {
         "query": ["SELECT COUNT(0) AS num_rows FROM `{DATASET_ID}.{TABLE_ID}_samples__chr19_1M`"],
         "expected_result": {"num_rows": 11}
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}_samples__chr19_1M`"],
-        "expected_result": {"sum_start": 6797237}
+        "expected_result": {"sum_start": 6797226}
       }
     ]
   }

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_bz2.json
@@ -16,7 +16,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234567}
+        "expected_result": {"sum_start": 1234566}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -28,7 +28,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 2372633}
+        "expected_result": {"sum_start": 2372629}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz.json
@@ -17,7 +17,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234567}
+        "expected_result": {"sum_start": 1234566}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -29,7 +29,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 2372633}
+        "expected_result": {"sum_start": 2372629}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz_1_based.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_0_gz_1_based.json
@@ -1,10 +1,10 @@
 [
   {
-    "test_name": "valid-4-0-gz-zero-based",
-    "table_name": "valid_4_0_gz_zero_based",
+    "test_name": "valid-4-0-gz-one-based",
+    "table_name": "valid_4_0_gz_one_based",
     "input_pattern": "gs://gcp-variant-transforms-testfiles/small_tests/valid-4.0.vcf.gz",
     "sharding_config_path": "gcp_variant_transforms/data/sharding_configs/homo_sapiens_default.yaml",
-    "use_1_based_coordinate": "False",
+    "use_1_based_coordinate": true,
     "runner": "DirectRunner",
     "assertion_configs": [
       {
@@ -17,7 +17,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 1234566}
+        "expected_result": {"sum_start": 1234567}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -29,7 +29,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 2372629}
+        "expected_result": {"sum_start": 2372633}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_1.json
@@ -16,7 +16,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],
-        "expected_result": {"sum_start": 5434967210}
+        "expected_result": {"sum_start": 5434957328}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr1`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2.json
@@ -16,7 +16,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370}
+        "expected_result": {"sum_start": 14369}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -29,7 +29,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 23000241}
+        "expected_result": {"sum_start": 23000231}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -41,7 +41,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330}
+        "expected_result": {"sum_start": 17329}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -53,7 +53,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 1}
+        "expected_result": {"sum_start": 0}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_VEP.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_VEP.json
@@ -18,7 +18,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370}
+        "expected_result": {"sum_start": 14369}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -30,7 +30,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 21770004}
+        "expected_result": {"sum_start": 21769995}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -42,7 +42,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330}
+        "expected_result": {"sum_start": 17329}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -52,7 +52,7 @@
         "query": [
           "SELECT COUNT(DISTINCT CSQ.Feature) AS num_features ",
           "FROM `{DATASET_ID}.{TABLE_ID}__chr20` AS t, t.alternate_bases as alts, alts.CSQ as CSQ ",
-          "WHERE start_position = 1110696 AND alts.alt = 'G'"
+          "WHERE start_position = 1110695 AND alts.alt = 'G'"
         ],
         "expected_result": {"num_features": 3}
       },

--- a/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz.json
+++ b/gcp_variant_transforms/testing/integration/vcf_to_bq_tests/presubmit_tests/small_tests/valid_4_2_gz.json
@@ -16,7 +16,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
-        "expected_result": {"sum_start": 14370}
+        "expected_result": {"sum_start": 14369}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr19`"],
@@ -28,7 +28,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
-        "expected_result": {"sum_start": 23000241}
+        "expected_result": {"sum_start": 23000231}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chr20`"],
@@ -40,7 +40,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
-        "expected_result": {"sum_start": 17330}
+        "expected_result": {"sum_start": 17329}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__chrY`"],
@@ -52,7 +52,7 @@
       },
       {
         "query": ["SELECT SUM(start_position) AS sum_start FROM `{DATASET_ID}.{TABLE_ID}__residual`"],
-        "expected_result": {"sum_start": 1}
+        "expected_result": {"sum_start": 0}
       },
       {
         "query": ["SELECT SUM(end_position) AS sum_end FROM `{DATASET_ID}.{TABLE_ID}__residual`"],


### PR DESCRIPTION
Based on the feedback from our users and also to keep all our docs, tutorials, and queries consistent with VT before v0.10.0 launch, we change the default behavior back to 0-based.

Reverts #633 