### PR TITLE
Adding a check in the less than method for the VariantCall class to ensure that in cases where there is a mix of arrays and scalar values that the comparison still works.

### DIFF
--- a/gcp_variant_transforms/beam_io/vcf_parser.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser.py
@@ -227,6 +227,10 @@ class VariantCall():
     if self.sample_id != other.sample_id:
       return self.sample_id < other.sample_id
     elif self.genotype != other.genotype:
+      if(type(self.genotype) is list and type(other.genotype) is not list):
+        return False
+      if(type(other.genotype) is list and type(self.genotype) is not list):
+        return True
       return self.genotype < other.genotype
     elif self.phaseset != other.phaseset:
       return self.phaseset < other.phaseset

--- a/gcp_variant_transforms/beam_io/vcf_parser_test.py
+++ b/gcp_variant_transforms/beam_io/vcf_parser_test.py
@@ -83,6 +83,14 @@ class VariantCallTest(unittest.TestCase):
     variant_call_2.phaseset = 1
     self.assertGreater(variant_call_2, variant_call_1)
 
+  def test_genotype_compare(self):
+      variant_call_1 = self._default_variant_call()
+      variant_call_2 = vcfio.VariantCall(
+          sample_id=hash_name('Sample1'), name='Sample1', genotype=-1,
+          phaseset=vcfio.DEFAULT_PHASESET_VALUE, info={'GQ': 48})
+
+      self.assertLess(variant_call_2, variant_call_1)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
Adding a check in the less than method for the VariantCall class to ensure that in cases where there is a mix of arrays and scalar values that the comparison still works.

When running bq_to_vcf the __lt__ method in VariantCall was attempting to compare a list to a single value (-1) that is getting set by using the MISSING_GENOTYPE_VALUE (set to -1) in the densify_variants._densify_variants method. This was causing an exception to occur.

Test:
Added a unit test and ran a test manually on a dataset that was receiving the error mentioned above to make sure the bq_to_vcf could successfully generate a VCF file.
