### PR TITLE
Pipline mode flag

### DIFF
--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -80,6 +80,11 @@ class VcfReadOptions(VariantTransformsOptions):
         type='bool', default=False, nargs='?', const=True,
         help='This flag is deprecated and will be removed in the next release.')
     parser.add_argument(
+        '--pipeline_mode',
+        default='',
+        help=('If provided ("small", "medium", or "large), overrides input size '
+              'checking logic and forces pipeline optimizations for input size. '))
+    parser.add_argument(
         '--representative_header_file',
         default='',
         help=('If provided, header values from the provided file will be used '

--- a/gcp_variant_transforms/pipeline_common.py
+++ b/gcp_variant_transforms/pipeline_common.py
@@ -159,13 +159,21 @@ def _get_file_names(input_file):
     return contents
 
 
-def get_pipeline_mode(all_patterns):
+def get_pipeline_mode(all_patterns, pipeline_mode=''):
   # type: (List[str], bool) -> int
   """Returns the mode the pipeline should operate in based on input size.
 
   Note: len(all_patterns) == 1: when --input_pattern is given as input argument.
         len(all_patterns) > 1: when --input_file is given as input argument.
   """
+
+  if pipeline_mode.lower() == 'small':
+    return PipelineModes.SMALL
+  if pipeline_mode.lower() == 'medium':
+    return PipelineModes.MEDIUM
+  if pipeline_mode.lower() == 'large':
+    return PipelineModes.LARGE
+
   if len(all_patterns) > 1:
     return PipelineModes.LARGE
 

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -51,7 +51,7 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
           input_pattern='nonexistent_file.vcf', input_file=None)
 
   def test_get_mode_small_pipeline_mode(self):
-    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='medium')
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='small')
     match_result = collections.namedtuple('MatchResult', ['metadata_list'])
     match = match_result([None for _ in range(100)])
     with mock.patch.object(FileSystems, 'match', return_value=[match]):

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -51,7 +51,7 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
           input_pattern='nonexistent_file.vcf', input_file=None)
 
   def test_get_mode_small_pipeline_mode(self):
-    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='small')
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='medium')
     match_result = collections.namedtuple('MatchResult', ['metadata_list'])
     match = match_result([None for _ in range(100)])
     with mock.patch.object(FileSystems, 'match', return_value=[match]):

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -72,7 +72,7 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
       self.assertEqual(self._get_pipeline_mode(args), PipelineModes.LARGE)
 
   def test_get_mode_small(self):
-    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='')
+    args = self._create_mock_args(input_pattern='*', input_file=None)
     match_result = collections.namedtuple('MatchResult', ['metadata_list'])
     match = match_result([None for _ in range(100)])
 

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -72,7 +72,7 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
       self.assertEqual(self._get_pipeline_mode(args), PipelineModes.LARGE)
 
   def test_get_mode_small(self):
-    args = self._create_mock_args(input_pattern='*', input_file=None)
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='')
     match_result = collections.namedtuple('MatchResult', ['metadata_list'])
     match = match_result([None for _ in range(100)])
 

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -41,7 +41,8 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
   def _get_pipeline_mode(self, args):
     all_patterns = pipeline_common._get_all_patterns(args.input_pattern,
                                                      args.input_file)
-    return pipeline_common.get_pipeline_mode(all_patterns)
+    return pipeline_common.get_pipeline_mode(all_patterns,
+                                             args.pipeline_mode)
 
   def test_validation_failure_for_invalid_input_pattern(self):
     with self.assertRaisesRegex(
@@ -49,8 +50,20 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
       pipeline_common._get_all_patterns(
           input_pattern='nonexistent_file.vcf', input_file=None)
 
+  def test_get_mode_small_pipeline_mode(self):
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='small')
+    self.assertEqual(self._get_pipeline_mode(args), PipelineModes.SMALL)
+
+  def test_get_mode_medium_pipeline_mode(self):
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='medium')
+    self.assertEqual(self._get_pipeline_mode(args), PipelineModes.MEDIUM)
+
+  def test_get_mode_large_pipeline_mode(self):
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='large')
+    self.assertEqual(self._get_pipeline_mode(args), PipelineModes.LARGE)
+
   def test_get_mode_small(self):
-    args = self._create_mock_args(input_pattern='*', input_file=None)
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='')
     match_result = collections.namedtuple('MatchResult', ['metadata_list'])
     match = match_result([None for _ in range(100)])
 
@@ -58,7 +71,7 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
       self.assertEqual(self._get_pipeline_mode(args), PipelineModes.SMALL)
 
   def test_get_mode_medium(self):
-    args = self._create_mock_args(input_pattern='*', input_file=None)
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='')
     match_result = collections.namedtuple('MatchResult', ['metadata_list'])
 
     match = match_result(list(range(101)))
@@ -70,7 +83,7 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
       self.assertEqual(self._get_pipeline_mode(args), PipelineModes.MEDIUM)
 
   def test_get_mode_large(self):
-    args = self._create_mock_args(input_pattern='test', input_file=None)
+    args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='')
     match_result = collections.namedtuple('MatchResult', ['metadata_list'])
 
     match = match_result(list(range(50001)))

--- a/gcp_variant_transforms/pipeline_common_test.py
+++ b/gcp_variant_transforms/pipeline_common_test.py
@@ -52,15 +52,24 @@ class PipelineCommonWithPatternTest(unittest.TestCase):
 
   def test_get_mode_small_pipeline_mode(self):
     args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='small')
-    self.assertEqual(self._get_pipeline_mode(args), PipelineModes.SMALL)
+    match_result = collections.namedtuple('MatchResult', ['metadata_list'])
+    match = match_result([None for _ in range(100)])
+    with mock.patch.object(FileSystems, 'match', return_value=[match]):
+      self.assertEqual(self._get_pipeline_mode(args), PipelineModes.SMALL)
 
   def test_get_mode_medium_pipeline_mode(self):
     args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='medium')
-    self.assertEqual(self._get_pipeline_mode(args), PipelineModes.MEDIUM)
+    match_result = collections.namedtuple('MatchResult', ['metadata_list'])
+    match = match_result([None for _ in range(100)])
+    with mock.patch.object(FileSystems, 'match', return_value=[match]):
+      self.assertEqual(self._get_pipeline_mode(args), PipelineModes.MEDIUM)
 
   def test_get_mode_large_pipeline_mode(self):
     args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='large')
-    self.assertEqual(self._get_pipeline_mode(args), PipelineModes.LARGE)
+    match_result = collections.namedtuple('MatchResult', ['metadata_list'])
+    match = match_result([None for _ in range(100)])
+    with mock.patch.object(FileSystems, 'match', return_value=[match]):
+      self.assertEqual(self._get_pipeline_mode(args), PipelineModes.LARGE)
 
   def test_get_mode_small(self):
     args = self._create_mock_args(input_pattern='*', input_file=None, pipeline_mode='')

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -225,7 +225,7 @@ def _shard_variants(known_args, pipeline_args, pipeline_mode):
 
 
 def _get_input_dimensions(known_args, pipeline_args):
-  pipeline_mode = pipeline_common.get_pipeline_mode(known_args.all_patterns)
+  pipeline_mode = pipeline_common.get_pipeline_mode(known_args.all_patterns, known_args.pipeline_mode)
   beam_pipeline_options = pipeline_options.PipelineOptions(pipeline_args)
   google_cloud_options = beam_pipeline_options.view_as(
       pipeline_options.GoogleCloudOptions)
@@ -403,7 +403,7 @@ def _run_annotation_pipeline(known_args, pipeline_args):
 
     files_to_be_annotated = known_args.all_patterns
     if known_args.shard_variants:
-      pipeline_mode = pipeline_common.get_pipeline_mode(files_to_be_annotated)
+      pipeline_mode = pipeline_common.get_pipeline_mode(files_to_be_annotated, known_args.pipeline_mode)
       files_to_be_annotated = _shard_variants(known_args,
                                               pipeline_args,
                                               pipeline_mode)
@@ -453,7 +453,7 @@ def run(argv=None):
 
   variant_merger = _get_variant_merge_strategy(known_args)
 
-  pipeline_mode = pipeline_common.get_pipeline_mode(all_patterns)
+  pipeline_mode = pipeline_common.get_pipeline_mode(all_patterns, known_args.pipeline_mode)
 
   beam_pipeline_options = pipeline_options.PipelineOptions(pipeline_args)
   avro_root_path = _get_avro_root_path(beam_pipeline_options)


### PR DESCRIPTION
Add a pipeline mode flag to override existing behavior. 

Default set to '' which will use existing behavior, but can be set to 'small', 'medium', or 'large' to force a pipeline mode.