### PR TITLE
Fix yaml.load error

### DIFF
--- a/gcp_variant_transforms/libs/variant_sharding.py
+++ b/gcp_variant_transforms/libs/variant_sharding.py
@@ -137,7 +137,8 @@ class VariantSharding():
     has_any_interval = False
     with FileSystems.open(config_file_path, 'r') as f:
       try:
-        shards = yaml.load(f, Loader=yaml.BaseLoader)
+        yaml.warnings({'YAMLLoadWarning': False})
+        shards = yaml.load(f, Loader=yaml.FullLoader)
       except yaml.YAMLError as e:
         raise ValueError('Invalid yaml file: {}'.format(str(e))) from e
     if len(shards) > _MAX_NUM_SHARDS:
@@ -228,7 +229,8 @@ class VariantSharding():
     """
     with FileSystems.open(config_file_path, 'r') as f:
       try:
-        shards = yaml.load(f, Loader=yaml.BaseLoader)
+        yaml.warnings({'YAMLLoadWarning': False})
+        shards = yaml.load(f, Loader=yaml.FullLoader)
       except yaml.YAMLError as e:
         raise ValueError('Invalid yaml file: {}'.format(str(e))) from e
 

--- a/gcp_variant_transforms/libs/variant_sharding.py
+++ b/gcp_variant_transforms/libs/variant_sharding.py
@@ -137,7 +137,6 @@ class VariantSharding():
     has_any_interval = False
     with FileSystems.open(config_file_path, 'r') as f:
       try:
-        yaml.warnings({'YAMLLoadWarning': False})
         shards = yaml.load(f, Loader=yaml.FullLoader)
       except yaml.YAMLError as e:
         raise ValueError('Invalid yaml file: {}'.format(str(e))) from e
@@ -229,7 +228,6 @@ class VariantSharding():
     """
     with FileSystems.open(config_file_path, 'r') as f:
       try:
-        yaml.warnings({'YAMLLoadWarning': False})
         shards = yaml.load(f, Loader=yaml.FullLoader)
       except yaml.YAMLError as e:
         raise ValueError('Invalid yaml file: {}'.format(str(e))) from e

--- a/gcp_variant_transforms/libs/variant_sharding.py
+++ b/gcp_variant_transforms/libs/variant_sharding.py
@@ -137,7 +137,7 @@ class VariantSharding():
     has_any_interval = False
     with FileSystems.open(config_file_path, 'r') as f:
       try:
-        shards = yaml.load(f)
+        shards = yaml.load(f, Loader=yaml.BaseLoader)
       except yaml.YAMLError as e:
         raise ValueError('Invalid yaml file: {}'.format(str(e))) from e
     if len(shards) > _MAX_NUM_SHARDS:
@@ -228,7 +228,7 @@ class VariantSharding():
     """
     with FileSystems.open(config_file_path, 'r') as f:
       try:
-        shards = yaml.load(f)
+        shards = yaml.load(f, Loader=yaml.BaseLoader)
       except yaml.YAMLError as e:
         raise ValueError('Invalid yaml file: {}'.format(str(e))) from e
 


### PR DESCRIPTION
yaml.load as currently used was deprecated and requires specification of a loader.