### PR TITLE
chore: Migrate gsutil usage to gcloud storage

### DIFF
--- a/docs/multiple_files.md
+++ b/docs/multiple_files.md
@@ -33,4 +33,3 @@ consistent across all VCF files, or else pipeline fails by default.
 However, Variant Transforms pipeline is able to handle such malformed files if
 instructed to do so. See [Dealing with malformed files](./malformed_files.md)
 for more details.
-

--- a/gcp_variant_transforms/libs/annotation/vep/vep_runner.py
+++ b/gcp_variant_transforms/libs/annotation/vep/vep_runner.py
@@ -45,8 +45,8 @@ _GLOBAL_LOG_FILE = 'VEP_run_info.log'
 _API_PIPELINE = 'pipeline'
 _API_ACTIONS = 'actions'
 
-# The following image wraps gsutil with additional retry logic.
-_GSUTIL_IMAGE = 'gcr.io/cloud-genomics-pipelines/io'
+# The gcloud image.
+_GCLOUD_IMAGE = 'gcr.io/cloud-builders/gcloud'
 # The expected path of the run_vep.sh script in the docker container.
 _VEP_RUN_SCRIPT = '/opt/variant_effect_predictor/run_vep.sh'
 
@@ -181,7 +181,7 @@ class VepRunner():
             _API_ACTIONS: [
                 self._make_action(self._vep_image_uri, 'mkdir', '-p',
                                   '/mnt/vep/vep_cache'),
-                self._make_action(_GSUTIL_IMAGE, 'gsutil', '-q', 'cp',
+                self._make_action(_GCLOUD_IMAGE, 'storage', 'cp',
                                   self._vep_cache_path, '/mnt/vep/vep_cache/')
             ],
             'environment': {
@@ -404,7 +404,7 @@ class VepRunner():
       api_request[_API_PIPELINE][_API_ACTIONS].extend(
           self._create_actions(input_file, output_file))
     api_request[_API_PIPELINE][_API_ACTIONS].append(
-        self._make_action(_GSUTIL_IMAGE, 'gsutil', '-q', 'cp',
+        self._make_action(_GCLOUD_IMAGE, 'storage', 'cp',
                           '/google/logs/output',
                           output_log_path))
     # pylint: disable=no-member
@@ -452,14 +452,14 @@ class VepRunner():
                                  local_input_file,
                                  _LOCAL_OUTPUT_FILE)
     return [
-        self._make_action(_GSUTIL_IMAGE, 'gsutil', '-q', 'cp', input_file,
+        self._make_action(_GCLOUD_IMAGE, 'storage', 'cp', input_file,
                           local_input_file),
         self._make_action(self._vep_image_uri, 'rm', '-r', '-f',
                           _LOCAL_OUTPUT_DIR),
         action,
         # TODO(bashir2): When the output files are local, the output directory
-        # structure should be created as well otherwise gsutil fails.
-        self._make_action(_GSUTIL_IMAGE, 'gsutil', '-q', 'cp',
+        # structure should be created as well otherwise gcloud storage fails.
+        self._make_action(_GCLOUD_IMAGE, 'storage', 'cp',
                           _LOCAL_OUTPUT_FILE, output_file)]
 
 

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -34,7 +34,7 @@ _VcfHeaderTypeConstants = vcf_header_io.VcfHeaderFieldTypeConstants
 TABLE_SUFFIX_SEPARATOR = '__'
 
 _BQ_DELETE_TABLE_COMMAND = 'bq rm -f -t {FULL_TABLE_ID}'
-_GCS_DELETE_FILES_COMMAND = 'gsutil -m rm -f -R {ROOT_PATH}'
+_GCS_DELETE_FILES_COMMAND = 'gcloud storage rm --continue-on-error --recursive {ROOT_PATH}'
 BQ_NUM_RETRIES = 5
 
 


### PR DESCRIPTION
Automated: Migrate {target_path} from gsutil to gcloud storage

This CL is part of the on going effort to migrate from the legacy `gsutil` tool to the new and improved `gcloud storage` command-line interface.
`gcloud storage` is the recommended and modern tool for interacting with Google Cloud Storage, offering better performance, unified authentication, and a more consistent command structure with other `gcloud` components. 🚀

### Automation Details

This change was **generated automatically** by an agent that targets users of `gsutil`.
The transformations applied are based on the  [gsutil to gcloud storage migration guide](http://go/gsutil-gcloud-storage-migration-guide).

### ⚠️ Action Required: Please Review and Test Carefully

While we have based the automation on the migration guide, every use case is unique.
**It is crucial that you thoroughly test these changes in environments appropriate to your use-case before merging.**  
Be aware of potential differences between `gsutil` and `gcloud storage` that could impact your workflows.  
For instance, the structure of command output may have changed, requiring updates to any scripts that parse it. Similarly, command behavior can differ subtly; the `gcloud storage rsync` command has a different file deletion logic than `gsutil rsync`, which could lead to unintended file deletions.  

Our migration guides can help guide you through a list of mappings and some notable differences between the two tools.

Standard presubmit tests are run as part of this CL's workflow. **If you need to target an additional test workflow or require assistance with testing, please let us know.**

Please verify that all your Cloud Storage operations continue to work as expected to avoid any potential disruptions in production.

### Support and Collaboration

The `GCS CLI` team is here to help! If you encounter any issues, have a complex use case that this automated change doesn't cover, or face any other blockers, please don't hesitate to reach out.
We are happy to work with you to test and adjust these changes as needed.

**Contact:** `gcs-cli-hyd@google.com`

We appreciate your partnership in this important migration effort!

#gsutil-migration
