### PR TITLE
Use VEP version as docker image tags

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -359,8 +359,8 @@ class AnnotationOptions(VariantTransformsOptions):
               'process of running VEP pipelines.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_IMAGE_FLAG,
-        default='gcr.io/cloud-lifesciences/vep_91',
-        help=('The URI of the docker image for VEP.'))
+        default='gcr.io/cloud-lifesciences/vep:91',
+        help=('The URI of the latest docker image for VEP.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_CACHE_FLAG,
         default='',


### PR DESCRIPTION
In order to make the versioning of VEP docker images more streamlined,
we use more conventional docker image tags applied to the following
repo:gcr.io/cloud-lifesciences/vep

This change is a follow up to this PR:
github.com/googlegenomics/variant-annotation/pull/12